### PR TITLE
Handle FITS extension data during ingestion

### DIFF
--- a/tests/server/test_ingest_fits.py
+++ b/tests/server/test_ingest_fits.py
@@ -1,0 +1,35 @@
+import numpy as np
+from astropy.io import fits
+
+from app.server.ingest_fits import parse_fits
+
+
+def test_parse_fits_uses_first_data_extension(tmp_path):
+    flux_values = np.array([1.0, 2.0, 3.0], dtype=float)
+
+    primary_hdu = fits.PrimaryHDU()
+    primary_hdu.header["CRVAL1"] = 999.0
+    primary_hdu.header["CDELT1"] = 5.0
+
+    sci_header = fits.Header()
+    sci_header["CRVAL1"] = 400.0
+    sci_header["CDELT1"] = 0.5
+    sci_header["CRPIX1"] = 1.0
+    sci_header["CUNIT1"] = "nm"
+
+    sci_hdu = fits.ImageHDU(data=flux_values, header=sci_header, name="SCI")
+
+    hdul = fits.HDUList([primary_hdu, sci_hdu])
+    fits_path = tmp_path / "extension_data.fits"
+    hdul.writeto(fits_path, overwrite=True)
+    hdul.close()
+
+    result = parse_fits(str(fits_path))
+
+    expected_wavelength = [400.0 + 0.5 * i for i in range(flux_values.size)]
+
+    assert result["flux"] == flux_values.tolist()
+    assert result["wavelength"] == expected_wavelength
+    assert result["unit_wavelength"] == "nm"
+    assert result["meta"]["original_unit_wavelength"] == "nm"
+    assert result["unit_flux"] == "arb"


### PR DESCRIPTION
## Summary
- open FITS files with a context manager and pull metadata from the HDU that actually carries the data
- validate required WCS keywords, normalise the selected flux array to 1-D, and surface clearer errors when ingestion fails
- add a regression test covering FITS files where the science data lives in the first extension

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf04b8c0a883298bcfdd7087022454