### PR TITLE
Add tabbed UI with similarity analysis and archive providers

### DIFF
--- a/PATCHLOG.txt
+++ b/PATCHLOG.txt
@@ -2,3 +2,4 @@ Spectra App — Patch Log (append-only)
 ===============================
 
 
+- v1.1.5a: Refactored Streamlit UI with overlay/differential/archive tabs, similarity ribbon, and provider-backed archive workflows.

--- a/app/archive_ui.py
+++ b/app/archive_ui.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+"""Archive tab controller that bridges provider adapters with the overlay UI."""
+
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Sequence, Tuple
+
+import plotly.graph_objects as go
+import streamlit as st
+
+from app.providers import ProviderHit, ProviderQuery, provider_labels, search as provider_search
+
+AddOverlayFn = Callable[[Dict[str, object]], Tuple[bool, str]]
+
+
+@dataclass
+class ArchiveUI:
+    """Render archive providers and push selections into session state."""
+
+    add_overlay: AddOverlayFn
+
+    def render(self) -> None:
+        st.subheader("Archive lookups")
+        st.caption(
+            "Query public archives or DOI references and push results into the overlay "
+            "workspace. Synthetic samples stand in for real responses until adapters are wired."
+        )
+        labels = provider_labels()
+        tabs = st.tabs([labels[name] for name in ("MAST", "ESO", "SDSS", "DOI")])
+        for provider_name, tab in zip(("MAST", "ESO", "SDSS", "DOI"), tabs):
+            with tab:
+                self._render_provider(provider_name)
+
+    # ------------------------------------------------------------------
+    def _results_key(self, provider: str) -> str:
+        return f"archive_results_{provider.lower()}"
+
+    def _render_provider(self, provider: str) -> None:
+        query_key = f"archive_query_{provider.lower()}"
+        default_query = st.session_state.get(query_key, {})
+        with st.form(f"{provider}_search_form"):
+            if provider == "DOI":
+                doi_value = st.text_input("DOI", value=default_query.get("doi", ""), help="Enter a DOI or literature identifier.")
+                text_value = st.text_input("Title/label", value=default_query.get("text", ""))
+                limit = 1
+                submit = st.form_submit_button("Resolve DOI")
+                query = ProviderQuery(doi=doi_value.strip(), text=text_value.strip(), limit=limit)
+            else:
+                target = st.text_input("Target", value=default_query.get("target", ""))
+                instrument = st.text_input("Instrument", value=default_query.get("instrument", ""))
+                limit = st.slider("Max results", min_value=1, max_value=5, value=int(default_query.get("limit", 3)))
+                submit = st.form_submit_button("Search")
+                query = ProviderQuery(target=target.strip(), instrument=instrument.strip(), limit=limit)
+            if submit:
+                st.session_state[query_key] = query.as_dict()
+                try:
+                    hits = provider_search(provider, query)
+                except Exception as exc:  # pragma: no cover - defensive UI branch
+                    st.error(f"{provider} search failed: {exc}")
+                    hits = []
+                st.session_state[self._results_key(provider)] = hits
+
+        hits = st.session_state.get(self._results_key(provider), [])
+        if not hits:
+            st.info("Run a search to see results.")
+            return
+
+        summary_df = self._build_summary(hits)
+        if not summary_df.empty:
+            st.dataframe(summary_df, use_container_width=True, hide_index=True)
+
+        for idx, hit in enumerate(hits):
+            exp_label = f"{hit.label} — {hit.summary}"
+            with st.expander(exp_label, expanded=(idx == 0)):
+                df = hit.to_dataframe().head(200)
+                fig = go.Figure()
+                fig.add_trace(
+                    go.Scatter(
+                        x=df["wavelength_nm"],
+                        y=df["flux"],
+                        mode="lines",
+                        name=hit.label,
+                    )
+                )
+                fig.update_layout(
+                    xaxis_title="Wavelength (nm)",
+                    yaxis_title="Flux",
+                    height=260,
+                    margin=dict(t=20, b=20, l=40, r=10),
+                )
+                st.plotly_chart(fig, use_container_width=True)
+                st.caption(hit.summary)
+                cols = st.columns(2)
+                with cols[0]:
+                    st.write("**Metadata**")
+                    st.json(dict(hit.metadata))
+                with cols[1]:
+                    st.write("**Provenance**")
+                    st.json(dict(hit.provenance))
+
+                if st.button(f"Add to overlay", key=f"add_{provider}_{idx}"):
+                    added, message = self.add_overlay(hit.to_overlay_payload())
+                    if added:
+                        st.success(message)
+                    else:
+                        st.warning(message)
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _build_summary(hits: Sequence[ProviderHit]):
+        from app.providers.base import summarise_hits
+
+        return summarise_hits(hits)

--- a/app/providers/__init__.py
+++ b/app/providers/__init__.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+"""Provider registry and helper functions for archive integration."""
+
+from typing import Dict, List, Sequence
+
+from .base import ProviderHit, ProviderQuery
+from . import doi, eso, mast, sdss
+
+_PROVIDER_MAP = {
+    "MAST": mast,
+    "ESO": eso,
+    "SDSS": sdss,
+    "DOI": doi,
+}
+
+
+def providers() -> Sequence[str]:
+    """Return the list of available provider identifiers."""
+
+    return list(_PROVIDER_MAP.keys())
+
+
+def get_provider(name: str):  # type: ignore[override]
+    key = (name or "").upper()
+    if key not in _PROVIDER_MAP:
+        raise KeyError(f"Unknown provider: {name!r}")
+    return _PROVIDER_MAP[key]
+
+
+def search(name: str, query: ProviderQuery) -> List[ProviderHit]:
+    """Run a provider search returning inline spectra hits."""
+
+    provider = get_provider(name)
+    return list(provider.search(query))
+
+
+def provider_labels() -> Dict[str, str]:
+    """Human readable provider titles used in the UI."""
+
+    return {
+        "MAST": "MAST",  # Mikulski Archive for Space Telescopes
+        "ESO": "ESO",  # European Southern Observatory
+        "SDSS": "SDSS",  # Sloan Digital Sky Survey
+        "DOI": "DOI",  # DOI-based ingest
+    }
+
+__all__ = [
+    "ProviderHit",
+    "ProviderQuery",
+    "providers",
+    "provider_labels",
+    "search",
+    "get_provider",
+]

--- a/app/providers/base.py
+++ b/app/providers/base.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+"""Base dataclasses and helpers for archive provider adapters."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple
+
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class ProviderQuery:
+    """Normalised query payload passed to provider adapters."""
+
+    target: str = ""
+    text: str = ""
+    instrument: str = ""
+    doi: str = ""
+    limit: int = 5
+    wavelength_range: Tuple[Optional[float], Optional[float]] = (None, None)
+
+    def as_dict(self) -> Dict[str, object]:
+        return {
+            "target": self.target,
+            "text": self.text,
+            "instrument": self.instrument,
+            "doi": self.doi,
+            "limit": self.limit,
+            "wavelength_range": self.wavelength_range,
+        }
+
+
+@dataclass
+class ProviderHit:
+    """Lightweight record describing a search hit with inline spectral data."""
+
+    provider: str
+    identifier: str
+    label: str
+    summary: str
+    wavelengths_nm: Sequence[float]
+    flux: Sequence[float]
+    metadata: Mapping[str, object]
+    provenance: MutableMapping[str, object]
+    kind: str = "spectrum"
+
+    def __post_init__(self) -> None:
+        # Normalise provider case and ensure provenance metadata exists.
+        self.provider = (self.provider or "").upper()
+        self.provenance.setdefault("provider", self.provider)
+        self.provenance.setdefault("retrieved_utc", datetime.utcnow().isoformat() + "Z")
+
+    def to_dataframe(self) -> pd.DataFrame:
+        """Return a tabular preview of the hit's spectral data."""
+
+        data = {
+            "wavelength_nm": list(self.wavelengths_nm),
+            "flux": list(self.flux),
+        }
+        return pd.DataFrame(data)
+
+    def to_overlay_payload(self) -> Dict[str, object]:
+        """Return a serialisable payload for the overlay session state."""
+
+        return {
+            "label": self.label,
+            "wavelength_nm": list(self.wavelengths_nm),
+            "flux": list(self.flux),
+            "provider": self.provider,
+            "summary": self.summary,
+            "kind": self.kind,
+            "metadata": dict(self.metadata),
+            "provenance": dict(self.provenance),
+        }
+
+
+def summarise_hits(hits: Iterable[ProviderHit]) -> pd.DataFrame:
+    """Aggregate provider hits into a summary dataframe for display."""
+
+    records: List[Dict[str, object]] = []
+    for hit in hits:
+        records.append(
+            {
+                "Provider": hit.provider,
+                "Identifier": hit.identifier,
+                "Label": hit.label,
+                "Points": len(hit.wavelengths_nm),
+                "Summary": hit.summary,
+            }
+        )
+    if not records:
+        return pd.DataFrame(columns=["Provider", "Identifier", "Label", "Points", "Summary"])
+    return pd.DataFrame.from_records(records)

--- a/app/providers/doi.py
+++ b/app/providers/doi.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+"""DOI provider adapter stub that fabricates provenance-rich spectra."""
+
+from typing import Iterable
+
+import numpy as np
+
+from .base import ProviderHit, ProviderQuery
+
+
+def _synthetic_doi(seed: int) -> tuple[list[float], list[float]]:
+    wavelengths = np.linspace(400.0, 800.0, 180)
+    baseline = 1.0 + 0.1 * np.cos(wavelengths / 45.0)
+    line = 0.7 * np.exp(-0.5 * ((wavelengths - 486.1) / 4.0) ** 2)
+    line += 0.5 * np.exp(-0.5 * ((wavelengths - 656.3) / 5.0) ** 2)
+    ripple = 0.1 * np.sin(wavelengths / 18.0 + seed)
+    flux = baseline + line + ripple
+    flux -= flux.min()
+    return wavelengths.tolist(), flux.tolist()
+
+
+def search(query: ProviderQuery) -> Iterable[ProviderHit]:
+    doi_value = query.doi or query.text or "10.0000/example"
+    title = query.text or "Literature trace"
+    wavelengths, flux = _synthetic_doi(7)
+    metadata = {
+        "doi": doi_value,
+        "citation": f"{title} et al. (2022)",
+        "journal": "Astronomical Journal",
+    }
+    provenance = {
+        "archive": "DOI",
+        "query": query.as_dict(),
+        "doi": doi_value,
+    }
+    yield ProviderHit(
+        provider="DOI",
+        identifier=doi_value,
+        label=f"{title} • DOI {doi_value}",
+        summary="DOI-linked synthetic spectrum",
+        wavelengths_nm=wavelengths,
+        flux=flux,
+        metadata=metadata,
+        provenance=provenance,
+    )

--- a/app/providers/eso.py
+++ b/app/providers/eso.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+"""ESO provider adapter producing deterministic high-resolution previews."""
+
+from typing import Iterable
+
+import numpy as np
+
+from .base import ProviderHit, ProviderQuery
+
+
+def _synthetic_eso(seed: int, resolution: float = 0.2) -> tuple[list[float], list[float]]:
+    rng = np.random.default_rng(seed)
+    wavelengths = np.linspace(380.0, 920.0, int((920.0 - 380.0) / resolution))
+    base = 0.6 + 0.2 * np.cos(wavelengths / 22.0 + seed / 3.0)
+    features = sum(
+        np.exp(-0.5 * ((wavelengths - (450 + offset)) / (8 + idx)) ** 2)
+        for idx, offset in enumerate(range(0, 180, 45))
+    )
+    noise = 0.03 * rng.normal(size=wavelengths.size)
+    flux = base + 0.5 * features + noise
+    flux -= flux.min()
+    return wavelengths.tolist(), flux.tolist()
+
+
+def search(query: ProviderQuery) -> Iterable[ProviderHit]:
+    target = query.target or query.text or "ESO Source"
+    for idx in range(min(max(query.limit, 1), 3)):
+        resolution = 0.25 - idx * 0.05
+        wavelengths, flux = _synthetic_eso(idx + 11, resolution)
+        identifier = f"ESO-{target[:6].upper()}-{idx+1:02d}"
+        summary = f"ESO X-SHOOTER synthetic segment @R~{int(1000/resolution)}"
+        metadata = {
+            "target": target,
+            "instrument": query.instrument or "X-SHOOTER",
+            "resolution_nm": resolution,
+            "segment": idx + 1,
+        }
+        provenance = {
+            "archive": "ESO",
+            "query": query.as_dict(),
+        }
+        yield ProviderHit(
+            provider="ESO",
+            identifier=identifier,
+            label=f"{target} • X-SHOOTER seg {idx + 1}",
+            summary=summary,
+            wavelengths_nm=wavelengths,
+            flux=flux,
+            metadata=metadata,
+            provenance=provenance,
+        )

--- a/app/providers/mast.py
+++ b/app/providers/mast.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+"""Synthetic MAST adapter delivering deterministic preview spectra."""
+
+from typing import Iterable
+
+import numpy as np
+
+from .base import ProviderHit, ProviderQuery
+
+
+def _synthetic_spectrum(seed: int, center_nm: float = 550.0) -> tuple[list[float], list[float]]:
+    rng = np.random.default_rng(seed)
+    wavelengths = np.linspace(350.0, 950.0, 320)
+    envelope = np.exp(-0.5 * ((wavelengths - center_nm) / 90.0) ** 2)
+    modulation = 0.35 * np.sin(wavelengths / 35.0 + seed)
+    noise = 0.05 * rng.normal(size=wavelengths.size)
+    flux = envelope * (1.2 + modulation) + noise
+    flux -= flux.min()
+    return wavelengths.tolist(), flux.tolist()
+
+
+def search(query: ProviderQuery) -> Iterable[ProviderHit]:
+    target = query.target or query.text or "Target"
+    for idx in range(min(max(query.limit, 1), 5)):
+        center = 520.0 + 25.0 * idx
+        wavelengths, flux = _synthetic_spectrum(idx + 3, center)
+        identifier = f"MAST-{target[:6].upper()}-{idx+1:02d}"
+        summary = f"Synthetic preview for {target} centred at {center:.0f} nm"
+        metadata = {
+            "target": target,
+            "instrument": query.instrument or "STIS",
+            "exposure": 1200 + 120 * idx,
+            "preview_center_nm": center,
+        }
+        provenance = {
+            "archive": "MAST",
+            "query": query.as_dict(),
+        }
+        yield ProviderHit(
+            provider="MAST",
+            identifier=identifier,
+            label=f"{target} • STIS • {center:.0f} nm",
+            summary=summary,
+            wavelengths_nm=wavelengths,
+            flux=flux,
+            metadata=metadata,
+            provenance=provenance,
+        )

--- a/app/providers/sdss.py
+++ b/app/providers/sdss.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+"""SDSS provider adapter returning coarse-resolution synthetic spectra."""
+
+from typing import Iterable
+
+import numpy as np
+
+from .base import ProviderHit, ProviderQuery
+
+
+def _synthetic_sdss(seed: int) -> tuple[list[float], list[float]]:
+    rng = np.random.default_rng(seed)
+    wavelengths = np.linspace(360.0, 890.0, 220)
+    continuum = 0.8 + 0.15 * np.sin(wavelengths / 85.0 + seed)
+    absorption = 0.3 * np.exp(-0.5 * ((wavelengths - (515 + 30 * seed)) / 18.0) ** 2)
+    emission = 0.4 * np.exp(-0.5 * ((wavelengths - 656.0) / 9.0) ** 2)
+    noise = 0.06 * rng.normal(size=wavelengths.size)
+    flux = continuum - absorption + emission + noise
+    flux -= flux.min()
+    return wavelengths.tolist(), flux.tolist()
+
+
+def search(query: ProviderQuery) -> Iterable[ProviderHit]:
+    target = query.target or query.text or "SDSS Source"
+    for idx in range(min(max(query.limit, 1), 4)):
+        wavelengths, flux = _synthetic_sdss(idx + 21)
+        identifier = f"SDSS-{target[:6].upper()}-{idx+1:02d}"
+        summary = "Synthetic SDSS DR18-style preview"
+        metadata = {
+            "target": target,
+            "plate": 4000 + idx,
+            "mjd": 59000 + idx,
+            "fiber": 200 + idx,
+        }
+        provenance = {
+            "archive": "SDSS",
+            "query": query.as_dict(),
+        }
+        yield ProviderHit(
+            provider="SDSS",
+            identifier=identifier,
+            label=f"{target} • plate {metadata['plate']}",
+            summary=summary,
+            wavelengths_nm=wavelengths,
+            flux=flux,
+            metadata=metadata,
+            provenance=provenance,
+        )

--- a/app/similarity.py
+++ b/app/similarity.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+"""Similarity metrics and memoisation for overlay traces."""
+
+from dataclasses import dataclass
+import math
+import threading
+from typing import Dict, List, Sequence, Tuple
+
+import numpy as np
+import pandas as pd
+
+Viewport = Tuple[float | None, float | None]
+
+
+@dataclass(frozen=True)
+class TraceVectors:
+    """Numeric representation of a trace used for similarity calculations."""
+
+    trace_id: str
+    label: str
+    wavelengths_nm: np.ndarray
+    flux: np.ndarray
+    kind: str = "spectrum"
+    fingerprint: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "wavelengths_nm", np.asarray(self.wavelengths_nm, dtype=float))
+        object.__setattr__(self, "flux", np.asarray(self.flux, dtype=float))
+
+    def cleaned(self) -> "TraceVectors":
+        mask = np.isfinite(self.wavelengths_nm) & np.isfinite(self.flux)
+        return TraceVectors(
+            trace_id=self.trace_id,
+            label=self.label,
+            wavelengths_nm=self.wavelengths_nm[mask],
+            flux=self.flux[mask],
+            kind=self.kind,
+            fingerprint=self.fingerprint,
+        )
+
+
+@dataclass(frozen=True)
+class SimilarityOptions:
+    metrics: Tuple[str, ...]
+    normalization: str = "unit"
+    line_match_top_n: int = 8
+    primary_metric: str = "cosine"
+    reference_id: str | None = None
+
+    def __post_init__(self) -> None:
+        metrics = tuple(metric for metric in self.metrics if metric)
+        if not metrics:
+            metrics = ("cosine",)
+        object.__setattr__(self, "metrics", metrics)
+
+
+class SimilarityCache:
+    """Thread-safe memoisation of pairwise similarity metrics."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._store: Dict[Tuple[str, str, Tuple[float | None, float | None], Tuple[str, ...], str, int], Dict[str, float]] = {}
+
+    def _pair_key(
+        self,
+        trace_a: TraceVectors,
+        trace_b: TraceVectors,
+        viewport: Viewport,
+        options: SimilarityOptions,
+    ) -> Tuple[str, str, Tuple[float | None, float | None], Tuple[str, ...], str, int]:
+        identity_a = trace_a.fingerprint or trace_a.trace_id
+        identity_b = trace_b.fingerprint or trace_b.trace_id
+        ordered = tuple(sorted((identity_a, identity_b)))
+        low, high = viewport
+        viewport_key = (_normalise_float(low), _normalise_float(high))
+        metrics_key = tuple(sorted(options.metrics))
+        return ordered + (viewport_key, metrics_key, options.normalization, options.line_match_top_n)
+
+    def compute(
+        self,
+        trace_a: TraceVectors,
+        trace_b: TraceVectors,
+        viewport: Viewport,
+        options: SimilarityOptions,
+    ) -> Dict[str, float]:
+        key = self._pair_key(trace_a, trace_b, viewport, options)
+        with self._lock:
+            cached = self._store.get(key)
+        if cached is not None:
+            return dict(cached)
+        result = _compute_metrics(trace_a, trace_b, viewport, options)
+        with self._lock:
+            self._store[key] = dict(result)
+        return result
+
+    def reset(self) -> None:
+        with self._lock:
+            self._store.clear()
+
+
+# ---------------------------------------------------------------------------
+
+def _normalise_float(value: float | None) -> float | None:
+    if value is None:
+        return None
+    if not math.isfinite(value):
+        return None
+    return round(float(value), 6)
+
+
+def _prepare_vectors(
+    trace_a: TraceVectors,
+    trace_b: TraceVectors,
+    viewport: Viewport,
+) -> Tuple[np.ndarray | None, np.ndarray | None, np.ndarray | None]:
+    cleaned_a = trace_a.cleaned()
+    cleaned_b = trace_b.cleaned()
+    if cleaned_a.wavelengths_nm.size == 0 or cleaned_b.wavelengths_nm.size == 0:
+        return None, None, None
+
+    wavelengths = np.union1d(cleaned_a.wavelengths_nm, cleaned_b.wavelengths_nm)
+    if viewport[0] is not None:
+        wavelengths = wavelengths[wavelengths >= viewport[0]]
+    if viewport[1] is not None:
+        wavelengths = wavelengths[wavelengths <= viewport[1]]
+    if wavelengths.size == 0:
+        return None, None, None
+
+    values_a = np.interp(
+        wavelengths,
+        cleaned_a.wavelengths_nm,
+        cleaned_a.flux,
+        left=np.nan,
+        right=np.nan,
+    )
+    values_b = np.interp(
+        wavelengths,
+        cleaned_b.wavelengths_nm,
+        cleaned_b.flux,
+        left=np.nan,
+        right=np.nan,
+    )
+    mask = np.isfinite(values_a) & np.isfinite(values_b)
+    wavelengths = wavelengths[mask]
+    values_a = values_a[mask]
+    values_b = values_b[mask]
+    if wavelengths.size == 0:
+        return None, None, None
+    return wavelengths, values_a, values_b
+
+
+def apply_normalization(values: np.ndarray, mode: str) -> np.ndarray:
+    if values.size == 0:
+        return values
+    mode = (mode or "none").lower()
+    if mode in {"unit", "l2"}:
+        norm = float(np.linalg.norm(values))
+        if norm > 0:
+            return values / norm
+        return values
+    if mode in {"max", "peak"}:
+        peak = float(np.max(np.abs(values)))
+        if peak > 0:
+            return values / peak
+        return values
+    if mode in {"zscore", "z", "standard"}:
+        mean = float(np.mean(values))
+        std = float(np.std(values))
+        if std > 0:
+            return (values - mean) / std
+        return values - mean
+    return values
+
+
+def _cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
+    denom = float(np.linalg.norm(a) * np.linalg.norm(b))
+    if denom == 0:
+        return float("nan")
+    value = float(np.dot(a, b) / denom)
+    return max(min(value, 1.0), -1.0)
+
+
+def _rmse(a: np.ndarray, b: np.ndarray) -> float:
+    if a.size == 0:
+        return float("nan")
+    return float(np.sqrt(np.mean((a - b) ** 2)))
+
+
+def _xcorr(a: np.ndarray, b: np.ndarray) -> float:
+    if a.size == 0:
+        return float("nan")
+    a_zero = a - np.mean(a)
+    b_zero = b - np.mean(b)
+    denom = float(np.linalg.norm(a_zero) * np.linalg.norm(b_zero))
+    if denom == 0:
+        return float("nan")
+    value = float(np.dot(a_zero, b_zero) / denom)
+    return max(min(value, 1.0), -1.0)
+
+
+def _line_match(axis: np.ndarray, a: np.ndarray, b: np.ndarray, top_n: int) -> float:
+    if axis.size == 0 or top_n <= 0:
+        return float("nan")
+    k = min(top_n, axis.size)
+    idx_a = np.argsort(np.abs(a))[-k:]
+    idx_b = np.argsort(np.abs(b))[-k:]
+    peaks_a = axis[idx_a]
+    peaks_b = axis[idx_b]
+    if peaks_a.size == 0 or peaks_b.size == 0:
+        return float("nan")
+    span = float(axis.max() - axis.min()) or 1.0
+    distances: List[float] = []
+    for value in peaks_a:
+        distances.append(float(np.min(np.abs(peaks_b - value))))
+    for value in peaks_b:
+        distances.append(float(np.min(np.abs(peaks_a - value))))
+    if not distances:
+        return float("nan")
+    mean_distance = float(np.mean(distances))
+    score = 1.0 - min(1.0, mean_distance / span)
+    return max(min(score, 1.0), 0.0)
+
+
+def _compute_metrics(
+    trace_a: TraceVectors,
+    trace_b: TraceVectors,
+    viewport: Viewport,
+    options: SimilarityOptions,
+) -> Dict[str, float]:
+    axis, values_a, values_b = _prepare_vectors(trace_a, trace_b, viewport)
+    result: Dict[str, float] = {metric: float("nan") for metric in options.metrics}
+    if axis is None or values_a is None or values_b is None:
+        result["points"] = 0.0
+        return result
+
+    norm_a = apply_normalization(values_a, options.normalization)
+    norm_b = apply_normalization(values_b, options.normalization)
+    for metric in options.metrics:
+        if metric == "cosine":
+            result[metric] = _cosine_similarity(norm_a, norm_b)
+        elif metric == "rmse":
+            result[metric] = _rmse(norm_a, norm_b)
+        elif metric in {"xcorr", "corr", "correlation"}:
+            result[metric] = _xcorr(norm_a, norm_b)
+        elif metric in {"line_match", "lines"}:
+            result[metric] = _line_match(axis, norm_a, norm_b, options.line_match_top_n)
+        else:
+            # Unknown metric: leave NaN but keep key predictable
+            result.setdefault(metric, float("nan"))
+    result["points"] = float(axis.size)
+    return result
+
+
+def build_metric_frames(
+    traces: Sequence[TraceVectors],
+    viewport: Viewport,
+    options: SimilarityOptions,
+    cache: SimilarityCache,
+) -> Dict[str, pd.DataFrame]:
+    if len(traces) < 2:
+        return {}
+    labels = [trace.label for trace in traces]
+    frames: Dict[str, pd.DataFrame] = {}
+    for metric in options.metrics:
+        diag_value = 1.0 if metric != "rmse" else 0.0
+        frames[metric] = pd.DataFrame(
+            diag_value,
+            index=labels,
+            columns=labels,
+            dtype=float,
+        )
+    for i, trace_a in enumerate(traces):
+        for j in range(i + 1, len(traces)):
+            trace_b = traces[j]
+            metrics = cache.compute(trace_a, trace_b, viewport, options)
+            for metric in options.metrics:
+                value = metrics.get(metric, float("nan"))
+                frames[metric].iat[i, j] = value
+                frames[metric].iat[j, i] = value
+    return frames
+
+
+def viewport_alignment(
+    trace_a: TraceVectors,
+    trace_b: TraceVectors,
+    viewport: Viewport,
+) -> Tuple[np.ndarray | None, np.ndarray | None, np.ndarray | None]:
+    return _prepare_vectors(trace_a, trace_b, viewport)

--- a/app/similarity_panel.py
+++ b/app/similarity_panel.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+"""Streamlit rendering helpers for similarity metrics."""
+
+import math
+from typing import Dict, List, Sequence
+
+import pandas as pd
+import streamlit as st
+
+from app.similarity import (
+    SimilarityCache,
+    SimilarityOptions,
+    TraceVectors,
+    build_metric_frames,
+)
+
+
+def _format_value(value: float, metric: str) -> str:
+    if value is None or (isinstance(value, float) and math.isnan(value)):
+        return "—"
+    if metric == "rmse":
+        return f"{value:.4f}"
+    if metric in {"line_match", "lines"}:
+        return f"{value*100:.1f}%"
+    return f"{value:.3f}"
+
+
+def render_similarity_panel(
+    traces: Sequence[TraceVectors],
+    viewport,
+    options: SimilarityOptions,
+    cache: SimilarityCache,
+) -> Dict[str, pd.DataFrame]:
+    if len(traces) < 2:
+        st.info("Add at least two visible traces to compute similarity metrics.")
+        return {}
+
+    frames = build_metric_frames(traces, viewport, options, cache)
+    if not frames:
+        st.warning("No overlapping data in the selected viewport.")
+        return {}
+
+    st.markdown("### Similarity analysis")
+    reference = _resolve_reference(traces, options.reference_id)
+    _render_ribbon(reference, traces, viewport, options, cache)
+    ordered = _order_frames(frames, options.primary_metric)
+    _render_matrices(ordered)
+    return frames
+
+
+def _resolve_reference(traces: Sequence[TraceVectors], reference_id: str | None) -> TraceVectors:
+    if reference_id:
+        for trace in traces:
+            if trace.trace_id == reference_id:
+                return trace
+    return traces[0]
+
+
+def _render_ribbon(
+    reference: TraceVectors,
+    traces: Sequence[TraceVectors],
+    viewport,
+    options: SimilarityOptions,
+    cache: SimilarityCache,
+) -> None:
+    others = [trace for trace in traces if trace.trace_id != reference.trace_id]
+    if not others:
+        return
+
+    st.markdown(f"#### Ribbon — reference: **{reference.label}**")
+    columns = st.columns(len(others))
+    for column, trace in zip(columns, others):
+        metrics = cache.compute(reference, trace, viewport, options)
+        column.markdown(f"**{trace.label}**")
+        for metric in options.metrics:
+            label = metric.replace("_", " ").title()
+            column.metric(label, _format_value(metrics.get(metric), metric))
+        if "points" in metrics:
+            column.caption(f"{int(metrics['points'])} shared samples")
+
+
+def _order_frames(frames: Dict[str, pd.DataFrame], primary: str | None) -> List[tuple[str, pd.DataFrame]]:
+    ordered = list(frames.items())
+    if primary and primary in frames:
+        ordered.sort(key=lambda item: (0 if item[0] == primary else 1, item[0]))
+    return ordered
+
+
+def _render_matrices(frames: Sequence[tuple[str, pd.DataFrame]]) -> None:
+    tab_labels = [name.replace("_", " ").title() for name, _ in frames]
+    tabs = st.tabs(tab_labels)
+    for tab, (metric, frame) in zip(tabs, frames):
+        with tab:
+            styled = frame.style.format(lambda v, m=metric: _format_value(v, m))
+            st.dataframe(styled, use_container_width=True)
+            st.caption("Diagonal entries show self-similarity. NaN indicates insufficient overlap in the viewport.")

--- a/app/ui/main.py
+++ b/app/ui/main.py
@@ -1,288 +1,734 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import math
 import time
+import uuid
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
+import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
 import streamlit as st
 
 from app._version import get_version_info
+from app.archive_ui import ArchiveUI
 from app.export_manifest import build_manifest
 from app.server.fetch_archives import FetchError, fetch_spectrum
-
-st.set_page_config(page_title='Spectra App', layout='wide')
-
-VI = get_version_info()  # version info dict
-
-root = Path('.')
-exports = root / 'exports'
-exports.mkdir(exist_ok=True, parents=True)
-
-# Header with version badge
-st.markdown(
-    f"<div style='display:flex;justify-content:space-between;align-items:center;'>"
-    f"<h2 style='margin:0'>Spectra App</h2>"
-    f"<span style='background:#111;border:1px solid #333;padding:4px 8px;border-radius:8px;'>"
-    f"{VI['version']} • {VI['date_utc']}</span></div>",
-    unsafe_allow_html=True
+from app.similarity import (
+    SimilarityCache,
+    SimilarityOptions,
+    TraceVectors,
+    apply_normalization,
+    viewport_alignment,
 )
+from app.similarity_panel import render_similarity_panel
+from app.utils.duplicate_ledger import DuplicateLedger
 
-st.sidebar.title('Spectra Controls')
-st.sidebar.caption(f"Build: {VI['version']} — {VI['summary'] or 'No summary'}")
+st.set_page_config(page_title="Spectra App", layout="wide")
 
-with st.expander("What's new in this patch?"):
-    st.write(f"**{VI['version']}** — {VI['summary'] or 'No summary provided.'}")
-    st.caption(f"Built: {VI['date_utc']}")
-
-if "nist_overlays" not in st.session_state:
-    st.session_state["nist_overlays"] = []
-
-st.sidebar.markdown("### NIST ASD overlays")
-with st.sidebar.form("nist_overlay_form", clear_on_submit=False):
-    nist_identifier = st.text_input(
-        "Element or spectrum",
-        key="nist_element_identifier",
-        placeholder="e.g. H, Hydrogen, Fe II",
-        help="Enter an element symbol or name. Add a Roman numeral or +++ to specify the ion stage.",
-    )
-    nist_lower = st.number_input(
-        "Lower λ (nm)",
-        min_value=0.0,
-        value=380.0,
-        step=10.0,
-        key="nist_lower_bound",
-        help="Minimum wavelength to request from NIST (nanometers).",
-    )
-    nist_upper = st.number_input(
-        "Upper λ (nm)",
-        min_value=0.0,
-        value=750.0,
-        step=10.0,
-        key="nist_upper_bound",
-        help="Maximum wavelength to request from NIST (nanometers).",
-    )
-    nist_use_ritz = st.checkbox(
-        "Prefer Ritz wavelengths",
-        value=True,
-        key="nist_prefer_ritz",
-        help="Use Ritz wavelengths when available; fall back to observed values otherwise.",
-    )
-    if st.form_submit_button("Add NIST overlay"):
-        identifier = (st.session_state.get("nist_element_identifier") or "").strip()
-        lower = float(st.session_state.get("nist_lower_bound", nist_lower))
-        upper = float(st.session_state.get("nist_upper_bound", nist_upper))
-        use_ritz = bool(st.session_state.get("nist_prefer_ritz", True))
-        if not identifier:
-            st.sidebar.warning("Enter an element symbol or spectrum label.")
-        elif math.isclose(lower, upper):
-            st.sidebar.warning("Lower and upper wavelength bounds must differ.")
-        else:
-            try:
-                result = fetch_spectrum(
-                    "nist",
-                    element=identifier,
-                    lower_wavelength=min(lower, upper),
-                    upper_wavelength=max(lower, upper),
-                    wavelength_unit="nm",
-                    use_ritz=use_ritz,
-                )
-            except (FetchError, ValueError, RuntimeError) as exc:
-                st.sidebar.error(f"Failed to fetch NIST data: {exc}")
-            else:
-                st.session_state["nist_overlays"].append(result)
-                st.sidebar.success(f"Added {result['meta'].get('label', identifier)}")
-
-if st.session_state["nist_overlays"]:
-    if st.sidebar.button("Clear NIST overlays"):
-        st.session_state["nist_overlays"] = []
-        for key in list(st.session_state.keys()):
-            if key.startswith("nist_visible_"):
-                del st.session_state[key]
-    else:
-        st.sidebar.caption("Toggle overlays to display them on the charts.")
-        for idx, overlay in enumerate(st.session_state["nist_overlays"]):
-            label = overlay.get("meta", {}).get("label", f"NIST overlay {idx + 1}")
-            visible_key = f"nist_visible_{idx}"
-            visible = st.sidebar.checkbox(label, value=True, key=visible_key)
-            overlay["visible"] = visible
-
-st.sidebar.write('Examples')
-ex_toggle_he = st.sidebar.checkbox('He (example)', value=False)
-ex_toggle_ne = st.sidebar.checkbox('Ne (example)', value=False)
-display_mode = st.sidebar.selectbox(
-    'Display mode',
-    ['Flux (raw)', 'Flux (normalized)'],
-    index=0,
-    help='Choose how traces are scaled before plotting.'
-)
-display_units = st.sidebar.selectbox(
-    'Display units',
-    ['nm', 'Å', 'µm', 'cm^-1'],
-    index=0,
-    help='Unit applied to the wavelength axis.'
-)
-
-tabs = st.tabs(['Overlay', 'Differential', 'Docs'])
-
-def _convert_wavelength(series: pd.Series, unit: str) -> tuple[pd.Series, str]:
-    unit = unit or 'nm'
-    if unit == 'Å':
-        return series * 10.0, 'Wavelength (Å)'
-    if unit == 'µm':
-        return series / 1000.0, 'Wavelength (µm)'
-    if unit == 'cm^-1':
-        # Avoid divide-by-zero; replace zeros with NaN before inversion.
-        safe = series.replace(0, pd.NA)
-        return 1e7 / safe, 'Wavenumber (cm⁻¹)'
-    return series, 'Wavelength (nm)'
+EXPORT_DIR = Path("exports")
+EXPORT_DIR.mkdir(parents=True, exist_ok=True)
 
 
-def _prepare_trace(csv_path: str, label: str, display_units: str, display_mode: str) -> tuple[pd.DataFrame, str]:
-    df = pd.read_csv(csv_path)
-    wavelengths, axis_title = _convert_wavelength(df['wavelength_nm'], display_units)
-    intensities = pd.Series(df['intensity'], dtype=float)
-    if display_mode == 'Flux (normalized)':
-        max_val = float(intensities.abs().max())
-        if max_val:
-            intensities = intensities / max_val
-    plot_df = pd.DataFrame({'wavelength': wavelengths, 'flux': intensities}).dropna()
-    plot_df = plot_df.sort_values('wavelength')
-    plot_df['series'] = label
-    return plot_df, axis_title
+@dataclass
+class OverlayTrace:
+    trace_id: str
+    label: str
+    wavelength_nm: Tuple[float, ...]
+    flux: Tuple[float, ...]
+    kind: str = "spectrum"
+    provider: Optional[str] = None
+    summary: Optional[str] = None
+    visible: bool = True
+    metadata: Dict[str, object] = field(default_factory=dict)
+    provenance: Dict[str, object] = field(default_factory=dict)
+    fingerprint: str = ""
+    hover: Optional[Tuple[str, ...]] = None
 
-
-def _prepare_nist_trace(data: dict, display_units: str, display_mode: str) -> tuple[pd.DataFrame, str]:
-    lines = data.get('lines') or []
-    if not lines:
-        return pd.DataFrame(), 'Wavelength (nm)'
-
-    base_series = pd.Series([line.get('wavelength_nm') for line in lines], dtype=float)
-    converted, axis_title = _convert_wavelength(base_series, display_units)
-
-    if display_mode == 'Flux (normalized)':
-        intensities = pd.Series([line.get('relative_intensity_normalized') for line in lines], dtype=float)
-    else:
-        intensities = pd.Series([line.get('relative_intensity') for line in lines], dtype=float)
-
-    if intensities.notna().any():
-        intensities = intensities.fillna(0.0)
-    else:
-        intensities = pd.Series([1.0] * len(lines), dtype=float)
-
-    axis_unit = axis_title.split('(')[-1].strip(')') if '(' in axis_title else axis_title
-    converted_list = converted.tolist()
-
-    hover_texts: list[str] = []
-    for idx, line in enumerate(lines):
-        wavelength_value = converted_list[idx]
-        if isinstance(wavelength_value, (int, float)) and math.isfinite(wavelength_value):
-            text_lines = [f"λ: {wavelength_value:.4f} {axis_unit}"]
-        else:
-            text_lines = ["λ unavailable"]
-
-        ritz_nm = line.get('ritz_wavelength_nm')
-        observed_nm = line.get('observed_wavelength_nm')
-        if ritz_nm and observed_nm and not math.isclose(ritz_nm, observed_nm, rel_tol=1e-9, abs_tol=1e-9):
-            text_lines.append(f"Ritz: {ritz_nm:.4f} nm")
-            text_lines.append(f"Observed: {observed_nm:.4f} nm")
-        elif ritz_nm:
-            text_lines.append(f"Ritz: {ritz_nm:.4f} nm")
-        elif observed_nm:
-            text_lines.append(f"Observed: {observed_nm:.4f} nm")
-
-        rel_int = line.get('relative_intensity')
-        if rel_int is not None:
-            text_lines.append(f"Rel. intensity: {rel_int:g}")
-        norm_int = line.get('relative_intensity_normalized')
-        if norm_int is not None:
-            text_lines.append(f"Normalized: {norm_int:.3f}")
-
-        accuracy = line.get('accuracy')
-        if accuracy:
-            text_lines.append(f"Accuracy: {accuracy}")
-
-        lower = line.get('lower_level')
-        upper = line.get('upper_level')
-        if lower or upper:
-            text_lines.append(f"{lower or '?'} → {upper or '?'}")
-
-        hover_texts.append("<br>".join(text_lines))
-
-    plot_df = pd.DataFrame(
-        {
-            'wavelength': converted,
-            'flux': intensities,
-            'series': data.get('meta', {}).get('label', 'NIST ASD'),
-            'hover_text': hover_texts,
-            'relative_intensity': [line.get('relative_intensity') for line in lines],
-            'relative_intensity_normalized': [line.get('relative_intensity_normalized') for line in lines],
-            'observed_wavelength_nm': [line.get('observed_wavelength_nm') for line in lines],
-            'ritz_wavelength_nm': [line.get('ritz_wavelength_nm') for line in lines],
+    def to_dataframe(self) -> pd.DataFrame:
+        data: Dict[str, Iterable[object]] = {
+            "wavelength_nm": self.wavelength_nm,
+            "flux": self.flux,
         }
-    )
-    return plot_df, axis_title
+        if self.hover:
+            data["hover"] = list(self.hover)
+        df = pd.DataFrame(data)
+        df = df.replace([np.inf, -np.inf], np.nan)
+        df = df.dropna(subset=["wavelength_nm", "flux"])
+        return df.sort_values("wavelength_nm")
+
+    def to_vectors(self) -> TraceVectors:
+        df = self.to_dataframe()
+        return TraceVectors(
+            trace_id=self.trace_id,
+            label=self.label,
+            wavelengths_nm=df["wavelength_nm"].to_numpy(dtype=float),
+            flux=df["flux"].to_numpy(dtype=float),
+            kind=self.kind,
+            fingerprint=self.fingerprint,
+        )
+
+    @property
+    def points(self) -> int:
+        return len(self.wavelength_nm)
 
 
-def _add_nist_trace(fig: go.Figure, trace_df: pd.DataFrame, label: str) -> None:
-    if trace_df.empty:
+# ---------------------------------------------------------------------------
+# Session state helpers
+
+def _ensure_session_state() -> None:
+    st.session_state.setdefault("session_id", str(uuid.uuid4()))
+    st.session_state.setdefault("overlay_traces", [])
+    st.session_state.setdefault("display_units", "nm")
+    st.session_state.setdefault("display_mode", "Flux (raw)")
+    st.session_state.setdefault("viewport_nm", (None, None))
+    st.session_state.setdefault("auto_viewport", True)
+    st.session_state.setdefault("normalization_mode", "unit")
+    st.session_state.setdefault("differential_mode", "Off")
+    st.session_state.setdefault("reference_trace_id", None)
+    st.session_state.setdefault("similarity_metrics", ["cosine", "rmse", "xcorr", "line_match"])
+    st.session_state.setdefault("similarity_primary_metric", "cosine")
+    st.session_state.setdefault("similarity_line_peaks", 8)
+    st.session_state.setdefault("similarity_normalization", st.session_state.get("normalization_mode", "unit"))
+    st.session_state.setdefault("duplicate_policy", "allow")
+    if "duplicate_ledger" not in st.session_state:
+        st.session_state["duplicate_ledger"] = DuplicateLedger()
+    if "similarity_cache" not in st.session_state:
+        st.session_state["similarity_cache"] = SimilarityCache()
+
+
+def _get_overlays() -> List[OverlayTrace]:
+    return list(st.session_state.get("overlay_traces", []))
+
+
+def _set_overlays(overlays: Sequence[OverlayTrace]) -> None:
+    st.session_state["overlay_traces"] = list(overlays)
+    _ensure_reference_consistency()
+
+
+def _ensure_reference_consistency() -> None:
+    overlays = _get_overlays()
+    current = st.session_state.get("reference_trace_id")
+    if current and any(trace.trace_id == current for trace in overlays):
         return
-    xs: list[float | None] = []
-    ys: list[float | None] = []
-    hover: list[str | None] = []
-    for _, row in trace_df.iterrows():
-        wavelength = row['wavelength']
-        flux_value = float(row['flux']) if row['flux'] is not None else 0.0
-        text = row.get('hover_text')
-        xs.extend([wavelength, wavelength, None])
-        ys.extend([0.0, flux_value, None])
-        hover.extend([text, text, None])
+    if overlays:
+        st.session_state["reference_trace_id"] = overlays[0].trace_id
+    else:
+        st.session_state["reference_trace_id"] = None
 
+
+def _trace_label(trace_id: Optional[str]) -> str:
+    if trace_id is None:
+        return "—"
+    for trace in _get_overlays():
+        if trace.trace_id == trace_id:
+            suffix = f" ({trace.provider})" if trace.provider else ""
+            return f"{trace.label}{suffix}"
+    return trace_id
+
+
+def _compute_fingerprint(wavelengths: Sequence[float], flux: Sequence[float]) -> str:
+    payload = {
+        "wavelength_nm": [round(float(w), 6) for w in wavelengths],
+        "flux": [round(float(f), 6) for f in flux],
+    }
+    encoded = json.dumps(payload, sort_keys=True).encode("utf-8")
+    return hashlib.sha1(encoded).hexdigest()
+
+
+def _add_overlay(
+    label: str,
+    wavelengths: Sequence[float],
+    flux: Sequence[float],
+    *,
+    kind: str = "spectrum",
+    provider: Optional[str] = None,
+    summary: Optional[str] = None,
+    metadata: Optional[Dict[str, object]] = None,
+    provenance: Optional[Dict[str, object]] = None,
+    hover: Optional[Sequence[str]] = None,
+) -> Tuple[bool, str]:
+    try:
+        values_w = [float(v) for v in wavelengths]
+        values_f = [float(v) for v in flux]
+    except (TypeError, ValueError):
+        return False, "Unable to coerce spectral data to floats."
+    if not values_w or not values_f or len(values_w) != len(values_f):
+        return False, "No spectral samples available."
+
+    overlays = _get_overlays()
+    fingerprint = _compute_fingerprint(values_w, values_f)
+    policy = st.session_state.get("duplicate_policy", "allow")
+    if policy in {"skip", "ledger"}:
+        for existing in overlays:
+            if existing.fingerprint == fingerprint:
+                return False, f"Skipped duplicate trace: {label}"
+        if policy == "ledger":
+            ledger: DuplicateLedger = st.session_state["duplicate_ledger"]
+            if ledger.seen(fingerprint):
+                return False, f"Trace already recorded in ledger: {label}"
+
+    trace = OverlayTrace(
+        trace_id=str(uuid.uuid4()),
+        label=label,
+        wavelength_nm=tuple(values_w),
+        flux=tuple(values_f),
+        kind=kind,
+        provider=provider,
+        summary=summary,
+        metadata=dict(metadata or {}),
+        provenance=dict(provenance or {}),
+        fingerprint=fingerprint,
+        hover=tuple(str(text) for text in (hover or [])) if hover else None,
+    )
+    overlays.append(trace)
+    _set_overlays(overlays)
+
+    if policy == "ledger":
+        ledger = st.session_state["duplicate_ledger"]
+        ledger.record(
+            fingerprint,
+            {
+                "label": label,
+                "provider": provider,
+                "session_id": st.session_state.get("session_id"),
+                "added_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            },
+        )
+
+    if not st.session_state.get("reference_trace_id"):
+        st.session_state["reference_trace_id"] = trace.trace_id
+
+    message = f"Added {label}"
+    if provider:
+        message += f" ({provider})"
+    return True, message
+
+
+def _add_overlay_payload(payload: Dict[str, object]) -> Tuple[bool, str]:
+    return _add_overlay(
+        str(payload.get("label") or "Trace"),
+        payload.get("wavelength_nm") or [],
+        payload.get("flux") or [],
+        kind=str(payload.get("kind") or "spectrum"),
+        provider=payload.get("provider"),
+        summary=payload.get("summary"),
+        metadata=payload.get("metadata"),
+        provenance=payload.get("provenance"),
+        hover=payload.get("hover"),
+    )
+
+
+def _add_example_trace(example: str, label: str) -> Tuple[bool, str]:
+    csv_path = Path("app/examples") / f"{example}.csv"
+    if not csv_path.exists():
+        return False, f"Missing example data: {example}."
+    try:
+        df = pd.read_csv(csv_path)
+    except Exception as exc:
+        return False, f"Failed to load example {example}: {exc}"
+    if "wavelength_nm" not in df or "intensity" not in df:
+        return False, f"Example {example} missing required columns."
+    metadata = {"source": "example", "path": str(csv_path)}
+    provenance = {"source": "example", "file": str(csv_path)}
+    return _add_overlay(
+        label,
+        df["wavelength_nm"].tolist(),
+        df["intensity"].tolist(),
+        provider="EXAMPLE",
+        summary="Built-in example trace",
+        metadata=metadata,
+        provenance=provenance,
+    )
+
+# ---------------------------------------------------------------------------
+# Sidebar rendering
+
+def _render_reference_section() -> None:
+    st.sidebar.markdown("### Reference spectra")
+    col1, col2 = st.sidebar.columns(2)
+    if col1.button("Add He"):
+        added, message = _add_example_trace("He", "He (example)")
+        (st.sidebar.success if added else st.sidebar.info)(message)
+    if col2.button("Add Ne"):
+        added, message = _add_example_trace("Ne", "Ne (example)")
+        (st.sidebar.success if added else st.sidebar.info)(message)
+    _render_nist_form()
+
+    overlays = _get_overlays()
+    if overlays:
+        options = [trace.trace_id for trace in overlays]
+        current = st.session_state.get("reference_trace_id")
+        try:
+            index = options.index(current) if current in options else 0
+        except ValueError:
+            index = 0
+        st.session_state["reference_trace_id"] = st.sidebar.selectbox(
+            "Reference trace",
+            options,
+            index=index,
+            format_func=_trace_label,
+        )
+        if st.sidebar.button("Clear overlays"):
+            _clear_overlays()
+            st.sidebar.warning("Cleared all overlays.")
+    else:
+        st.sidebar.caption("Load an example or fetch from an archive to begin.")
+
+
+def _render_nist_form() -> None:
+    st.sidebar.markdown("#### NIST ASD lines")
+    with st.sidebar.form("nist_overlay_form", clear_on_submit=False):
+        identifier = st.text_input("Element or spectrum", placeholder="e.g. Fe II")
+        lower = st.number_input("Lower λ (nm)", min_value=0.0, value=380.0, step=5.0)
+        upper = st.number_input("Upper λ (nm)", min_value=0.0, value=750.0, step=5.0)
+        use_ritz = st.checkbox("Prefer Ritz wavelengths", value=True)
+        submitted = st.form_submit_button("Fetch lines")
+    if not submitted:
+        return
+    identifier = (identifier or "").strip()
+    if not identifier:
+        st.sidebar.warning("Enter an element identifier.")
+        return
+    if math.isclose(lower, upper):
+        st.sidebar.warning("Lower and upper bounds must differ.")
+        return
+    try:
+        result = fetch_spectrum(
+            "nist",
+            element=identifier,
+            lower_wavelength=min(lower, upper),
+            upper_wavelength=max(lower, upper),
+            wavelength_unit="nm",
+            use_ritz=use_ritz,
+        )
+    except (FetchError, ValueError, RuntimeError) as exc:
+        st.sidebar.error(f"NIST fetch failed: {exc}")
+        return
+    payload = _convert_nist_payload(result)
+    if not payload:
+        st.sidebar.warning("NIST returned no lines for that query.")
+        return
+    added, message = _add_overlay_payload(payload)
+    (st.sidebar.success if added else st.sidebar.info)(message)
+
+
+def _render_display_section() -> None:
+    st.sidebar.markdown("### Display & viewport")
+    units = st.sidebar.selectbox(
+        "Wavelength units",
+        ["nm", "Å", "µm", "cm^-1"],
+        index=["nm", "Å", "µm", "cm^-1"].index(st.session_state.get("display_units", "nm")),
+    )
+    st.session_state["display_units"] = units
+    display_mode_options = ["Flux (raw)", "Flux (normalized)"]
+    current_mode = st.session_state.get("display_mode", "Flux (raw)")
+    mode_index = display_mode_options.index(current_mode) if current_mode in display_mode_options else 0
+    st.session_state["display_mode"] = st.sidebar.selectbox("Flux scaling", display_mode_options, index=mode_index)
+
+    auto = st.sidebar.checkbox("Auto viewport", value=bool(st.session_state.get("auto_viewport", True)))
+    st.session_state["auto_viewport"] = auto
+    if auto:
+        st.session_state["viewport_nm"] = (None, None)
+        return
+
+    min_bound, max_bound = _infer_viewport_bounds(_get_overlays())
+    if math.isclose(min_bound, max_bound):
+        max_bound = min_bound + 1.0
+    low, high = st.session_state.get("viewport_nm", (min_bound, max_bound))
+    if low is None or high is None:
+        low, high = min_bound, max_bound
+    low = max(min_bound, float(low))
+    high = min(max_bound, float(high))
+    selection = st.sidebar.slider(
+        "Viewport (nm)",
+        min_value=float(min_bound),
+        max_value=float(max_bound),
+        value=(low, high),
+        step=1.0,
+    )
+    st.session_state["viewport_nm"] = (float(selection[0]), float(selection[1]))
+
+
+def _render_differential_section() -> None:
+    st.sidebar.markdown("### Differential & normalization")
+    norm_map = {
+        "Unit vector (L2)": "unit",
+        "Peak normalised": "max",
+        "Z-score": "zscore",
+        "None": "none",
+    }
+    current_norm = st.session_state.get("normalization_mode", "unit")
+    norm_labels = list(norm_map.keys())
+    try:
+        index = norm_labels.index(next(label for label, code in norm_map.items() if code == current_norm))
+    except StopIteration:
+        index = 0
+    selection = st.sidebar.selectbox("Normalization", norm_labels, index=index)
+    st.session_state["normalization_mode"] = norm_map[selection]
+
+    diff_options = ["Off", "Relative to reference"]
+    diff_mode = st.session_state.get("differential_mode", "Off")
+    diff_index = diff_options.index(diff_mode) if diff_mode in diff_options else 0
+    st.session_state["differential_mode"] = st.sidebar.selectbox("Differential mode", diff_options, index=diff_index)
+    if st.session_state["differential_mode"] != "Off":
+        st.sidebar.caption("Traces are regridded onto the reference before subtracting.")
+
+
+def _render_similarity_sidebar() -> None:
+    st.sidebar.markdown("### Similarity settings")
+    metric_options = ["cosine", "rmse", "xcorr", "line_match"]
+    current_metrics = st.session_state.get("similarity_metrics", metric_options)
+    metrics = st.sidebar.multiselect(
+        "Metrics",
+        options=metric_options,
+        default=current_metrics if current_metrics else metric_options[:1],
+        format_func=lambda m: m.replace("_", " ").title(),
+    )
+    if not metrics:
+        metrics = metric_options[:1]
+    st.session_state["similarity_metrics"] = metrics
+
+    primary = st.session_state.get("similarity_primary_metric", metrics[0])
+    if primary not in metrics:
+        primary = metrics[0]
+    st.session_state["similarity_primary_metric"] = st.sidebar.selectbox(
+        "Primary matrix",
+        metrics,
+        index=metrics.index(primary),
+        format_func=lambda m: m.replace("_", " ").title(),
+    )
+
+    line_peaks = st.sidebar.slider(
+        "Line peak count",
+        min_value=3,
+        max_value=20,
+        value=int(st.session_state.get("similarity_line_peaks", 8)),
+        help="Number of strongest samples considered for the line-match metric.",
+    )
+    st.session_state["similarity_line_peaks"] = int(line_peaks)
+
+    norm_labels = ["Unit vector (L2)", "Peak normalised", "Z-score", "None"]
+    norm_codes = {"Unit vector (L2)": "unit", "Peak normalised": "max", "Z-score": "zscore", "None": "none"}
+    current_code = st.session_state.get("similarity_normalization", st.session_state.get("normalization_mode", "unit"))
+    current_label = next((label for label, code in norm_codes.items() if code == current_code), norm_labels[0])
+    selection = st.sidebar.selectbox("Similarity normalization", norm_labels, index=norm_labels.index(current_label))
+    st.session_state["similarity_normalization"] = norm_codes[selection]
+
+
+def _render_duplicate_sidebar() -> None:
+    st.sidebar.markdown("### Duplicate handling")
+    policies = [
+        ("Allow duplicates", "allow"),
+        ("Skip duplicates (session)", "skip"),
+        ("Ledger lock (persistent)", "ledger"),
+    ]
+    codes = [code for _, code in policies]
+    labels = [label for label, _ in policies]
+    current = st.session_state.get("duplicate_policy", "allow")
+    try:
+        index = codes.index(current)
+    except ValueError:
+        index = 0
+    choice = st.sidebar.radio("Policy", labels, index=index)
+    st.session_state["duplicate_policy"] = dict(policies)[choice]
+
+    if st.session_state["duplicate_policy"] == "ledger":
+        if st.sidebar.button("Clear this session's ledger entries"):
+            ledger: DuplicateLedger = st.session_state["duplicate_ledger"]
+            ledger.purge_session(st.session_state.get("session_id"))
+            st.sidebar.success("Session ledger entries cleared.")
+    else:
+        st.sidebar.caption("Ledger disabled for the current policy.")
+
+# ---------------------------------------------------------------------------
+# Overlay rendering helpers
+
+def _infer_viewport_bounds(overlays: Sequence[OverlayTrace]) -> Tuple[float, float]:
+    wavelengths: List[float] = []
+    for trace in overlays:
+        wavelengths.extend(trace.wavelength_nm)
+    arr = np.array(wavelengths, dtype=float)
+    arr = arr[np.isfinite(arr)]
+    if arr.size == 0:
+        return 350.0, 900.0
+    return float(arr.min()), float(arr.max())
+
+
+def _filter_viewport(df: pd.DataFrame, viewport: Tuple[float | None, float | None]) -> pd.DataFrame:
+    low, high = viewport
+    if low is not None:
+        df = df[df["wavelength_nm"] >= low]
+    if high is not None:
+        df = df[df["wavelength_nm"] <= high]
+    return df
+
+
+def _convert_wavelength(series: pd.Series, unit: str) -> Tuple[pd.Series, str]:
+    unit = unit or "nm"
+    values = pd.to_numeric(series, errors="coerce")
+    if unit == "Å":
+        return values * 10.0, "Wavelength (Å)"
+    if unit == "µm":
+        return values / 1000.0, "Wavelength (µm)"
+    if unit == "cm^-1":
+        safe = values.replace(0, np.nan)
+        return 1e7 / safe, "Wavenumber (cm⁻¹)"
+    return values, "Wavelength (nm)"
+
+
+def _add_line_trace(fig: go.Figure, df: pd.DataFrame, label: str) -> None:
+    xs: List[float | None] = []
+    ys: List[float | None] = []
+    hover: List[Optional[str]] = []
+    for _, row in df.iterrows():
+        x = row.get("wavelength")
+        y = float(row.get("flux", 0.0))
+        text = row.get("hover")
+        xs.extend([x, x, None])
+        ys.extend([0.0, y, None])
+        hover.extend([text, text, None])
     fig.add_trace(
         go.Scatter(
             x=xs,
             y=ys,
-            mode='lines',
+            mode="lines",
             name=label,
-            hoverinfo='text',
-            hovertext=hover,
-            line=dict(width=2),
+            hovertext=hover if any(hover) else None,
+            hoverinfo="text",
         )
     )
     fig.add_trace(
         go.Scatter(
-            x=trace_df['wavelength'],
-            y=trace_df['flux'],
-            mode='markers',
-            marker=dict(size=6, symbol='line-ns'),
+            x=df["wavelength"],
+            y=df["flux"],
+            mode="markers",
+            marker=dict(size=6, symbol="line-ns"),
             name=f"{label} markers",
-            hoverinfo='text',
-            hovertext=trace_df['hover_text'],
+            hovertext=df.get("hover"),
+            hoverinfo="text",
             showlegend=False,
         )
     )
 
 
-def _build_nist_line_table(data: dict) -> pd.DataFrame:
-    records = []
-    for line in data.get('lines') or []:
+def _build_overlay_figure(
+    overlays: Sequence[OverlayTrace],
+    display_units: str,
+    display_mode: str,
+    normalization_mode: str,
+    viewport: Tuple[float | None, float | None],
+    reference: Optional[OverlayTrace],
+    differential_mode: str,
+    version_tag: str,
+) -> Tuple[go.Figure, str]:
+    fig = go.Figure()
+    axis_title = "Wavelength (nm)"
+    reference_vectors = reference.to_vectors() if reference else None
+
+    for trace in overlays:
+        if not trace.visible:
+            continue
+        df = trace.to_dataframe()
+        df = _filter_viewport(df, viewport)
+        if df.empty:
+            continue
+
+        if (
+            differential_mode == "Relative to reference"
+            and reference_vectors is not None
+            and trace.trace_id != reference_vectors.trace_id
+            and trace.kind != "lines"
+        ):
+            axis, values_trace, values_ref = viewport_alignment(trace.to_vectors(), reference_vectors, viewport)
+            if axis is None or values_trace is None or values_ref is None:
+                continue
+            df = pd.DataFrame({"wavelength_nm": axis, "flux": values_trace - values_ref})
+
+        converted, axis_title = _convert_wavelength(df["wavelength_nm"], display_units)
+        df = df.assign(wavelength=converted, flux=df["flux"].astype(float))
+        if "hover" in df:
+            df["hover"] = df["hover"].astype(str)
+        df = df.dropna(subset=["wavelength", "flux"])
+        if df.empty:
+            continue
+
+        if display_mode != "Flux (raw)":
+            df["flux"] = apply_normalization(df["flux"].to_numpy(dtype=float), "max")
+        elif normalization_mode and normalization_mode != "none" and trace.kind != "lines":
+            df["flux"] = apply_normalization(df["flux"].to_numpy(dtype=float), normalization_mode)
+
+        if trace.kind == "lines":
+            _add_line_trace(fig, df, trace.label)
+        else:
+            fig.add_trace(
+                go.Scatter(
+                    x=df["wavelength"],
+                    y=df["flux"],
+                    mode="lines",
+                    name=trace.label,
+                    hovertext=df.get("hover"),
+                    hoverinfo="text",
+                )
+            )
+
+    fig.update_layout(
+        xaxis_title=axis_title,
+        yaxis_title="Normalized flux" if display_mode != "Flux (raw)" else "Flux",
+        legend=dict(itemclick="toggleothers"),
+        margin=dict(t=50, b=40, l=60, r=20),
+        height=520,
+    )
+    fig.update_layout(
+        annotations=[
+            dict(
+                text=version_tag,
+                xref="paper",
+                yref="paper",
+                x=0.99,
+                y=-0.22,
+                showarrow=False,
+                font=dict(size=12),
+                align="right",
+                opacity=0.7,
+            )
+        ]
+    )
+    return fig, axis_title
+
+
+def _render_overlay_table(overlays: Sequence[OverlayTrace]) -> None:
+    if not overlays:
+        return
+    table = pd.DataFrame(
+        {
+            "Label": [trace.label for trace in overlays],
+            "Provider": [trace.provider or "—" for trace in overlays],
+            "Kind": [trace.kind for trace in overlays],
+            "Points": [trace.points for trace in overlays],
+            "Visible": [trace.visible for trace in overlays],
+        }
+    )
+    edited = st.data_editor(
+        table,
+        hide_index=True,
+        use_container_width=True,
+        column_config={
+            "Label": st.column_config.TextColumn("Label", disabled=True),
+            "Provider": st.column_config.TextColumn("Provider", disabled=True),
+            "Kind": st.column_config.TextColumn("Kind", disabled=True),
+            "Points": st.column_config.NumberColumn("Points", disabled=True),
+            "Visible": st.column_config.CheckboxColumn("Visible"),
+        },
+        key="overlay_table_editor",
+    )
+    for trace, visible in zip(overlays, edited["Visible"].tolist()):
+        trace.visible = bool(visible)
+    _set_overlays(overlays)
+
+    options = [trace.trace_id for trace in overlays]
+    selected = st.multiselect(
+        "Remove overlays",
+        options,
+        format_func=_trace_label,
+        key="overlay_remove_select",
+    )
+    if selected and st.button("Remove selected", key="overlay_remove_button"):
+        _remove_overlays(selected)
+        st.success(f"Removed {len(selected)} overlays.")
+
+
+def _remove_overlays(trace_ids: Sequence[str]) -> None:
+    remaining = [trace for trace in _get_overlays() if trace.trace_id not in set(trace_ids)]
+    _set_overlays(remaining)
+    cache: SimilarityCache = st.session_state["similarity_cache"]
+    cache.reset()
+
+
+def _clear_overlays() -> None:
+    st.session_state["overlay_traces"] = []
+    st.session_state["reference_trace_id"] = None
+    cache: SimilarityCache = st.session_state["similarity_cache"]
+    cache.reset()
+
+
+def _export_current_view(
+    fig: go.Figure,
+    overlays: Sequence[OverlayTrace],
+    display_units: str,
+    display_mode: str,
+    viewport: Tuple[float | None, float | None],
+) -> None:
+    rows: List[Dict[str, object]] = []
+    for trace in overlays:
+        if not trace.visible:
+            continue
+        df = _filter_viewport(trace.to_dataframe(), viewport)
+        if df.empty:
+            continue
+        converted, _ = _convert_wavelength(df["wavelength_nm"], display_units)
+        scaled = df["flux"].to_numpy(dtype=float)
+        if display_mode != "Flux (raw)":
+            scaled = apply_normalization(scaled, "max")
+        for wavelength_value, flux_value in zip(converted, scaled):
+            if not math.isfinite(float(wavelength_value)) or not math.isfinite(float(flux_value)):
+                continue
+            rows.append(
+                {
+                    "series": trace.label,
+                    "wavelength": float(wavelength_value),
+                    "unit": display_units,
+                    "flux": float(flux_value),
+                    "display_mode": display_mode,
+                }
+            )
+    if not rows:
+        st.warning("Nothing to export in the current viewport.")
+        return
+    df_export = pd.DataFrame(rows)
+    timestamp = time.strftime("%Y%m%d-%H%M%S")
+    csv_path = EXPORT_DIR / f"spectra_export_{timestamp}.csv"
+    png_path = EXPORT_DIR / f"spectra_export_{timestamp}.png"
+    manifest_path = EXPORT_DIR / f"spectra_export_{timestamp}.manifest.json"
+    df_export.to_csv(csv_path, index=False)
+    try:
+        fig.write_image(str(png_path))
+    except Exception as exc:
+        st.warning(f"PNG export requires kaleido ({exc}).")
+    manifest = build_manifest(
+        rows,
+        display_units=display_units,
+        display_mode=display_mode,
+        exported_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        viewport={"low_nm": viewport[0], "high_nm": viewport[1]},
+    )
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    st.success(f"Exported: {csv_path.name}, {png_path.name}, {manifest_path.name}")
+
+# ---------------------------------------------------------------------------
+# Line metadata helpers
+
+def _collect_line_overlays(overlays: Sequence[OverlayTrace]) -> List[OverlayTrace]:
+    return [trace for trace in overlays if trace.kind == "lines" and trace.metadata.get("lines")]
+
+
+def _build_line_table(trace: OverlayTrace) -> pd.DataFrame:
+    records: List[Dict[str, object]] = []
+    for line in trace.metadata.get("lines", []) or []:
         records.append(
             {
-                'Wavelength (nm)': line.get('wavelength_nm'),
-                'Observed (nm)': line.get('observed_wavelength_nm'),
-                'Ritz (nm)': line.get('ritz_wavelength_nm'),
-                'Relative intensity': line.get('relative_intensity'),
-                'Normalized intensity': line.get('relative_intensity_normalized'),
-                'Transition prob. (s⁻¹)': line.get('transition_probability_s'),
-                'Oscillator strength': line.get('oscillator_strength'),
-                'Accuracy': line.get('accuracy'),
-                'Lower level': line.get('lower_level'),
-                'Upper level': line.get('upper_level'),
-                'Type': line.get('transition_type'),
-                'TP reference': line.get('transition_probability_reference'),
-                'Line reference': line.get('line_reference'),
+                "Wavelength (nm)": line.get("wavelength_nm"),
+                "Observed (nm)": line.get("observed_wavelength_nm"),
+                "Ritz (nm)": line.get("ritz_wavelength_nm"),
+                "Relative intensity": line.get("relative_intensity"),
+                "Normalised": line.get("relative_intensity_normalized"),
+                "Lower": line.get("lower_level"),
+                "Upper": line.get("upper_level"),
+                "Transition": line.get("transition_type"),
             }
         )
     if not records:
@@ -290,149 +736,279 @@ def _build_nist_line_table(data: dict) -> pd.DataFrame:
     return pd.DataFrame.from_records(records)
 
 
-with tabs[0]:
-    st.header('Overlays')
-    fig = go.Figure()
-    axis_title = 'Wavelength (nm)'
-    rows = []
-    active_nist_overlays: list[dict] = []
+def _render_line_tables(overlays: Sequence[OverlayTrace]) -> None:
+    line_overlays = _collect_line_overlays(overlays)
+    if not line_overlays:
+        return
+    with st.expander("Line metadata tables"):
+        for trace in line_overlays:
+            st.markdown(f"**{trace.label}**")
+            table = _build_line_table(trace)
+            if table.empty:
+                st.info("No line metadata available.")
+            else:
+                st.dataframe(table, use_container_width=True, hide_index=True)
 
+
+# ---------------------------------------------------------------------------
+# Patch log helpers
+
+def _load_patch_note() -> str:
+    path = Path("PATCHLOG.txt")
+    if not path.exists():
+        return ""
     try:
-        if ex_toggle_he:
-            trace_df, axis_title = _prepare_trace('app/examples/He.csv', 'He (example)', display_units, display_mode)
-            fig.add_trace(go.Scatter(x=trace_df['wavelength'], y=trace_df['flux'], mode='lines+markers', name='He (example)'))
-            rows.extend(
-                {
-                    'series': 'He (example)',
-                    'wavelength': float(row['wavelength']),
-                    'unit': display_units,
-                    'flux': float(row['flux']),
-                    'display_mode': display_mode,
-                }
-                for _, row in trace_df.iterrows()
-            )
-        if ex_toggle_ne:
-            trace_df, axis_title = _prepare_trace('app/examples/Ne.csv', 'Ne (example)', display_units, display_mode)
-            fig.add_trace(go.Scatter(x=trace_df['wavelength'], y=trace_df['flux'], mode='lines+markers', name='Ne (example)'))
-            rows.extend(
-                {
-                    'series': 'Ne (example)',
-                    'wavelength': float(row['wavelength']),
-                    'unit': display_units,
-                    'flux': float(row['flux']),
-                    'display_mode': display_mode,
-                }
-                for _, row in trace_df.iterrows()
-            )
-    except Exception as e:
-        st.error(f"Failed to load examples: {e}")
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except Exception:
+        return ""
+    cleaned = [line.strip() for line in lines if line.strip() and not line.startswith("=")]
+    for line in reversed(cleaned):
+        if line.startswith("-"):
+            return line.lstrip("- ")
+    return ""
 
-    for idx, overlay in enumerate(st.session_state.get("nist_overlays", [])):
-        if not overlay.get('visible', True):
-            continue
-        trace_df, axis_override = _prepare_nist_trace(overlay, display_units, display_mode)
-        if trace_df.empty:
-            continue
-        axis_title = axis_override
-        label = overlay.get('meta', {}).get('label', f"NIST overlay {idx + 1}")
-        _add_nist_trace(fig, trace_df, label)
-        for _, row in trace_df.iterrows():
-            wavelength_value = row['wavelength']
-            flux_value = row['flux']
-            try:
-                wavelength_float = float(wavelength_value)
-                flux_float = float(flux_value)
-            except (TypeError, ValueError):
-                continue
-            if math.isnan(wavelength_float) or math.isnan(flux_float):
-                continue
-            rows.append(
-                {
-                    'series': label,
-                    'wavelength': wavelength_float,
-                    'unit': display_units,
-                    'flux': flux_float,
-                    'display_mode': display_mode,
-                }
-            )
-        active_nist_overlays.append(overlay)
 
-    fig.update_layout(
-        xaxis_title=axis_title,
-        yaxis_title='Normalized intensity' if display_mode == 'Flux (normalized)' else 'Flux / Intensity',
-        legend=dict(itemclick='toggleothers')
+def _format_line_hover(line: Dict[str, object]) -> str:
+    parts: List[str] = []
+    wavelength = line.get("wavelength_nm")
+    if isinstance(wavelength, (int, float)) and math.isfinite(wavelength):
+        parts.append(f"λ {wavelength:.4f} nm")
+    ritz = line.get("ritz_wavelength_nm")
+    observed = line.get("observed_wavelength_nm")
+    if isinstance(ritz, (int, float)) and math.isfinite(ritz):
+        parts.append(f"Ritz {ritz:.4f} nm")
+    if isinstance(observed, (int, float)) and math.isfinite(observed):
+        parts.append(f"Observed {observed:.4f} nm")
+    rel = line.get("relative_intensity")
+    if rel is not None:
+        parts.append(f"Rel {rel}")
+    norm = line.get("relative_intensity_normalized")
+    if norm is not None:
+        parts.append(f"Norm {norm:.3f}")
+    lower = line.get("lower_level")
+    upper = line.get("upper_level")
+    if lower or upper:
+        parts.append(f"{lower or '?'} → {upper or '?'}")
+    return " | ".join(parts)
+
+
+def _convert_nist_payload(data: Dict[str, object]) -> Optional[Dict[str, object]]:
+    lines = data.get("lines") or []
+    if not lines:
+        return None
+    meta = data.get("meta") or {}
+    wavelengths: List[float] = []
+    flux: List[float] = []
+    hover: List[str] = []
+    for line in lines:
+        wavelength = line.get("wavelength_nm")
+        if wavelength is None:
+            continue
+        wavelengths.append(float(wavelength))
+        intensity = line.get("relative_intensity_normalized")
+        if intensity is None:
+            intensity = line.get("relative_intensity")
+        if intensity is None:
+            intensity = 1.0
+        flux.append(float(intensity))
+        hover.append(_format_line_hover(line))
+    if not wavelengths:
+        return None
+    provenance = dict(meta)
+    provenance["archive"] = "NIST"
+    payload = {
+        "label": meta.get("label") or "NIST ASD",
+        "wavelength_nm": wavelengths,
+        "flux": flux,
+        "provider": "NIST",
+        "summary": f"{len(wavelengths)} NIST ASD lines",
+        "kind": "lines",
+        "metadata": {
+            "lines": lines,
+            "query": meta.get("query"),
+        },
+        "provenance": provenance,
+        "hover": hover,
+    }
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Status bar
+
+def _render_status_bar(version_info: Dict[str, str], patch_note: str) -> None:
+    overlays = _get_overlays()
+    viewport = st.session_state.get("viewport_nm", (None, None))
+    low, high = viewport
+    low_str = f"{low:.1f} nm" if low is not None else "auto"
+    high_str = f"{high:.1f} nm" if high is not None else "auto"
+    policy_map = {
+        "allow": "duplicates allowed",
+        "skip": "session dedupe",
+        "ledger": "ledger enforced",
+    }
+    policy = policy_map.get(st.session_state.get("duplicate_policy"), "duplicates allowed")
+    reference = _trace_label(st.session_state.get("reference_trace_id")) if overlays else "—"
+    st.markdown(
+        (
+            "<div style='margin-top:1rem;padding:0.6rem 0.8rem;border-top:1px solid #333;font-size:0.85rem;opacity:0.85;'>"
+            f"<strong>{len(overlays)}</strong> overlays • viewport {low_str} – {high_str} • reference: {reference} • {policy}<br/>"
+            f"{version_info.get('version', 'v?')} • {version_info.get('date_utc', '')}<br/>"
+            f"<em>{patch_note}</em>"
+            "</div>"
+        ),
+        unsafe_allow_html=True,
     )
-    # Version watermark annotation for screenshots/PNGs
-    fig.update_layout(annotations=[dict(text=f"{VI['version']}", xref="paper", yref="paper", x=0.99, y=-0.20, showarrow=False, font=dict(size=12), align="right", opacity=0.7)])
+
+
+# ---------------------------------------------------------------------------
+# Main tab renderers
+
+def _render_overlay_tab(version_info: Dict[str, str]) -> None:
+    overlays = _get_overlays()
+    st.header("Overlay workspace")
+    if not overlays:
+        st.info("Load a reference spectrum or fetch from the archive tab to begin.")
+        return
+
+    display_units = st.session_state.get("display_units", "nm")
+    display_mode = st.session_state.get("display_mode", "Flux (raw)")
+    normalization = st.session_state.get("normalization_mode", "unit")
+    differential_mode = st.session_state.get("differential_mode", "Off")
+    viewport = st.session_state.get("viewport_nm", (None, None))
+    reference = next((trace for trace in overlays if trace.trace_id == st.session_state.get("reference_trace_id")), overlays[0])
+
+    fig, axis_title = _build_overlay_figure(
+        overlays,
+        display_units,
+        display_mode,
+        normalization,
+        viewport,
+        reference,
+        differential_mode,
+        version_info.get("version", "v?"),
+    )
     st.plotly_chart(fig, use_container_width=True)
-    st.caption('Legend must have no empty labels.')
 
-    if active_nist_overlays:
-        with st.expander('View NIST line details'):
-            for overlay in active_nist_overlays:
-                meta = overlay.get('meta', {})
-                label = meta.get('label', 'NIST ASD')
-                query = meta.get('query', {})
-                count = len(overlay.get('lines') or [])
-                st.markdown(
-                    f"**{label}** — {count} lines from {query.get('lower_wavelength', '…')} to {query.get('upper_wavelength', '…')} {query.get('wavelength_unit', 'nm')}"
-                )
-                line_table = _build_nist_line_table(overlay)
-                if line_table.empty:
-                    st.info('No line details available for this selection.')
-                else:
-                    st.dataframe(line_table, use_container_width=True, hide_index=True)
+    control_col, action_col = st.columns([3, 1])
+    with control_col:
+        _render_overlay_table(overlays)
+    with action_col:
+        if st.button("Export view", key="export_view"):
+            _export_current_view(fig, overlays, display_units, display_mode, viewport)
+        st.caption(f"Axis: {axis_title}")
 
-    if st.button('Export what I see'):
-        if not rows:
-            st.warning('No traces selected for export.')
-        else:
-            ts = time.strftime('%Y%m%d-%H%M%S')
-            png_path = exports / f'spectra_export_{ts}.png'
-            csv_path = exports / f'spectra_export_{ts}.csv'
-            man_path = exports / f'spectra_export_{ts}.manifest.json'
-            pd.DataFrame(rows).to_csv(csv_path, index=False)
-            # Save PNG
-            try:
-                fig.write_image(str(png_path))
-            except Exception as e:
-                st.warning(f"PNG export requires kaleido. Error: {e}")
-            # Manifest with version stamping
-            manifest = build_manifest(
-                rows,
-                display_units=display_units,
-                display_mode=display_mode,
-                exported_at=time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime()),
-                viewport=None,
-            )
-            man_path.write_text(json.dumps(manifest, indent=2))
-            st.success(f'Exported: {png_path} / {csv_path} / {man_path}')
+    cache: SimilarityCache = st.session_state["similarity_cache"]
+    visible_vectors = [trace.to_vectors() for trace in overlays if trace.visible]
+    options = SimilarityOptions(
+        metrics=tuple(st.session_state.get("similarity_metrics", ["cosine"])),
+        normalization=st.session_state.get("similarity_normalization", normalization),
+        line_match_top_n=int(st.session_state.get("similarity_line_peaks", 8)),
+        primary_metric=st.session_state.get("similarity_primary_metric", "cosine"),
+        reference_id=st.session_state.get("reference_trace_id"),
+    )
+    render_similarity_panel(visible_vectors, viewport, options, cache)
+    _render_line_tables(overlays)
 
-with tabs[1]:
-    st.header('Differential (scaffold)')
-    st.info('Wire your backlight and observed spectra here. This is a placeholder view.')
 
-with tabs[2]:
-    st.header('Docs')
-    page = st.selectbox('Open doc', [
-        'docs/index.md',
-        'docs/ingestion.md',
-        'docs/ui/displaying_data_guide.md',
-        'docs/ui/ui_design_guide.md',
-        'docs/ui/bad_ui_guide.md',
-        'docs/sources/astro_data_docs.md',
-        'docs/sources/telescopes_overview.md',
-        'docs/sources/notable_sources_techniques_tools.md',
-        'docs/sources/stellar_light_methods.md',
-        'docs/math/spectroscopy_math_part1.md',
-        'docs/math/spectroscopy_math_part2.md',
-        'docs/math/instrument_accuracy_errors_interpretation.md',
-        'docs/differential/part1b.md',
-        'docs/differential/part1c.md',
-        'docs/differential/part2.md',
-        'docs/modeling/spectral_modeling_part1a.md',
-    ])
+def _render_differential_tab() -> None:
+    st.header("Differential analysis")
+    overlays = _get_overlays()
+    if len(overlays) < 2:
+        st.info("Add at least two traces to explore differential workflows.")
+    norm = st.session_state.get("normalization_mode", "unit")
+    diff = st.session_state.get("differential_mode", "Off")
+    st.write(f"Normalization mode: **{norm}**")
+    st.write(f"Differential mode: **{diff}**")
+    st.caption("Differential tooling shares normalization controls with the overlay tab.")
+
+
+def _render_archive_tab() -> None:
+    controller = ArchiveUI(add_overlay=_add_overlay_payload)
+    controller.render()
+
+
+def _render_docs_tab() -> None:
+    st.header("Docs & provenance")
+    documents = [
+        "docs/index.md",
+        "docs/ingestion.md",
+        "docs/ui/displaying_data_guide.md",
+        "docs/ui/ui_design_guide.md",
+        "docs/ui/bad_ui_guide.md",
+        "docs/sources/astro_data_docs.md",
+        "docs/sources/telescopes_overview.md",
+        "docs/sources/notable_sources_techniques_tools.md",
+        "docs/sources/stellar_light_methods.md",
+        "docs/math/spectroscopy_math_part1.md",
+        "docs/math/spectroscopy_math_part2.md",
+        "docs/math/instrument_accuracy_errors_interpretation.md",
+        "docs/differential/part1b.md",
+        "docs/differential/part1c.md",
+        "docs/differential/part2.md",
+        "docs/modeling/spectral_modeling_part1a.md",
+    ]
+    selection = st.selectbox("Open doc", documents)
     try:
-        st.code(Path(page).read_text(encoding='utf-8'), language='markdown')
-    except Exception as e:
-        st.error(f"Failed to load doc {page}: {e}")
+        content = Path(selection).read_text(encoding="utf-8")
+    except Exception as exc:
+        st.error(f"Failed to load doc {selection}: {exc}")
+    else:
+        st.code(content, language="markdown")
+
+    overlays = _get_overlays()
+    if overlays:
+        st.subheader("Session provenance")
+        for trace in overlays:
+            with st.expander(trace.label):
+                if trace.summary:
+                    st.write(trace.summary)
+                if trace.provenance:
+                    st.json(trace.provenance)
+                else:
+                    st.caption("No provenance metadata recorded.")
+    else:
+        st.caption("Load overlays to view provenance manifests.")
+
+
+# ---------------------------------------------------------------------------
+# Entry points
+
+def render() -> None:
+    _ensure_session_state()
+    version_info = get_version_info()
+    patch_note = _load_patch_note() or version_info.get("summary") or "No summary recorded."
+
+    st.title("Spectra App")
+    st.caption(f"Build {version_info.get('version', 'v?')} • {version_info.get('date_utc', '')}")
+    st.info(f"Patch: {patch_note}")
+
+    _render_reference_section()
+    st.sidebar.divider()
+    _render_display_section()
+    st.sidebar.divider()
+    _render_differential_section()
+    st.sidebar.divider()
+    _render_similarity_sidebar()
+    st.sidebar.divider()
+    _render_duplicate_sidebar()
+
+    overlay_tab, diff_tab, archive_tab, docs_tab = st.tabs(["Overlay", "Differential", "Archive", "Docs & Provenance"])
+    with overlay_tab:
+        _render_overlay_tab(version_info)
+    with diff_tab:
+        _render_differential_tab()
+    with archive_tab:
+        _render_archive_tab()
+    with docs_tab:
+        _render_docs_tab()
+
+    _render_status_bar(version_info, patch_note)
+
+
+def main() -> None:
+    render()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- refactor the Streamlit UI to provide overlay/differential/archive/docs tabs, extended sidebar controls, and a status bar
- add similarity computation utilities and panel rendering for cosine/RMSE/XCorr/line-match metrics scoped to the viewport
- wire a provider-backed archive controller (MAST/ESO/SDSS/DOI) and record the patch in PATCHLOG

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf361d45dc8329bec600983598e61e