### PR TITLE
Normalize wavelength unit handling

### DIFF
--- a/app/server/units.py
+++ b/app/server/units.py
@@ -1,16 +1,25 @@
-from dataclasses import dataclass
-
 SUPPORTED = {'nm':1.0, 'Å':0.1, 'A':0.1, 'um':1000.0, 'µm':1000.0}
 
+_ANGSTROM_WORDS = {'angstrom', 'ångström', 'ångstrom'}
+_ANGSTROM_SYMBOLS = {'Å', 'A', 'å'}
+
+
+def _normalize_unit(unit: str) -> str:
+    """Return the canonical key used for wavelength unit comparisons."""
+    trimmed = unit.strip()
+    casefolded = trimmed.casefold()
+    casefolded = casefolded.replace('μ', 'µ')
+    if casefolded in _ANGSTROM_WORDS or trimmed in _ANGSTROM_SYMBOLS or casefolded == 'å':
+        return 'Å'
+    return casefolded
+
 def to_nm(values, unit: str):
-    u = unit.replace('Angstrom','Å').replace('angstrom','Å')
-    u = 'Å' if u in ['Å','A'] else u
+    u = _normalize_unit(unit)
     if u not in SUPPORTED:
         raise ValueError(f'Unsupported wavelength unit: {unit}')
     scale = SUPPORTED[u]
     return [v*scale for v in values]
 
 def canonical_unit(unit: str) -> str:
-    u = unit.replace('Angstrom','Å').replace('angstrom','Å')
-    return 'Å' if u in ['Å','A'] else u
+    return _normalize_unit(unit)
 

--- a/tests/server/test_units.py
+++ b/tests/server/test_units.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.server.units import canonical_unit, to_nm
+
+
+@pytest.mark.parametrize(
+    "raw_unit, values, expected",
+    [
+        (" NM", [1.0, 2.0], [1.0, 2.0]),
+        ("Angstrom ", [10.0, 20.0], [1.0, 2.0]),
+        ("Å ", [10.0, 20.0], [1.0, 2.0]),
+    ],
+)
+def test_to_nm_accepts_units_with_whitespace(raw_unit, values, expected):
+    converted = to_nm(values, raw_unit)
+    assert converted == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    "raw_unit, expected",
+    [
+        (" NM", "nm"),
+        ("Angstrom ", "Å"),
+        ("Å ", "Å"),
+    ],
+)
+def test_canonical_unit_normalizes_spacing(raw_unit, expected):
+    assert canonical_unit(raw_unit) == expected


### PR DESCRIPTION
## Summary
- normalize wavelength units by trimming/casefolding and mapping Angstrom variants before lookup
- reuse the same normalization in `canonical_unit`
- add tests ensuring units with trailing/leading spaces convert without errors

## Testing
- pytest tests/server/test_units.py

------
https://chatgpt.com/codex/tasks/task_e_68cf04bcc09c8329bbf458cf310dfbc6