### PR TITLE
Add NIST ASD spectral overlay support

### DIFF
--- a/app/server/fetch_archives.py
+++ b/app/server/fetch_archives.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict
 
-from .fetchers import eso, mast, simbad
+from .fetchers import eso, mast, nist, simbad
 
 class FetchError(Exception):
     pass
@@ -20,6 +20,8 @@ def fetch_spectrum(archive: str, **kwargs) -> Dict[str, Any]:
         return simbad.fetch(**kwargs)
     if archive == 'eso':
         return eso.fetch(**kwargs)
+    if archive == 'nist':
+        return nist.fetch(**kwargs)
     raise FetchError(f'Unsupported archive: {archive}')
 
 

--- a/app/server/fetchers/nist.py
+++ b/app/server/fetchers/nist.py
@@ -1,0 +1,513 @@
+"""Fetch spectral line data from the NIST Atomic Spectra Database."""
+from __future__ import annotations
+
+"""Client helpers for fetching NIST Atomic Spectra Database line lists."""
+
+import math
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+try:  # pragma: no cover - import guard executed at runtime
+    import astropy.units as u
+    from astroquery.nist import Nist
+except Exception as exc:  # pragma: no cover - handled in fetch()
+    ASTROQUERY_AVAILABLE = False
+    _IMPORT_ERROR: Exception | None = exc
+else:  # pragma: no cover - simple constant assignment
+    ASTROQUERY_AVAILABLE = True
+    _IMPORT_ERROR = None
+
+
+@dataclass(frozen=True)
+class ElementRecord:
+    """Mapping between element names, symbols, and atomic numbers."""
+
+    number: int
+    symbol: str
+    name: str
+    aliases: Tuple[str, ...] = ()
+
+
+_ELEMENTS: Tuple[ElementRecord, ...] = (
+    ElementRecord(1, "H", "Hydrogen"),
+    ElementRecord(2, "He", "Helium"),
+    ElementRecord(3, "Li", "Lithium"),
+    ElementRecord(4, "Be", "Beryllium"),
+    ElementRecord(5, "B", "Boron"),
+    ElementRecord(6, "C", "Carbon"),
+    ElementRecord(7, "N", "Nitrogen"),
+    ElementRecord(8, "O", "Oxygen"),
+    ElementRecord(9, "F", "Fluorine"),
+    ElementRecord(10, "Ne", "Neon"),
+    ElementRecord(11, "Na", "Sodium"),
+    ElementRecord(12, "Mg", "Magnesium"),
+    ElementRecord(13, "Al", "Aluminium", ("Aluminum",)),
+    ElementRecord(14, "Si", "Silicon"),
+    ElementRecord(15, "P", "Phosphorus"),
+    ElementRecord(16, "S", "Sulfur", ("Sulphur",)),
+    ElementRecord(17, "Cl", "Chlorine"),
+    ElementRecord(18, "Ar", "Argon"),
+    ElementRecord(19, "K", "Potassium"),
+    ElementRecord(20, "Ca", "Calcium"),
+    ElementRecord(21, "Sc", "Scandium"),
+    ElementRecord(22, "Ti", "Titanium"),
+    ElementRecord(23, "V", "Vanadium"),
+    ElementRecord(24, "Cr", "Chromium"),
+    ElementRecord(25, "Mn", "Manganese"),
+    ElementRecord(26, "Fe", "Iron"),
+    ElementRecord(27, "Co", "Cobalt"),
+    ElementRecord(28, "Ni", "Nickel"),
+    ElementRecord(29, "Cu", "Copper"),
+    ElementRecord(30, "Zn", "Zinc"),
+    ElementRecord(31, "Ga", "Gallium"),
+    ElementRecord(32, "Ge", "Germanium"),
+    ElementRecord(33, "As", "Arsenic"),
+    ElementRecord(34, "Se", "Selenium"),
+    ElementRecord(35, "Br", "Bromine"),
+    ElementRecord(36, "Kr", "Krypton"),
+    ElementRecord(37, "Rb", "Rubidium"),
+    ElementRecord(38, "Sr", "Strontium"),
+    ElementRecord(39, "Y", "Yttrium"),
+    ElementRecord(40, "Zr", "Zirconium"),
+    ElementRecord(41, "Nb", "Niobium"),
+    ElementRecord(42, "Mo", "Molybdenum"),
+    ElementRecord(43, "Tc", "Technetium"),
+    ElementRecord(44, "Ru", "Ruthenium"),
+    ElementRecord(45, "Rh", "Rhodium"),
+    ElementRecord(46, "Pd", "Palladium"),
+    ElementRecord(47, "Ag", "Silver"),
+    ElementRecord(48, "Cd", "Cadmium"),
+    ElementRecord(49, "In", "Indium"),
+    ElementRecord(50, "Sn", "Tin"),
+    ElementRecord(51, "Sb", "Antimony"),
+    ElementRecord(52, "Te", "Tellurium"),
+    ElementRecord(53, "I", "Iodine"),
+    ElementRecord(54, "Xe", "Xenon"),
+    ElementRecord(55, "Cs", "Caesium", ("Cesium",)),
+    ElementRecord(56, "Ba", "Barium"),
+    ElementRecord(57, "La", "Lanthanum"),
+    ElementRecord(58, "Ce", "Cerium"),
+    ElementRecord(59, "Pr", "Praseodymium"),
+    ElementRecord(60, "Nd", "Neodymium"),
+    ElementRecord(61, "Pm", "Promethium"),
+    ElementRecord(62, "Sm", "Samarium"),
+    ElementRecord(63, "Eu", "Europium"),
+    ElementRecord(64, "Gd", "Gadolinium"),
+    ElementRecord(65, "Tb", "Terbium"),
+    ElementRecord(66, "Dy", "Dysprosium"),
+    ElementRecord(67, "Ho", "Holmium"),
+    ElementRecord(68, "Er", "Erbium"),
+    ElementRecord(69, "Tm", "Thulium"),
+    ElementRecord(70, "Yb", "Ytterbium"),
+    ElementRecord(71, "Lu", "Lutetium"),
+    ElementRecord(72, "Hf", "Hafnium"),
+    ElementRecord(73, "Ta", "Tantalum"),
+    ElementRecord(74, "W", "Tungsten"),
+    ElementRecord(75, "Re", "Rhenium"),
+    ElementRecord(76, "Os", "Osmium"),
+    ElementRecord(77, "Ir", "Iridium"),
+    ElementRecord(78, "Pt", "Platinum"),
+    ElementRecord(79, "Au", "Gold"),
+    ElementRecord(80, "Hg", "Mercury"),
+    ElementRecord(81, "Tl", "Thallium"),
+    ElementRecord(82, "Pb", "Lead"),
+    ElementRecord(83, "Bi", "Bismuth"),
+    ElementRecord(84, "Po", "Polonium"),
+    ElementRecord(85, "At", "Astatine"),
+    ElementRecord(86, "Rn", "Radon"),
+    ElementRecord(87, "Fr", "Francium"),
+    ElementRecord(88, "Ra", "Radium"),
+    ElementRecord(89, "Ac", "Actinium"),
+    ElementRecord(90, "Th", "Thorium"),
+    ElementRecord(91, "Pa", "Protactinium"),
+    ElementRecord(92, "U", "Uranium"),
+    ElementRecord(93, "Np", "Neptunium"),
+    ElementRecord(94, "Pu", "Plutonium"),
+    ElementRecord(95, "Am", "Americium"),
+    ElementRecord(96, "Cm", "Curium"),
+    ElementRecord(97, "Bk", "Berkelium"),
+    ElementRecord(98, "Cf", "Californium"),
+    ElementRecord(99, "Es", "Einsteinium"),
+    ElementRecord(100, "Fm", "Fermium"),
+    ElementRecord(101, "Md", "Mendelevium"),
+    ElementRecord(102, "No", "Nobelium"),
+    ElementRecord(103, "Lr", "Lawrencium"),
+    ElementRecord(104, "Rf", "Rutherfordium"),
+    ElementRecord(105, "Db", "Dubnium"),
+    ElementRecord(106, "Sg", "Seaborgium"),
+    ElementRecord(107, "Bh", "Bohrium"),
+    ElementRecord(108, "Hs", "Hassium"),
+    ElementRecord(109, "Mt", "Meitnerium"),
+    ElementRecord(110, "Ds", "Darmstadtium"),
+    ElementRecord(111, "Rg", "Roentgenium"),
+    ElementRecord(112, "Cn", "Copernicium"),
+    ElementRecord(113, "Nh", "Nihonium"),
+    ElementRecord(114, "Fl", "Flerovium"),
+    ElementRecord(115, "Mc", "Moscovium"),
+    ElementRecord(116, "Lv", "Livermorium"),
+    ElementRecord(117, "Ts", "Tennessine"),
+    ElementRecord(118, "Og", "Oganesson"),
+)
+
+
+_SYMBOL_TO_ELEMENT = {rec.symbol.lower(): rec for rec in _ELEMENTS}
+_NAME_TO_ELEMENT = {
+    rec.name.lower(): rec for rec in _ELEMENTS
+}
+for rec in _ELEMENTS:
+    for alias in rec.aliases:
+        _NAME_TO_ELEMENT[alias.lower()] = rec
+
+
+_ROMAN_VALUES = {"I": 1, "V": 5, "X": 10, "L": 50, "C": 100, "D": 500, "M": 1000}
+
+
+class NistUnavailableError(RuntimeError):
+    """Raised when astroquery is not available to service NIST requests."""
+
+
+class NistQueryError(RuntimeError):
+    """Raised when a NIST request cannot be satisfied."""
+
+
+def _roman_to_int(token: str) -> Optional[int]:
+    token = token.strip().upper()
+    if not token or any(ch not in _ROMAN_VALUES for ch in token):
+        return None
+    total = 0
+    prev = 0
+    for ch in reversed(token):
+        value = _ROMAN_VALUES[ch]
+        if value < prev:
+            total -= value
+        else:
+            total += value
+            prev = value
+    return total or None
+
+
+def _int_to_roman(value: int) -> str:
+    if value <= 0:
+        raise ValueError("Ion stage must be positive")
+    numerals = (
+        (1000, "M"), (900, "CM"), (500, "D"), (400, "CD"),
+        (100, "C"), (90, "XC"), (50, "L"), (40, "XL"),
+        (10, "X"), (9, "IX"), (5, "V"), (4, "IV"), (1, "I"),
+    )
+    remaining = value
+    parts: List[str] = []
+    for magnitude, symbol in numerals:
+        while remaining >= magnitude:
+            parts.append(symbol)
+            remaining -= magnitude
+    return "".join(parts)
+
+
+def _parse_plus_notation(token: str) -> Optional[int]:
+    token = token.strip()
+    if not token or not set(token) <= {"+"}:
+        return None
+    return len(token) + 1
+
+
+def _parse_ion_token(token: str | int | None) -> Optional[int]:
+    if token is None:
+        return None
+    if isinstance(token, int):
+        return max(1, token)
+    cleaned = token.strip()
+    if not cleaned:
+        return None
+    plus = _parse_plus_notation(cleaned)
+    if plus:
+        return plus
+    if cleaned.isdigit():
+        return max(1, int(cleaned))
+    roman = _roman_to_int(cleaned)
+    if roman:
+        return roman
+    return None
+
+
+def _lookup_element(identifier: str) -> ElementRecord:
+    token = identifier.strip().lower()
+    if not token:
+        raise ValueError("Element identifier is empty")
+    element = _SYMBOL_TO_ELEMENT.get(token) or _NAME_TO_ELEMENT.get(token)
+    if element:
+        return element
+    raise ValueError(f"Unknown element identifier: {identifier!r}")
+
+
+def _resolve_spectrum(
+    *,
+    element: str | None = None,
+    linename: str | None = None,
+    ion_stage: str | int | None = None,
+) -> Tuple[ElementRecord, int, str, str]:
+    """Return the element record and formatted spectrum identifier."""
+
+    chosen_element: Optional[ElementRecord] = None
+    stage_value: Optional[int] = _parse_ion_token(ion_stage)
+
+    def inspect_tokens(tokens: Iterable[str]) -> None:
+        nonlocal chosen_element, stage_value
+        for token in tokens:
+            token = token.strip()
+            if not token:
+                continue
+            if chosen_element is None:
+                try:
+                    chosen_element = _lookup_element(token)
+                    if chosen_element:
+                        continue
+                except ValueError:
+                    pass
+            parsed = _parse_ion_token(token)
+            if parsed:
+                stage_value = stage_value or parsed
+
+    if linename:
+        inspect_tokens(re.split(r"[\s,/;]+", linename))
+    if element and not chosen_element:
+        inspect_tokens(re.split(r"[\s,/;]+", element))
+
+    if chosen_element is None:
+        if linename:
+            raise ValueError(f"Could not resolve element from spectrum identifier {linename!r}")
+        raise ValueError("Element must be provided")
+
+    stage_value = stage_value or 1
+    stage_roman = _int_to_roman(stage_value)
+    spectrum = f"{chosen_element.symbol} {stage_roman}"
+    label = f"{chosen_element.symbol} {stage_roman} (NIST ASD)"
+    return chosen_element, stage_value, stage_roman, spectrum, label
+
+
+_FLOAT_PATTERN = re.compile(r"-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?")
+
+
+def _extract_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        if math.isnan(value):
+            return None
+        return float(value)
+    text = str(value).strip()
+    if not text or text in {"-", "--"}:
+        return None
+    match = _FLOAT_PATTERN.search(text.replace(",", ""))
+    if not match:
+        return None
+    try:
+        return float(match.group(0))
+    except ValueError:
+        return None
+
+
+def _split_energy(value: Any) -> Tuple[Optional[float], Optional[float]]:
+    text = str(value).strip()
+    if not text or text in {"-", "--"}:
+        return (None, None)
+    matches = _FLOAT_PATTERN.findall(text.replace(",", ""))
+    if not matches:
+        return (None, None)
+    lower = float(matches[0]) if matches else None
+    upper = float(matches[1]) if len(matches) > 1 else None
+    return (lower, upper)
+
+
+def _clean_text(value: Any) -> Optional[str]:
+    text = str(value).strip()
+    if not text or text in {"-", "--"}:
+        return None
+    return re.sub(r"\s+", " ", text)
+
+
+DEFAULT_LOWER_WAVELENGTH_NM = 380.0
+DEFAULT_UPPER_WAVELENGTH_NM = 750.0
+
+
+def fetch(
+    *,
+    element: str | None = None,
+    linename: str | None = None,
+    ion_stage: str | int | None = None,
+    lower_wavelength: float | None = None,
+    upper_wavelength: float | None = None,
+    wavelength_unit: str = "nm",
+    use_ritz: bool = True,
+    wavelength_type: str = "vacuum",
+) -> Dict[str, Any]:
+    """Fetch spectral line data from the NIST ASD service.
+
+    Parameters
+    ----------
+    element:
+        Element symbol or name (e.g. ``"Fe"`` or ``"Iron"``). Ignored if
+        ``linename`` is provided but still used for metadata resolution.
+    linename:
+        Explicit spectrum identifier (e.g. ``"Fe II"``). If omitted, the
+        identifier will be constructed from ``element`` and ``ion_stage``.
+    ion_stage:
+        Ionisation stage expressed as an integer, Roman numeral, or count of
+        ``+`` characters (``"++"`` becomes ``III``). Defaults to neutral.
+    lower_wavelength / upper_wavelength:
+        Wavelength bounds expressed in ``wavelength_unit`` units. Defaults to
+        the optical range of 380-750 nm when not supplied.
+    wavelength_unit:
+        Unit label for the wavelength inputs. Supported values: ``"nm"``,
+        ``"Angstrom"``/``"Å"``, ``"um"``/``"µm"``.
+    use_ritz:
+        Prefer the Ritz wavelength when available; otherwise fall back to the
+        observed value.
+    wavelength_type:
+        Forwarded to the ASD query. ``"vacuum"`` (default) returns vacuum
+        wavelengths, while ``"vac+air"`` toggles air/vacuum switching.
+    """
+
+    if not ASTROQUERY_AVAILABLE:
+        raise NistUnavailableError(
+            "astroquery.nist is required to fetch NIST spectra"  # pragma: no cover - defensive branch
+        ) from _IMPORT_ERROR
+
+    element_record, stage_value, stage_roman, spectrum, label = _resolve_spectrum(
+        element=element,
+        linename=linename,
+        ion_stage=ion_stage,
+    )
+
+    unit_normalised = wavelength_unit.strip().lower() if wavelength_unit else "nm"
+    if unit_normalised in {"ang", "angstrom", "ångström", "å", "aa"}:
+        unit = u.AA
+    elif unit_normalised in {"um", "µm", "micron", "micrometer", "micrometre"}:
+        unit = u.um
+    else:
+        unit = u.nm
+
+    lower = lower_wavelength if lower_wavelength is not None else DEFAULT_LOWER_WAVELENGTH_NM
+    upper = upper_wavelength if upper_wavelength is not None else DEFAULT_UPPER_WAVELENGTH_NM
+    if lower > upper:
+        lower, upper = upper, lower
+
+    min_wav = lower * unit
+    max_wav = upper * unit
+
+    try:
+        table = Nist.query(
+            min_wav,
+            max_wav,
+            linename=spectrum,
+            wavelength_type=wavelength_type,
+        )
+    except Exception as exc:  # pragma: no cover - network failure path
+        raise NistQueryError(f"Failed to query NIST ASD: {exc}") from exc
+
+    lines: List[Dict[str, Any]] = []
+    max_relative_intensity = 0.0
+
+    if table is not None:
+        for row in table:
+            observed_nm = _extract_float(row.get("Observed"))
+            ritz_nm = _extract_float(row.get("Ritz"))
+            chosen_nm = ritz_nm if use_ritz and ritz_nm is not None else observed_nm or ritz_nm
+            if chosen_nm is None:
+                continue
+
+            relative_intensity = _extract_float(row.get("Rel."))
+            if relative_intensity is not None:
+                max_relative_intensity = max(max_relative_intensity, relative_intensity)
+
+            aki = _extract_float(row.get("Aki"))
+            fik = _extract_float(row.get("fik"))
+            energy_lower, energy_upper = _split_energy(row.get("Ei           Ek"))
+
+            line_record = {
+                "wavelength_nm": chosen_nm,
+                "observed_wavelength_nm": observed_nm,
+                "ritz_wavelength_nm": ritz_nm,
+                "relative_intensity": relative_intensity,
+                "transition_probability_s": aki,
+                "oscillator_strength": fik,
+                "accuracy": _clean_text(row.get("Acc.")),
+                "lower_level": _clean_text(row.get("Lower level")),
+                "upper_level": _clean_text(row.get("Upper level")),
+                "transition_type": _clean_text(row.get("Type")),
+                "transition_probability_reference": _clean_text(row.get("TP")),
+                "line_reference": _clean_text(row.get("Line")),
+                "lower_level_energy_ev": energy_lower,
+                "upper_level_energy_ev": energy_upper,
+            }
+            lines.append(line_record)
+
+    if not lines:
+        meta = {
+            "source_type": "reference",
+            "archive": "NIST ASD",
+            "label": label,
+            "element_symbol": element_record.symbol,
+            "element_name": element_record.name,
+            "atomic_number": element_record.number,
+            "ion_stage": stage_roman,
+            "ion_stage_number": stage_value,
+            "query": {
+                "linename": spectrum,
+                "lower_wavelength": float(lower),
+                "upper_wavelength": float(upper),
+                "wavelength_unit": str(unit),
+                "wavelength_type": wavelength_type,
+                "use_ritz": use_ritz,
+            },
+            "fetched_at_utc": datetime.now(timezone.utc).isoformat(),
+            "citation": "NIST ASD Team, https://physics.nist.gov/asd",
+            "note": "No spectral lines returned for requested range.",
+        }
+        return {
+            "wavelength_nm": [],
+            "intensity": [],
+            "intensity_normalized": [],
+            "lines": [],
+            "meta": meta,
+        }
+
+    if max_relative_intensity <= 0:
+        max_relative_intensity = None
+
+    for line in lines:
+        rel = line["relative_intensity"]
+        if rel is None or max_relative_intensity is None:
+            line["relative_intensity_normalized"] = None
+        else:
+            line["relative_intensity_normalized"] = rel / max_relative_intensity if max_relative_intensity else None
+
+    meta = {
+        "source_type": "reference",
+        "archive": "NIST ASD",
+        "label": label,
+        "element_symbol": element_record.symbol,
+        "element_name": element_record.name,
+        "atomic_number": element_record.number,
+        "ion_stage": stage_roman,
+        "ion_stage_number": stage_value,
+        "query": {
+            "linename": spectrum,
+            "lower_wavelength": float(lower),
+            "upper_wavelength": float(upper),
+            "wavelength_unit": str(unit),
+            "wavelength_type": wavelength_type,
+            "use_ritz": use_ritz,
+        },
+        "fetched_at_utc": datetime.now(timezone.utc).isoformat(),
+        "citation": "Kramida, A. et al. (NIST ASD), https://physics.nist.gov/asd",
+    }
+
+    return {
+        "wavelength_nm": [line["wavelength_nm"] for line in lines],
+        "intensity": [line.get("relative_intensity") for line in lines],
+        "intensity_normalized": [line.get("relative_intensity_normalized") for line in lines],
+        "lines": lines,
+        "meta": meta,
+    }

--- a/app/ui/main.py
+++ b/app/ui/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 import time
 from pathlib import Path
 
@@ -9,6 +10,7 @@ import plotly.graph_objects as go
 import streamlit as st
 
 from app._version import get_version_info
+from app.server.fetch_archives import FetchError, fetch_spectrum
 
 st.set_page_config(page_title='Spectra App', layout='wide')
 
@@ -33,6 +35,78 @@ st.sidebar.caption(f"Build: {VI['version']} — {VI['summary'] or 'No summary'}"
 with st.expander("What's new in this patch?"):
     st.write(f"**{VI['version']}** — {VI['summary'] or 'No summary provided.'}")
     st.caption(f"Built: {VI['date_utc']}")
+
+if "nist_overlays" not in st.session_state:
+    st.session_state["nist_overlays"] = []
+
+st.sidebar.markdown("### NIST ASD overlays")
+with st.sidebar.form("nist_overlay_form", clear_on_submit=False):
+    nist_identifier = st.text_input(
+        "Element or spectrum",
+        key="nist_element_identifier",
+        placeholder="e.g. H, Hydrogen, Fe II",
+        help="Enter an element symbol or name. Add a Roman numeral or +++ to specify the ion stage.",
+    )
+    nist_lower = st.number_input(
+        "Lower λ (nm)",
+        min_value=0.0,
+        value=380.0,
+        step=10.0,
+        key="nist_lower_bound",
+        help="Minimum wavelength to request from NIST (nanometers).",
+    )
+    nist_upper = st.number_input(
+        "Upper λ (nm)",
+        min_value=0.0,
+        value=750.0,
+        step=10.0,
+        key="nist_upper_bound",
+        help="Maximum wavelength to request from NIST (nanometers).",
+    )
+    nist_use_ritz = st.checkbox(
+        "Prefer Ritz wavelengths",
+        value=True,
+        key="nist_prefer_ritz",
+        help="Use Ritz wavelengths when available; fall back to observed values otherwise.",
+    )
+    if st.form_submit_button("Add NIST overlay"):
+        identifier = (st.session_state.get("nist_element_identifier") or "").strip()
+        lower = float(st.session_state.get("nist_lower_bound", nist_lower))
+        upper = float(st.session_state.get("nist_upper_bound", nist_upper))
+        use_ritz = bool(st.session_state.get("nist_prefer_ritz", True))
+        if not identifier:
+            st.sidebar.warning("Enter an element symbol or spectrum label.")
+        elif math.isclose(lower, upper):
+            st.sidebar.warning("Lower and upper wavelength bounds must differ.")
+        else:
+            try:
+                result = fetch_spectrum(
+                    "nist",
+                    element=identifier,
+                    lower_wavelength=min(lower, upper),
+                    upper_wavelength=max(lower, upper),
+                    wavelength_unit="nm",
+                    use_ritz=use_ritz,
+                )
+            except (FetchError, ValueError, RuntimeError) as exc:
+                st.sidebar.error(f"Failed to fetch NIST data: {exc}")
+            else:
+                st.session_state["nist_overlays"].append(result)
+                st.sidebar.success(f"Added {result['meta'].get('label', identifier)}")
+
+if st.session_state["nist_overlays"]:
+    if st.sidebar.button("Clear NIST overlays"):
+        st.session_state["nist_overlays"] = []
+        for key in list(st.session_state.keys()):
+            if key.startswith("nist_visible_"):
+                del st.session_state[key]
+    else:
+        st.sidebar.caption("Toggle overlays to display them on the charts.")
+        for idx, overlay in enumerate(st.session_state["nist_overlays"]):
+            label = overlay.get("meta", {}).get("label", f"NIST overlay {idx + 1}")
+            visible_key = f"nist_visible_{idx}"
+            visible = st.sidebar.checkbox(label, value=True, key=visible_key)
+            overlay["visible"] = visible
 
 st.sidebar.write('Examples')
 ex_toggle_he = st.sidebar.checkbox('He (example)', value=False)
@@ -79,11 +153,148 @@ def _prepare_trace(csv_path: str, label: str, display_units: str, display_mode: 
     return plot_df, axis_title
 
 
+def _prepare_nist_trace(data: dict, display_units: str, display_mode: str) -> tuple[pd.DataFrame, str]:
+    lines = data.get('lines') or []
+    if not lines:
+        return pd.DataFrame(), 'Wavelength (nm)'
+
+    base_series = pd.Series([line.get('wavelength_nm') for line in lines], dtype=float)
+    converted, axis_title = _convert_wavelength(base_series, display_units)
+
+    if display_mode == 'Flux (normalized)':
+        intensities = pd.Series([line.get('relative_intensity_normalized') for line in lines], dtype=float)
+    else:
+        intensities = pd.Series([line.get('relative_intensity') for line in lines], dtype=float)
+
+    if intensities.notna().any():
+        intensities = intensities.fillna(0.0)
+    else:
+        intensities = pd.Series([1.0] * len(lines), dtype=float)
+
+    axis_unit = axis_title.split('(')[-1].strip(')') if '(' in axis_title else axis_title
+    converted_list = converted.tolist()
+
+    hover_texts: list[str] = []
+    for idx, line in enumerate(lines):
+        wavelength_value = converted_list[idx]
+        if isinstance(wavelength_value, (int, float)) and math.isfinite(wavelength_value):
+            text_lines = [f"λ: {wavelength_value:.4f} {axis_unit}"]
+        else:
+            text_lines = ["λ unavailable"]
+
+        ritz_nm = line.get('ritz_wavelength_nm')
+        observed_nm = line.get('observed_wavelength_nm')
+        if ritz_nm and observed_nm and not math.isclose(ritz_nm, observed_nm, rel_tol=1e-9, abs_tol=1e-9):
+            text_lines.append(f"Ritz: {ritz_nm:.4f} nm")
+            text_lines.append(f"Observed: {observed_nm:.4f} nm")
+        elif ritz_nm:
+            text_lines.append(f"Ritz: {ritz_nm:.4f} nm")
+        elif observed_nm:
+            text_lines.append(f"Observed: {observed_nm:.4f} nm")
+
+        rel_int = line.get('relative_intensity')
+        if rel_int is not None:
+            text_lines.append(f"Rel. intensity: {rel_int:g}")
+        norm_int = line.get('relative_intensity_normalized')
+        if norm_int is not None:
+            text_lines.append(f"Normalized: {norm_int:.3f}")
+
+        accuracy = line.get('accuracy')
+        if accuracy:
+            text_lines.append(f"Accuracy: {accuracy}")
+
+        lower = line.get('lower_level')
+        upper = line.get('upper_level')
+        if lower or upper:
+            text_lines.append(f"{lower or '?'} → {upper or '?'}")
+
+        hover_texts.append("<br>".join(text_lines))
+
+    plot_df = pd.DataFrame(
+        {
+            'wavelength': converted,
+            'flux': intensities,
+            'series': data.get('meta', {}).get('label', 'NIST ASD'),
+            'hover_text': hover_texts,
+            'relative_intensity': [line.get('relative_intensity') for line in lines],
+            'relative_intensity_normalized': [line.get('relative_intensity_normalized') for line in lines],
+            'observed_wavelength_nm': [line.get('observed_wavelength_nm') for line in lines],
+            'ritz_wavelength_nm': [line.get('ritz_wavelength_nm') for line in lines],
+        }
+    )
+    return plot_df, axis_title
+
+
+def _add_nist_trace(fig: go.Figure, trace_df: pd.DataFrame, label: str) -> None:
+    if trace_df.empty:
+        return
+    xs: list[float | None] = []
+    ys: list[float | None] = []
+    hover: list[str | None] = []
+    for _, row in trace_df.iterrows():
+        wavelength = row['wavelength']
+        flux_value = float(row['flux']) if row['flux'] is not None else 0.0
+        text = row.get('hover_text')
+        xs.extend([wavelength, wavelength, None])
+        ys.extend([0.0, flux_value, None])
+        hover.extend([text, text, None])
+
+    fig.add_trace(
+        go.Scatter(
+            x=xs,
+            y=ys,
+            mode='lines',
+            name=label,
+            hoverinfo='text',
+            hovertext=hover,
+            line=dict(width=2),
+        )
+    )
+    fig.add_trace(
+        go.Scatter(
+            x=trace_df['wavelength'],
+            y=trace_df['flux'],
+            mode='markers',
+            marker=dict(size=6, symbol='line-ns'),
+            name=f"{label} markers",
+            hoverinfo='text',
+            hovertext=trace_df['hover_text'],
+            showlegend=False,
+        )
+    )
+
+
+def _build_nist_line_table(data: dict) -> pd.DataFrame:
+    records = []
+    for line in data.get('lines') or []:
+        records.append(
+            {
+                'Wavelength (nm)': line.get('wavelength_nm'),
+                'Observed (nm)': line.get('observed_wavelength_nm'),
+                'Ritz (nm)': line.get('ritz_wavelength_nm'),
+                'Relative intensity': line.get('relative_intensity'),
+                'Normalized intensity': line.get('relative_intensity_normalized'),
+                'Transition prob. (s⁻¹)': line.get('transition_probability_s'),
+                'Oscillator strength': line.get('oscillator_strength'),
+                'Accuracy': line.get('accuracy'),
+                'Lower level': line.get('lower_level'),
+                'Upper level': line.get('upper_level'),
+                'Type': line.get('transition_type'),
+                'TP reference': line.get('transition_probability_reference'),
+                'Line reference': line.get('line_reference'),
+            }
+        )
+    if not records:
+        return pd.DataFrame()
+    return pd.DataFrame.from_records(records)
+
+
 with tabs[0]:
     st.header('Overlays')
     fig = go.Figure()
     axis_title = 'Wavelength (nm)'
     rows = []
+    active_nist_overlays: list[dict] = []
 
     try:
         if ex_toggle_he:
@@ -115,6 +326,36 @@ with tabs[0]:
     except Exception as e:
         st.error(f"Failed to load examples: {e}")
 
+    for idx, overlay in enumerate(st.session_state.get("nist_overlays", [])):
+        if not overlay.get('visible', True):
+            continue
+        trace_df, axis_override = _prepare_nist_trace(overlay, display_units, display_mode)
+        if trace_df.empty:
+            continue
+        axis_title = axis_override
+        label = overlay.get('meta', {}).get('label', f"NIST overlay {idx + 1}")
+        _add_nist_trace(fig, trace_df, label)
+        for _, row in trace_df.iterrows():
+            wavelength_value = row['wavelength']
+            flux_value = row['flux']
+            try:
+                wavelength_float = float(wavelength_value)
+                flux_float = float(flux_value)
+            except (TypeError, ValueError):
+                continue
+            if math.isnan(wavelength_float) or math.isnan(flux_float):
+                continue
+            rows.append(
+                {
+                    'series': label,
+                    'wavelength': wavelength_float,
+                    'unit': display_units,
+                    'flux': flux_float,
+                    'display_mode': display_mode,
+                }
+            )
+        active_nist_overlays.append(overlay)
+
     fig.update_layout(
         xaxis_title=axis_title,
         yaxis_title='Normalized intensity' if display_mode == 'Flux (normalized)' else 'Flux / Intensity',
@@ -124,6 +365,22 @@ with tabs[0]:
     fig.update_layout(annotations=[dict(text=f"{VI['version']}", xref="paper", yref="paper", x=0.99, y=-0.20, showarrow=False, font=dict(size=12), align="right", opacity=0.7)])
     st.plotly_chart(fig, use_container_width=True)
     st.caption('Legend must have no empty labels.')
+
+    if active_nist_overlays:
+        with st.expander('View NIST line details'):
+            for overlay in active_nist_overlays:
+                meta = overlay.get('meta', {})
+                label = meta.get('label', 'NIST ASD')
+                query = meta.get('query', {})
+                count = len(overlay.get('lines') or [])
+                st.markdown(
+                    f"**{label}** — {count} lines from {query.get('lower_wavelength', '…')} to {query.get('upper_wavelength', '…')} {query.get('wavelength_unit', 'nm')}"
+                )
+                line_table = _build_nist_line_table(overlay)
+                if line_table.empty:
+                    st.info('No line details available for this selection.')
+                else:
+                    st.dataframe(line_table, use_container_width=True, hide_index=True)
 
     if st.button('Export what I see'):
         if not rows:

--- a/tests/server/test_fetch_nist.py
+++ b/tests/server/test_fetch_nist.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+from astropy.table import Table
+
+from app.server.fetchers import nist
+
+
+@pytest.fixture
+def sample_table() -> Table:
+    return Table(
+        rows=[
+            (
+                '500.0',
+                '500.2',
+                '20',
+                '1.0e+6',
+                '5.0e-1',
+                'AAA',
+                '10.0  -  11.0',
+                '1s     | 2S | 1/2 |',
+                '2p     | 2P* | 3/2 |',
+                'E1',
+                'T1000',
+                'L2000',
+            ),
+            (
+                '',
+                '600.0',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+                '',
+            ),
+        ],
+        names=[
+            'Observed',
+            'Ritz',
+            'Rel.',
+            'Aki',
+            'fik',
+            'Acc.',
+            'Ei           Ek',
+            'Lower level',
+            'Upper level',
+            'Type',
+            'TP',
+            'Line',
+        ],
+    )
+
+
+def test_fetch_basic(monkeypatch: pytest.MonkeyPatch, sample_table: Table) -> None:
+    captured = {}
+
+    def fake_query(min_wav, max_wav, *, linename=None, wavelength_type=None):
+        captured['min_wav'] = min_wav
+        captured['max_wav'] = max_wav
+        captured['linename'] = linename
+        captured['wavelength_type'] = wavelength_type
+        return sample_table.copy()
+
+    monkeypatch.setattr(nist, 'Nist', type('Dummy', (), {'query': staticmethod(fake_query)}))
+
+    result = nist.fetch(element='H', lower_wavelength=380.0, upper_wavelength=780.0)
+
+    assert captured['linename'] == 'H I'
+    assert pytest.approx(captured['min_wav'].value, rel=1e-6) == 380.0
+    assert pytest.approx(captured['max_wav'].value, rel=1e-6) == 780.0
+    assert result['meta']['label'] == 'H I (NIST ASD)'
+    assert result['meta']['element_symbol'] == 'H'
+    assert result['wavelength_nm'] == [500.2, 600.0]
+    assert result['intensity'][0] == pytest.approx(20.0)
+    assert result['intensity'][1] is None
+    assert result['intensity_normalized'][0] == pytest.approx(1.0)
+    assert result['intensity_normalized'][1] is None
+    first_line = result['lines'][0]
+    assert math.isclose(first_line['wavelength_nm'], 500.2)
+    assert first_line['transition_probability_s'] == pytest.approx(1.0e6)
+    assert first_line['oscillator_strength'] == pytest.approx(5.0e-1)
+    assert first_line['lower_level_energy_ev'] == pytest.approx(10.0)
+    assert first_line['upper_level_energy_ev'] == pytest.approx(11.0)
+    assert '2P*' in (first_line['upper_level'] or '')
+
+
+def test_fetch_linename(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_query(min_wav, max_wav, *, linename=None, wavelength_type=None):  # noqa: D401 - simple stub
+        return Table(rows=[], names=['Observed', 'Ritz', 'Rel.', 'Aki', 'fik', 'Acc.', 'Ei           Ek', 'Lower level', 'Upper level', 'Type', 'TP', 'Line'])
+
+    monkeypatch.setattr(nist, 'Nist', type('Dummy', (), {'query': staticmethod(fake_query)}))
+
+    result = nist.fetch(linename='Fe II')
+    assert result['wavelength_nm'] == []
+    assert result['meta']['element_symbol'] == 'Fe'
+    assert result['meta']['ion_stage'] == 'II'
+    assert 'note' in result['meta']
+
+
+def test_fetch_unknown_element() -> None:
+    with pytest.raises(ValueError):
+        nist.fetch(element='Xx')


### PR DESCRIPTION
## Summary
- implement a NIST ASD fetcher that resolves element/ion identifiers, normalises wavelengths, and returns detailed line metadata
- wire the new fetcher into the Streamlit UI with sidebar controls, stick-plot overlays, and line detail tables
- cover the fetcher with unit tests that exercise basic queries and error handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf209667a883299a998b6ae3885a7c