### PR TITLE
Fix NIST wavelengths to use nanometers

### DIFF
--- a/app/server/fetchers/nist.py
+++ b/app/server/fetchers/nist.py
@@ -411,9 +411,18 @@ def fetch(
 
     if table is not None:
         for row in table:
-            observed_nm = _extract_float(row.get("Observed"))
-            ritz_nm = _extract_float(row.get("Ritz"))
-            chosen_nm = ritz_nm if use_ritz and ritz_nm is not None else observed_nm or ritz_nm
+            observed_value = _extract_float(row.get("Observed"))
+            ritz_value = _extract_float(row.get("Ritz"))
+
+            observed_nm = observed_value / 10.0 if observed_value is not None else None
+            ritz_nm = ritz_value / 10.0 if ritz_value is not None else None
+
+            if use_ritz and ritz_nm is not None:
+                chosen_nm = ritz_nm
+            elif observed_nm is not None:
+                chosen_nm = observed_nm
+            else:
+                chosen_nm = ritz_nm
             if chosen_nm is None:
                 continue
 

--- a/tests/server/test_fetch_nist.py
+++ b/tests/server/test_fetch_nist.py
@@ -13,8 +13,8 @@ def sample_table() -> Table:
     return Table(
         rows=[
             (
-                '500.0',
-                '500.2',
+                '5000.0',
+                '5002.0',
                 '20',
                 '1.0e+6',
                 '5.0e-1',
@@ -28,7 +28,7 @@ def sample_table() -> Table:
             ),
             (
                 '',
-                '600.0',
+                '6000.0',
                 '',
                 '',
                 '',
@@ -84,6 +84,12 @@ def test_fetch_basic(monkeypatch: pytest.MonkeyPatch, sample_table: Table) -> No
     assert result['intensity_normalized'][1] is None
     first_line = result['lines'][0]
     assert math.isclose(first_line['wavelength_nm'], 500.2)
+    assert math.isclose(first_line['observed_wavelength_nm'] or 0.0, 500.0)
+    assert math.isclose(first_line['ritz_wavelength_nm'] or 0.0, 500.2)
+    second_line = result['lines'][1]
+    assert math.isclose(second_line['wavelength_nm'], 600.0)
+    assert second_line['observed_wavelength_nm'] is None
+    assert math.isclose(second_line['ritz_wavelength_nm'] or 0.0, 600.0)
     assert first_line['transition_probability_s'] == pytest.approx(1.0e6)
     assert first_line['oscillator_strength'] == pytest.approx(5.0e-1)
     assert first_line['lower_level_energy_ev'] == pytest.approx(10.0)


### PR DESCRIPTION
## Summary
- convert observed and Ritz wavelengths returned by the NIST fetcher from ångströms to nanometers before storing them in the response payload
- update the NIST fetch unit test to supply ångström-scale inputs and assert that the fetcher yields nanometer values throughout the response

## Testing
- PYTHONPATH=. pytest tests/server/test_fetch_nist.py
- PYTHONPATH=. python - <<'PY'
from astropy.table import Table
from app.server.fetchers import nist
from app.server.fetch_archives import fetch_spectrum
from app.ui import main as ui_main

def fake_query(min_wav, max_wav, *, linename=None, wavelength_type=None):
    return Table(
        rows=[
            (
                '3800.0',
                '3825.0',
                '10',
                '1e3',
                '1e-1',
                'A',
                '1.0  -  2.0',
                'lower',
                'upper',
                'E1',
                '',
                '',
            ),
            (
                '',
                '7500.0',
                '5',
                '',
                '',
                '',
                '',
                '',
                '',
                '',
                '',
                '',
            ),
        ],
        names=[
            'Observed',
            'Ritz',
            'Rel.',
            'Aki',
            'fik',
            'Acc.',
            'Ei           Ek',
            'Lower level',
            'Upper level',
            'Type',
            'TP',
            'Line',
        ],
    )

nist.Nist = type('Dummy', (), {'query': staticmethod(fake_query)})

result = fetch_spectrum(
    'nist',
    element='H',
    lower_wavelength=380.0,
    upper_wavelength=750.0,
    wavelength_unit='nm',
    use_ritz=True,
)

trace_df, axis_title = ui_main._prepare_nist_trace(result, 'nm', 'Flux (raw)')

print('axis_title:', axis_title)
print('overlay_wavelengths:', result['wavelength_nm'])
print('trace_min_max:', float(trace_df['wavelength'].min()), float(trace_df['wavelength'].max()))
PY

------
https://chatgpt.com/codex/tasks/task_e_68cf2eb707588329a9e688b936994300