### PR TITLE
Handle sorting and overlap validation in resampling

### DIFF
--- a/app/server/differential.py
+++ b/app/server/differential.py
@@ -1,8 +1,26 @@
 import numpy as np
 
+
+def _to_sorted_arrays(wavelengths, fluxes):
+    wavelengths = np.asarray(wavelengths, dtype=float)
+    fluxes = np.asarray(fluxes, dtype=float)
+
+    order = np.argsort(wavelengths)
+    return wavelengths[order], fluxes[order]
+
+
 def resample_to_common_grid(wl_a, fl_a, wl_b, fl_b, n=2000):
-    lo = max(min(wl_a), min(wl_b))
-    hi = min(max(wl_a), max(wl_b))
+    wl_a, fl_a = _to_sorted_arrays(wl_a, fl_a)
+    wl_b, fl_b = _to_sorted_arrays(wl_b, fl_b)
+
+    lo = max(wl_a.min(), wl_b.min())
+    hi = min(wl_a.max(), wl_b.max())
+
+    if lo >= hi:
+        raise ValueError(
+            "Wavelength ranges do not overlap; cannot resample to a common grid."
+        )
+
     grid = np.linspace(lo, hi, n)
     fa = np.interp(grid, wl_a, fl_a)
     fb = np.interp(grid, wl_b, fl_b)

--- a/tests/server/test_differential.py
+++ b/tests/server/test_differential.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.server.differential import resample_to_common_grid
+
+
+def test_resample_sorts_descending_inputs():
+    wl_a = [5, 3, 1]
+    fl_a = [50, 30, 10]
+    wl_b = [4, 2]
+    fl_b = [40, 20]
+
+    grid, fa, fb = resample_to_common_grid(wl_a, fl_a, wl_b, fl_b, n=3)
+
+    assert grid == pytest.approx([2.0, 3.0, 4.0])
+    assert fa == pytest.approx([20.0, 30.0, 40.0])
+    assert fb == pytest.approx([20.0, 30.0, 40.0])
+
+
+def test_resample_raises_when_no_overlap():
+    wl_a = [1, 2, 3]
+    fl_a = [10, 20, 30]
+    wl_b = [4, 5, 6]
+    fl_b = [40, 50, 60]
+
+    with pytest.raises(ValueError, match="Wavelength ranges do not overlap"):
+        resample_to_common_grid(wl_a, fl_a, wl_b, fl_b)


### PR DESCRIPTION
## Summary
- sort wavelength and flux inputs before resampling to a common grid
- raise a clear exception when the wavelength domains do not overlap
- add regression tests covering descending and non-overlapping inputs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf04bd52fc83299e2d2307de890f48