### PR TITLE
Normalize ingestion units and add upload pipeline

### DIFF
--- a/PATCHLOG.txt
+++ b/PATCHLOG.txt
@@ -3,3 +3,4 @@ Spectra App — Patch Log (append-only)
 
 
 - v1.1.5a: Refactored Streamlit UI with overlay/differential/archive tabs, similarity ribbon, and provider-backed archive workflows.
+- v1.1.5b: Normalised ingestion to SI units, added CSV/TXT/FITS upload pipeline with provenance logging, dual-axis overlay plotting, and enriched export manifest/metadata presentation.

--- a/app/export_manifest.py
+++ b/app/export_manifest.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import time
-from typing import Iterable, List, Mapping, MutableMapping
+from typing import Iterable, List, Mapping, MutableMapping, Sequence
 
 from app._version import get_version_info
 from app.continuity import get_continuity_links
@@ -26,6 +26,7 @@ def build_manifest(
     display_mode: str,
     exported_at: str | None = None,
     viewport: MutableMapping[str, object] | None = None,
+    traces: Sequence[Mapping[str, object]] | None = None,
 ) -> dict:
     """Build the export manifest used by the UI."""
 
@@ -33,20 +34,50 @@ def build_manifest(
     continuity = get_continuity_links()
     timestamp = exported_at or time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())
 
+    rows_list = list(rows)
+
+    flux_reference = 'normalized' if display_mode != 'Flux (raw)' else 'W m⁻² m⁻¹'
+
     manifest = {
         'exported_at': timestamp,
         'viewport': viewport,
         'series': [],
-        'global_units': {'wavelength': display_units, 'intensity_mode': display_mode},
+        'traces': [],
+        'global_units': {
+            'wavelength': display_units,
+            'intensity_mode': display_mode,
+            'flux_reference': flux_reference,
+        },
         'software': {'name': 'spectra-app', 'version': vi['version'], 'built_utc': vi['date_utc']},
         'notes': vi['summary'],
         'continuity': continuity,
+        'transformations': {
+            'display_mode': display_mode,
+            'wavelength_units': display_units,
+            'rows_exported': len(rows_list),
+        },
     }
 
-    rows_list = list(rows)
     for label in _unique_series(rows_list):
         count = sum(1 for row in rows_list if str(row.get('series', '')) == label)
         manifest['series'].append({'label': label, 'points': count})
+
+    if traces:
+        for trace in traces:
+            manifest['traces'].append(
+                {
+                    'label': trace.get('label'),
+                    'provider': trace.get('provider'),
+                    'kind': trace.get('kind'),
+                    'points': trace.get('points'),
+                    'axis': trace.get('axis'),
+                    'flux_unit': trace.get('flux_unit'),
+                    'flux_kind': trace.get('flux_kind'),
+                    'metadata': trace.get('metadata'),
+                    'provenance': trace.get('provenance'),
+                    'mirrored': trace.get('mirrored', False),
+                }
+            )
 
     return manifest
 

--- a/app/server/ingestion_pipeline.py
+++ b/app/server/ingestion_pipeline.py
@@ -1,0 +1,373 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import re
+from dataclasses import dataclass, field
+from typing import Dict, List, Mapping, Optional, Sequence, Tuple
+
+import numpy as np
+import pandas as pd
+from astropy.io import fits
+
+from app.utils.units import (
+    ConversionLog,
+    convert_uncertainty,
+    convert_wavelength_for_display,
+    detect_flux_unit,
+    detect_wavelength_unit,
+    flux_to_f_lambda,
+    infer_axis_assignment,
+    wavelength_to_m,
+)
+
+
+def _convert_air_to_vacuum(wavelength_m: np.ndarray, log: ConversionLog) -> np.ndarray:
+    lam_a = wavelength_m * 1e10
+    sigma2 = (1e4 / np.where(lam_a != 0, lam_a, np.nan)) ** 2
+    n = 1 + 0.0000834254 + 0.02406147 / (130 - sigma2) + 0.00015998 / (38.9 - sigma2)
+    log.add(
+        "wavelength_medium",
+        original_unit="air",
+        target_unit="vacuum",
+        formula="λ_vac = λ_air × n(λ)",
+    )
+    return wavelength_m * n
+
+
+def _maybe_air_to_vacuum_metadata(
+    wavelength_m: np.ndarray,
+    metadata: Mapping[str, object],
+    log: ConversionLog,
+) -> np.ndarray:
+    medium = str(metadata.get("wavelength_medium") or metadata.get("medium") or "").lower()
+    if "air" in medium:
+        return _convert_air_to_vacuum(wavelength_m, log)
+    return wavelength_m
+
+
+@dataclass
+class SpectrumSegment:
+    """Canonical internal representation of an ingested spectral segment."""
+
+    label: str
+    wavelength_m: np.ndarray
+    flux: np.ndarray
+    flux_unit: str
+    flux_kind: str
+    uncertainty: Optional[np.ndarray] = None
+    metadata: Dict[str, object] = field(default_factory=dict)
+    provenance: List[Dict[str, object]] = field(default_factory=list)
+    provider: Optional[str] = None
+
+    def as_payload(self) -> Dict[str, object]:
+        wavelength_nm = self.wavelength_m * 1e9
+        payload = {
+            "label": self.label,
+            "wavelength_m": self.wavelength_m.tolist(),
+            "wavelength_nm": wavelength_nm.tolist(),
+            "flux": self.flux.tolist(),
+            "flux_unit": self.flux_unit,
+            "flux_kind": self.flux_kind,
+            "uncertainty": self.uncertainty.tolist() if self.uncertainty is not None else None,
+            "metadata": dict(self.metadata),
+            "provenance": list(self.provenance),
+        }
+        if self.provider:
+            payload["provider"] = self.provider
+        return payload
+
+
+def checksum_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _parse_header_metadata(lines: Sequence[str]) -> Dict[str, object]:
+    metadata: Dict[str, object] = {}
+    for raw in lines:
+        line = raw.strip().lstrip("#; ")
+        if not line:
+            continue
+        if ":" in line:
+            key, value = line.split(":", 1)
+        elif "=" in line:
+            key, value = line.split("=", 1)
+        else:
+            continue
+        metadata[key.strip()] = value.strip()
+    return metadata
+
+
+def _find_numeric_start(lines: Sequence[str]) -> int:
+    for idx, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        tokens = [token for token in re.split(r"[\s,;|]+", stripped) if token]
+        numeric_tokens = 0
+        for token in tokens[:3]:
+            try:
+                float(token)
+            except ValueError:
+                break
+            else:
+                numeric_tokens += 1
+        if numeric_tokens >= 2:
+            return idx
+    return 0
+
+
+def _decode_text_bytes(data: bytes) -> Tuple[List[str], str]:
+    text = data.decode("utf-8", errors="ignore")
+    lines = text.splitlines()
+    return lines, text
+
+
+def _resolve_column(columns: Sequence[str], fallback_index: int) -> Tuple[str, Optional[str]]:
+    if not columns:
+        return str(fallback_index), None
+    for column in columns:
+        lower = column.lower()
+        if any(key in lower for key in ("wave", "lambda", "wl")):
+            return column, detect_wavelength_unit(column)
+    column = columns[min(fallback_index, len(columns) - 1)]
+    return column, detect_wavelength_unit(column)
+
+
+def _resolve_flux_column(columns: Sequence[str]) -> Tuple[str, Optional[str]]:
+    if not columns:
+        return "flux", None
+    for column in columns:
+        lower = column.lower()
+        if any(key in lower for key in ("flux", "intensity", "fnu", "flam", "counts", "adu", "transmission")):
+            return column, detect_flux_unit(column)
+    column = columns[1 if len(columns) > 1 else 0]
+    return column, detect_flux_unit(column)
+
+
+def _resolve_uncertainty_column(columns: Sequence[str]) -> Optional[Tuple[str, Optional[str]]]:
+    for column in columns:
+        lower = column.lower()
+        if any(key in lower for key in ("err", "sigma", "unc", "std")):
+            return column, detect_flux_unit(column)
+    return None
+
+
+def ingest_ascii_bytes(name: str, data: bytes) -> Tuple[List[SpectrumSegment], Dict[str, object]]:
+    lines, text = _decode_text_bytes(data)
+    start = _find_numeric_start(lines)
+    header_lines = lines[:start]
+    metadata = _parse_header_metadata(header_lines)
+    stream = io.StringIO("\n".join(lines[start:]))
+
+    try:
+        df = pd.read_csv(stream, comment="#", sep=None, engine="python")
+    except Exception:
+        stream.seek(0)
+        df = pd.read_csv(stream, comment="#", sep=",", engine="python")
+
+    df = df.dropna(axis=0, how="all")
+    if df.empty or df.shape[1] < 2:
+        raise ValueError("ASCII/CSV file must contain at least two columns (wavelength, flux).")
+
+    if any(not isinstance(col, str) for col in df.columns):
+        df.columns = [str(col) for col in df.columns]
+
+    wavelength_column, wave_unit_hint = _resolve_column(df.columns.tolist(), 0)
+    flux_column, flux_unit_hint = _resolve_flux_column(df.columns.tolist())
+    unc_column = _resolve_uncertainty_column(df.columns.tolist())
+
+    log = ConversionLog()
+    wave_unit = metadata.get("wavelength_unit") or wave_unit_hint or "nm"
+    wavelength_m = wavelength_to_m(df[wavelength_column].to_numpy(), wave_unit, log)
+    wavelength_m = _maybe_air_to_vacuum_metadata(wavelength_m, metadata, log)
+
+    flux_unit = metadata.get("flux_unit") or flux_unit_hint
+    flux_si, flux_si_unit, flux_kind = flux_to_f_lambda(
+        df[flux_column].to_numpy(),
+        wavelength_m,
+        flux_unit,
+        log,
+    )
+
+    uncertainty = None
+    uncertainty_unit = None
+    if unc_column is not None:
+        column, uncert_unit = unc_column
+        uncertainty_unit = uncert_unit or flux_unit
+        uncertainty = convert_uncertainty(df[column].to_numpy(), wavelength_m, uncertainty_unit, flux_kind, log)
+
+    medium_value = metadata.get("wavelength_medium") or metadata.get("medium")
+
+    metadata_out = {
+        **metadata,
+        "filename": name,
+        "points": int(len(df)),
+        "wavelength_unit_input": wave_unit,
+        "flux_unit_input": flux_unit,
+        "flux_unit_si": flux_si_unit,
+        "wavelength_range_nm": [float(np.nanmin(wavelength_m) * 1e9), float(np.nanmax(wavelength_m) * 1e9)],
+        "flux_kind": flux_kind,
+    }
+    if medium_value:
+        metadata_out.setdefault("wavelength_medium_input", medium_value)
+    metadata_out["wavelength_medium_internal"] = "vacuum"
+    if uncertainty_unit:
+        metadata_out["uncertainty_unit_input"] = uncertainty_unit
+
+    finite = wavelength_m[np.isfinite(wavelength_m)]
+    if finite.size > 1:
+        diffs = np.diff(np.sort(finite))
+        diffs = diffs[diffs > 0]
+        if diffs.size > 0:
+            r_native = float(np.median(finite[1:] / diffs))
+            metadata_out["resolution_native"] = r_native
+
+    axis = infer_axis_assignment(flux_si, flux_kind)
+
+    segment = SpectrumSegment(
+        label=name,
+        wavelength_m=wavelength_m,
+        flux=flux_si,
+        flux_unit=flux_si_unit,
+        flux_kind=flux_kind,
+        uncertainty=uncertainty,
+        metadata={**metadata_out, "axis": axis},
+        provenance=log.to_records(),
+    )
+    return [segment], metadata_out
+
+
+def _extract_fits_metadata(header) -> Dict[str, object]:
+    fields = {}
+    for key in ("TELESCOP", "INSTRUME", "OBSERVER", "OBJECT", "DATE-OBS", "BUNIT", "SPECSYS", "CTYPE1", "CUNIT1"):
+        if key in header:
+            fields[key.lower()] = header[key]
+    return fields
+
+
+def _ensure_1d(array: np.ndarray) -> np.ndarray:
+    if array.ndim == 1:
+        return array
+    if array.ndim == 0:
+        return array.reshape(1)
+    squeezed = np.squeeze(array)
+    if squeezed.ndim != 1:
+        raise ValueError("FITS data must be one-dimensional for spectral ingestion.")
+    return squeezed
+
+
+def _compute_wavelength_axis(header, size: int) -> Tuple[np.ndarray, str]:
+    crval1 = header.get("CRVAL1")
+    cdelt1 = header.get("CDELT1") or header.get("CD1_1")
+    crpix1 = header.get("CRPIX1", 1.0)
+    if crval1 is None or cdelt1 is None:
+        raise ValueError("FITS header missing CRVAL1/CDELT1 for spectral axis.")
+    try:
+        crval1 = float(crval1)
+        cdelt1 = float(cdelt1)
+        crpix1 = float(crpix1)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Invalid WCS keywords in FITS header.") from exc
+
+    pix = np.arange(size, dtype=float)
+    wavelength = crval1 + (pix - (crpix1 - 1.0)) * cdelt1
+    unit = header.get("CUNIT1") or header.get("XUNIT") or "nm"
+    return wavelength, unit
+
+
+def _maybe_air_to_vacuum(wavelength_m: np.ndarray, header, log: ConversionLog) -> np.ndarray:
+    medium = str(header.get("SPECSYS", "")).lower()
+    ctype = str(header.get("CTYPE1", "")).lower()
+    air_flag = "air" in medium or "wave-air" in ctype
+    if not air_flag:
+        return wavelength_m
+    return _convert_air_to_vacuum(wavelength_m, log)
+
+
+def ingest_fits_bytes(name: str, data: bytes) -> Tuple[List[SpectrumSegment], Dict[str, object]]:
+    segments: List[SpectrumSegment] = []
+    metadata_out: Dict[str, object] = {"filename": name}
+
+    with fits.open(io.BytesIO(data)) as hdul:
+        for index, hdu in enumerate(hdul):
+            if not hasattr(hdu, "data") or hdu.data is None:
+                continue
+            try:
+                flux = np.asarray(_ensure_1d(np.ma.getdata(hdu.data)), dtype=float)
+            except ValueError:
+                continue
+            if flux.size == 0:
+                continue
+            header = hdu.header
+            metadata_out.update(_extract_fits_metadata(header))
+
+            log = ConversionLog()
+            wavelength_axis, wavelength_unit = _compute_wavelength_axis(header, flux.size)
+            wavelength_m = wavelength_to_m(wavelength_axis, wavelength_unit, log)
+            wavelength_m = _maybe_air_to_vacuum(wavelength_m, header, log)
+
+            flux_unit = header.get("BUNIT")
+            flux_si, flux_si_unit, flux_kind = flux_to_f_lambda(flux, wavelength_m, flux_unit, log)
+
+            uncertainty = None
+            if "ERRS" in hdul:
+                err_hdu = hdul["ERRS"]
+                try:
+                    uncertainty = np.asarray(_ensure_1d(np.ma.getdata(err_hdu.data)), dtype=float)
+                except ValueError:
+                    uncertainty = None
+            uncertainty = convert_uncertainty(uncertainty, wavelength_m, flux_unit, flux_kind, log)
+
+            meta_segment = {
+                "filename": name,
+                "hdu_index": index,
+                "wavelength_unit_input": wavelength_unit,
+                "flux_unit_input": flux_unit,
+                "flux_unit_si": flux_si_unit,
+                "points": int(flux.size),
+                "axis": infer_axis_assignment(flux_si, flux_kind),
+                "flux_kind": flux_kind,
+                "wavelength_medium_internal": "vacuum",
+                "wavelength_range_nm": [
+                    float(np.nanmin(wavelength_m) * 1e9),
+                    float(np.nanmax(wavelength_m) * 1e9),
+                ],
+            }
+            finite = wavelength_m[np.isfinite(wavelength_m)]
+            if finite.size > 1:
+                diffs = np.diff(np.sort(finite))
+                diffs = diffs[diffs > 0]
+                if diffs.size > 0:
+                    meta_segment["resolution_native"] = float(np.median(finite[1:] / diffs))
+            meta_segment.update(_extract_fits_metadata(header))
+
+            segment = SpectrumSegment(
+                label=f"{name} [HDU {index}]",
+                wavelength_m=wavelength_m,
+                flux=flux_si,
+                flux_unit=flux_si_unit,
+                flux_kind=flux_kind,
+                uncertainty=uncertainty,
+                metadata=meta_segment,
+                provenance=log.to_records(),
+            )
+            segments.append(segment)
+
+    if not segments:
+        raise ValueError("No spectral segments found in FITS file.")
+
+    return segments, metadata_out
+
+
+def convert_for_display(segment: SpectrumSegment, display_unit: str) -> Tuple[np.ndarray, str]:
+    return convert_wavelength_for_display(segment.wavelength_m, display_unit)
+
+
+__all__ = [
+    "SpectrumSegment",
+    "checksum_bytes",
+    "ingest_ascii_bytes",
+    "ingest_fits_bytes",
+    "convert_for_display",
+]

--- a/app/ui/main.py
+++ b/app/ui/main.py
@@ -13,11 +13,18 @@ import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
 import streamlit as st
+from plotly.subplots import make_subplots
 
 from app._version import get_version_info
 from app.archive_ui import ArchiveUI
 from app.export_manifest import build_manifest
 from app.server.fetch_archives import FetchError, fetch_spectrum
+from app.server.ingestion_pipeline import (
+    SpectrumSegment,
+    checksum_bytes,
+    ingest_ascii_bytes,
+    ingest_fits_bytes,
+)
 from app.similarity import (
     SimilarityCache,
     SimilarityOptions,
@@ -27,6 +34,13 @@ from app.similarity import (
 )
 from app.similarity_panel import render_similarity_panel
 from app.utils.duplicate_ledger import DuplicateLedger
+from app.utils.units import (
+    convert_wavelength_for_display,
+    flux_to_f_lambda,
+    format_flux_unit,
+    infer_axis_assignment,
+    wavelength_to_m,
+)
 
 st.set_page_config(page_title="Spectra App", layout="wide")
 
@@ -38,22 +52,30 @@ EXPORT_DIR.mkdir(parents=True, exist_ok=True)
 class OverlayTrace:
     trace_id: str
     label: str
-    wavelength_nm: Tuple[float, ...]
+    wavelength_m: Tuple[float, ...]
     flux: Tuple[float, ...]
+    flux_unit: str
+    flux_kind: str
     kind: str = "spectrum"
     provider: Optional[str] = None
     summary: Optional[str] = None
     visible: bool = True
     metadata: Dict[str, object] = field(default_factory=dict)
-    provenance: Dict[str, object] = field(default_factory=dict)
+    provenance: List[Dict[str, object]] = field(default_factory=list)
     fingerprint: str = ""
     hover: Optional[Tuple[str, ...]] = None
+    uncertainty: Optional[Tuple[float, ...]] = None
+    axis: str = "emission"
 
     def to_dataframe(self) -> pd.DataFrame:
+        arr_m = np.asarray(self.wavelength_m, dtype=float)
         data: Dict[str, Iterable[object]] = {
-            "wavelength_nm": self.wavelength_nm,
-            "flux": self.flux,
+            "wavelength_m": arr_m,
+            "wavelength_nm": arr_m * 1e9,
+            "flux": np.asarray(self.flux, dtype=float),
         }
+        if self.uncertainty is not None:
+            data["uncertainty"] = np.asarray(self.uncertainty, dtype=float)
         if self.hover:
             data["hover"] = list(self.hover)
         df = pd.DataFrame(data)
@@ -74,7 +96,7 @@ class OverlayTrace:
 
     @property
     def points(self) -> int:
-        return len(self.wavelength_nm)
+        return len(self.wavelength_m)
 
 
 # ---------------------------------------------------------------------------
@@ -95,6 +117,7 @@ def _ensure_session_state() -> None:
     st.session_state.setdefault("similarity_line_peaks", 8)
     st.session_state.setdefault("similarity_normalization", st.session_state.get("normalization_mode", "unit"))
     st.session_state.setdefault("duplicate_policy", "allow")
+    st.session_state.setdefault("uploaded_hashes", set())
     if "duplicate_ledger" not in st.session_state:
         st.session_state["duplicate_ledger"] = DuplicateLedger()
     if "similarity_cache" not in st.session_state:
@@ -133,7 +156,7 @@ def _trace_label(trace_id: Optional[str]) -> str:
 
 def _compute_fingerprint(wavelengths: Sequence[float], flux: Sequence[float]) -> str:
     payload = {
-        "wavelength_nm": [round(float(w), 6) for w in wavelengths],
+        "wavelength_m": [round(float(w), 12) for w in wavelengths],
         "flux": [round(float(f), 6) for f in flux],
     }
     encoded = json.dumps(payload, sort_keys=True).encode("utf-8")
@@ -142,23 +165,34 @@ def _compute_fingerprint(wavelengths: Sequence[float], flux: Sequence[float]) ->
 
 def _add_overlay(
     label: str,
-    wavelengths: Sequence[float],
+    wavelengths_m: Sequence[float],
     flux: Sequence[float],
     *,
+    flux_unit: str = "W m⁻² m⁻¹",
+    flux_kind: str = "F_lambda",
     kind: str = "spectrum",
     provider: Optional[str] = None,
     summary: Optional[str] = None,
     metadata: Optional[Dict[str, object]] = None,
-    provenance: Optional[Dict[str, object]] = None,
+    provenance: Optional[Iterable[Dict[str, object]] | Dict[str, object]] = None,
     hover: Optional[Sequence[str]] = None,
+    uncertainty: Optional[Sequence[float]] = None,
+    axis: Optional[str] = None,
 ) -> Tuple[bool, str]:
     try:
-        values_w = [float(v) for v in wavelengths]
+        values_w = [float(v) for v in wavelengths_m]
         values_f = [float(v) for v in flux]
     except (TypeError, ValueError):
         return False, "Unable to coerce spectral data to floats."
     if not values_w or not values_f or len(values_w) != len(values_f):
         return False, "No spectral samples available."
+
+    values_uncert: Optional[Tuple[float, ...]] = None
+    if uncertainty is not None:
+        try:
+            values_uncert = tuple(float(v) for v in uncertainty)
+        except (TypeError, ValueError):
+            values_uncert = None
 
     overlays = _get_overlays()
     fingerprint = _compute_fingerprint(values_w, values_f)
@@ -172,18 +206,46 @@ def _add_overlay(
             if ledger.seen(fingerprint):
                 return False, f"Trace already recorded in ledger: {label}"
 
+    meta = dict(metadata or {})
+    if "flux_unit_display" not in meta:
+        meta["flux_unit_display"] = format_flux_unit(flux_unit)
+    meta.setdefault("wavelength_unit_internal", "m")
+
+    if isinstance(provenance, dict):
+        provenance_records = [
+            {
+                "stage": "legacy",
+                "details": dict(provenance),
+            }
+        ]
+    elif provenance is None:
+        provenance_records = []
+    else:
+        provenance_records = [dict(event) for event in provenance]
+
+    axis_choice = axis or str(meta.get("axis") or "")
+    axis_choice = axis_choice.lower()
+    if axis_choice not in {"emission", "absorption"}:
+        axis_choice = infer_axis_assignment(values_f, flux_kind)
+
+    meta["axis"] = axis_choice
+
     trace = OverlayTrace(
         trace_id=str(uuid.uuid4()),
         label=label,
-        wavelength_nm=tuple(values_w),
+        wavelength_m=tuple(values_w),
         flux=tuple(values_f),
+        flux_unit=format_flux_unit(flux_unit),
+        flux_kind=flux_kind,
         kind=kind,
         provider=provider,
         summary=summary,
-        metadata=dict(metadata or {}),
-        provenance=dict(provenance or {}),
+        metadata=meta,
+        provenance=provenance_records,
         fingerprint=fingerprint,
         hover=tuple(str(text) for text in (hover or [])) if hover else None,
+        uncertainty=values_uncert,
+        axis=axis_choice,
     )
     overlays.append(trace)
     _set_overlays(overlays)
@@ -210,16 +272,28 @@ def _add_overlay(
 
 
 def _add_overlay_payload(payload: Dict[str, object]) -> Tuple[bool, str]:
+    wavelengths_m = payload.get("wavelength_m")
+    if not wavelengths_m and payload.get("wavelength_nm"):
+        wavelengths_m = wavelength_to_m(payload.get("wavelength_nm") or [], "nm")
+    flux_unit = str(payload.get("flux_unit") or "W m⁻² m⁻¹")
+    flux_kind = str(payload.get("flux_kind") or "F_lambda")
+    uncertainty = payload.get("uncertainty")
+    meta = payload.get("metadata") or {}
+    axis = payload.get("axis") or meta.get("axis")
     return _add_overlay(
         str(payload.get("label") or "Trace"),
-        payload.get("wavelength_nm") or [],
+        wavelengths_m or [],
         payload.get("flux") or [],
+        flux_unit=flux_unit,
+        flux_kind=flux_kind,
         kind=str(payload.get("kind") or "spectrum"),
         provider=payload.get("provider"),
         summary=payload.get("summary"),
-        metadata=payload.get("metadata"),
+        metadata=meta,
         provenance=payload.get("provenance"),
         hover=payload.get("hover"),
+        uncertainty=uncertainty,
+        axis=axis,
     )
 
 
@@ -233,12 +307,33 @@ def _add_example_trace(example: str, label: str) -> Tuple[bool, str]:
         return False, f"Failed to load example {example}: {exc}"
     if "wavelength_nm" not in df or "intensity" not in df:
         return False, f"Example {example} missing required columns."
-    metadata = {"source": "example", "path": str(csv_path)}
-    provenance = {"source": "example", "file": str(csv_path)}
+    wavelength_m = wavelength_to_m(df["wavelength_nm"].to_numpy(dtype=float), "nm")
+    flux_si, flux_unit, flux_kind = flux_to_f_lambda(
+        df["intensity"].to_numpy(dtype=float),
+        wavelength_m,
+        "W/m^2/nm",
+    )
+    metadata = {
+        "source": "example",
+        "path": str(csv_path),
+        "wavelength_unit_input": "nm",
+        "flux_unit_input": "W/m^2/nm",
+        "axis": infer_axis_assignment(flux_si, flux_kind),
+    }
+    provenance = [
+        {
+            "stage": "example_conversion",
+            "from": "W m⁻² nm⁻¹",
+            "to": flux_unit,
+            "formula": "Assumed built-in examples are provided per nm",
+        }
+    ]
     return _add_overlay(
         label,
-        df["wavelength_nm"].tolist(),
-        df["intensity"].tolist(),
+        wavelength_m,
+        flux_si,
+        flux_unit=flux_unit,
+        flux_kind=flux_kind,
         provider="EXAMPLE",
         summary="Built-in example trace",
         metadata=metadata,
@@ -448,10 +543,53 @@ def _render_duplicate_sidebar() -> None:
 # ---------------------------------------------------------------------------
 # Overlay rendering helpers
 
+
+def _render_upload_panel() -> None:
+    st.subheader("Upload spectra")
+    uploaded = st.file_uploader(
+        "Add spectra files (CSV/TXT/FITS)",
+        accept_multiple_files=True,
+        type=["csv", "txt", "fits"],
+    )
+    if not uploaded:
+        return
+
+    seen: set[str] = st.session_state.setdefault("uploaded_hashes", set())
+    for file in uploaded:
+        content = file.getvalue()
+        digest = checksum_bytes(content)
+        if digest in seen:
+            st.info(f"{file.name}: duplicate upload skipped.")
+            continue
+        try:
+            if file.name.lower().endswith(".fits"):
+                segments, meta = ingest_fits_bytes(file.name, content)
+            else:
+                segments, meta = ingest_ascii_bytes(file.name, content)
+        except Exception as exc:
+            st.error(f"Failed to ingest {file.name}: {exc}")
+            continue
+
+        for idx, segment in enumerate(segments, start=1):
+            payload = segment.as_payload()
+            metadata = payload.get("metadata") or {}
+            metadata.update({
+                "upload_digest": digest,
+                "upload_file": file.name,
+            })
+            payload["metadata"] = metadata
+            added, message = _add_overlay_payload(payload)
+            if added:
+                st.success(f"{file.name} segment {idx}: {message}")
+            else:
+                st.warning(f"{file.name} segment {idx}: {message}")
+        seen.add(digest)
+    st.session_state["uploaded_hashes"] = seen
+
 def _infer_viewport_bounds(overlays: Sequence[OverlayTrace]) -> Tuple[float, float]:
     wavelengths: List[float] = []
     for trace in overlays:
-        wavelengths.extend(trace.wavelength_nm)
+        wavelengths.extend(float(w) * 1e9 for w in trace.wavelength_m)
     arr = np.array(wavelengths, dtype=float)
     arr = arr[np.isfinite(arr)]
     if arr.size == 0:
@@ -471,17 +609,11 @@ def _filter_viewport(df: pd.DataFrame, viewport: Tuple[float | None, float | Non
 def _convert_wavelength(series: pd.Series, unit: str) -> Tuple[pd.Series, str]:
     unit = unit or "nm"
     values = pd.to_numeric(series, errors="coerce")
-    if unit == "Å":
-        return values * 10.0, "Wavelength (Å)"
-    if unit == "µm":
-        return values / 1000.0, "Wavelength (µm)"
-    if unit == "cm^-1":
-        safe = values.replace(0, np.nan)
-        return 1e7 / safe, "Wavenumber (cm⁻¹)"
-    return values, "Wavelength (nm)"
+    converted, axis_title = convert_wavelength_for_display(values.to_numpy(dtype=float), unit)
+    return pd.Series(converted, index=series.index), axis_title
 
 
-def _add_line_trace(fig: go.Figure, df: pd.DataFrame, label: str) -> None:
+def _add_line_trace(fig: go.Figure, df: pd.DataFrame, label: str, *, secondary_y: bool = False) -> None:
     xs: List[float | None] = []
     ys: List[float | None] = []
     hover: List[Optional[str]] = []
@@ -500,7 +632,8 @@ def _add_line_trace(fig: go.Figure, df: pd.DataFrame, label: str) -> None:
             name=label,
             hovertext=hover if any(hover) else None,
             hoverinfo="text",
-        )
+        ),
+        secondary_y=secondary_y,
     )
     fig.add_trace(
         go.Scatter(
@@ -512,7 +645,8 @@ def _add_line_trace(fig: go.Figure, df: pd.DataFrame, label: str) -> None:
             hovertext=df.get("hover"),
             hoverinfo="text",
             showlegend=False,
-        )
+        ),
+        secondary_y=secondary_y,
     )
 
 
@@ -526,8 +660,10 @@ def _build_overlay_figure(
     differential_mode: str,
     version_tag: str,
 ) -> Tuple[go.Figure, str]:
-    fig = go.Figure()
+    fig = make_subplots(specs=[[{"secondary_y": True}]])
     axis_title = "Wavelength (nm)"
+    emission_units: set[str] = set()
+    absorption_units: set[str] = set()
     reference_vectors = reference.to_vectors() if reference else None
 
     for trace in overlays:
@@ -544,12 +680,21 @@ def _build_overlay_figure(
             and trace.trace_id != reference_vectors.trace_id
             and trace.kind != "lines"
         ):
-            axis, values_trace, values_ref = viewport_alignment(trace.to_vectors(), reference_vectors, viewport)
-            if axis is None or values_trace is None or values_ref is None:
+            axis_nm, values_trace, values_ref = viewport_alignment(
+                trace.to_vectors(), reference_vectors, viewport
+            )
+            if axis_nm is None or values_trace is None or values_ref is None:
                 continue
-            df = pd.DataFrame({"wavelength_nm": axis, "flux": values_trace - values_ref})
+            axis_m = wavelength_to_m(axis_nm, "nm")
+            df = pd.DataFrame(
+                {
+                    "wavelength_m": axis_m,
+                    "wavelength_nm": axis_nm,
+                    "flux": values_trace - values_ref,
+                }
+            )
 
-        converted, axis_title = _convert_wavelength(df["wavelength_nm"], display_units)
+        converted, axis_title = _convert_wavelength(df["wavelength_m"], display_units)
         df = df.assign(wavelength=converted, flux=df["flux"].astype(float))
         if "hover" in df:
             df["hover"] = df["hover"].astype(str)
@@ -557,28 +702,64 @@ def _build_overlay_figure(
         if df.empty:
             continue
 
+        y_values = df["flux"].to_numpy(dtype=float)
+        mirrored = False
+        if trace.axis == "absorption":
+            finite = y_values[np.isfinite(y_values)]
+            if finite.size and np.mean(finite < 0) > 0.5:
+                y_values = -y_values
+                mirrored = True
         if display_mode != "Flux (raw)":
-            df["flux"] = apply_normalization(df["flux"].to_numpy(dtype=float), "max")
+            y_values = apply_normalization(y_values, "max")
         elif normalization_mode and normalization_mode != "none" and trace.kind != "lines":
-            df["flux"] = apply_normalization(df["flux"].to_numpy(dtype=float), normalization_mode)
+            y_values = apply_normalization(y_values, normalization_mode)
+
+        df_plot = df.copy()
+        df_plot["flux"] = y_values
+        secondary = trace.axis == "absorption"
+        if secondary:
+            absorption_units.add(trace.flux_unit)
+            if mirrored:
+                trace.metadata["absorption_mirrored"] = True
+        else:
+            emission_units.add(trace.flux_unit)
 
         if trace.kind == "lines":
-            _add_line_trace(fig, df, trace.label)
+            _add_line_trace(fig, df_plot, trace.label, secondary_y=secondary)
         else:
             fig.add_trace(
                 go.Scatter(
-                    x=df["wavelength"],
-                    y=df["flux"],
+                    x=df_plot["wavelength"],
+                    y=df_plot["flux"],
                     mode="lines",
                     name=trace.label,
-                    hovertext=df.get("hover"),
+                    hovertext=df_plot.get("hover"),
                     hoverinfo="text",
-                )
+                ),
+                secondary_y=secondary,
             )
+
+    if display_mode != "Flux (raw)":
+        left_title = "Normalized flux"
+        right_title = "Normalized absorption"
+    else:
+        left_title = "Flux"
+        if emission_units:
+            if len(emission_units) == 1:
+                left_title = f"Flux ({next(iter(emission_units))})"
+            else:
+                left_title = "Flux (mixed units)"
+        right_title = "Absorption"
+        if absorption_units:
+            if len(absorption_units) == 1:
+                right_title = f"Absorption ({next(iter(absorption_units))})"
+            else:
+                right_title = "Absorption (mixed units)"
+        else:
+            right_title = ""
 
     fig.update_layout(
         xaxis_title=axis_title,
-        yaxis_title="Normalized flux" if display_mode != "Flux (raw)" else "Flux",
         legend=dict(itemclick="toggleothers"),
         margin=dict(t=50, b=40, l=60, r=20),
         height=520,
@@ -598,6 +779,8 @@ def _build_overlay_figure(
             )
         ]
     )
+    fig.update_yaxes(title_text=left_title, secondary_y=False)
+    fig.update_yaxes(title_text=right_title, secondary_y=True, showticklabels=bool(absorption_units))
     return fig, axis_title
 
 
@@ -611,6 +794,8 @@ def _render_overlay_table(overlays: Sequence[OverlayTrace]) -> None:
             "Kind": [trace.kind for trace in overlays],
             "Points": [trace.points for trace in overlays],
             "Visible": [trace.visible for trace in overlays],
+            "Axis": [trace.axis for trace in overlays],
+            "Flux unit": [trace.flux_unit for trace in overlays],
         }
     )
     edited = st.data_editor(
@@ -623,11 +808,25 @@ def _render_overlay_table(overlays: Sequence[OverlayTrace]) -> None:
             "Kind": st.column_config.TextColumn("Kind", disabled=True),
             "Points": st.column_config.NumberColumn("Points", disabled=True),
             "Visible": st.column_config.CheckboxColumn("Visible"),
+            "Axis": st.column_config.SelectboxColumn(
+                "Axis",
+                options=["emission", "absorption"],
+            ),
+            "Flux unit": st.column_config.TextColumn("Flux unit", disabled=True),
         },
         key="overlay_table_editor",
     )
-    for trace, visible in zip(overlays, edited["Visible"].tolist()):
+    for trace, visible, axis in zip(
+        overlays,
+        edited["Visible"].tolist(),
+        edited["Axis"].tolist(),
+    ):
         trace.visible = bool(visible)
+        axis_value = str(axis or trace.axis).lower()
+        if axis_value not in {"emission", "absorption"}:
+            axis_value = trace.axis
+        trace.axis = axis_value
+        trace.metadata["axis"] = axis_value
     _set_overlays(overlays)
 
     options = [trace.trace_id for trace in overlays]
@@ -649,6 +848,45 @@ def _remove_overlays(trace_ids: Sequence[str]) -> None:
     cache.reset()
 
 
+def _render_metadata_summary(overlays: Sequence[OverlayTrace]) -> None:
+    if not overlays:
+        return
+    rows: List[Dict[str, object]] = []
+    for trace in overlays:
+        meta = {str(k).lower(): v for k, v in (trace.metadata or {}).items()}
+        wavelength_range = meta.get("wavelength_range_nm")
+        if isinstance(wavelength_range, (list, tuple)) and len(wavelength_range) == 2:
+            wavelength_range = f"{wavelength_range[0]:.2f} – {wavelength_range[1]:.2f}"
+        elif wavelength_range is None:
+            wavelength_range = "—"
+        rows.append(
+            {
+                "Label": trace.label,
+                "Axis": trace.axis,
+                "Flux unit": trace.flux_unit,
+                "Instrument": meta.get("instrument") or meta.get("instrume") or "—",
+                "Telescope": meta.get("telescope") or meta.get("telescop") or "—",
+                "Observation": meta.get("date-obs") or meta.get("date_obs") or meta.get("observation_date") or "—",
+                "Range (nm)": wavelength_range,
+                "Resolution": meta.get("resolution_native") or meta.get("resolution") or "—",
+            }
+        )
+    if rows:
+        st.markdown("#### Metadata summary")
+        st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)
+    with st.expander("Metadata & provenance details", expanded=False):
+        for trace in overlays:
+            st.markdown(f"**{trace.label}**")
+            if trace.metadata:
+                st.json(trace.metadata)
+            else:
+                st.caption("No metadata recorded.")
+            if trace.provenance:
+                st.json(trace.provenance)
+            else:
+                st.caption("No conversion provenance available.")
+
+
 def _clear_overlays() -> None:
     st.session_state["overlay_traces"] = []
     st.session_state["reference_trace_id"] = None
@@ -662,19 +900,65 @@ def _export_current_view(
     display_units: str,
     display_mode: str,
     viewport: Tuple[float | None, float | None],
+    normalization_mode: str,
+    differential_mode: str,
+    reference: Optional[OverlayTrace],
 ) -> None:
     rows: List[Dict[str, object]] = []
+    manifest_traces: List[Dict[str, object]] = []
+    reference_vectors = reference.to_vectors() if reference else None
+
     for trace in overlays:
         if not trace.visible:
             continue
         df = _filter_viewport(trace.to_dataframe(), viewport)
         if df.empty:
             continue
-        converted, _ = _convert_wavelength(df["wavelength_nm"], display_units)
-        scaled = df["flux"].to_numpy(dtype=float)
+
+        if (
+            differential_mode == "Relative to reference"
+            and reference_vectors is not None
+            and trace.trace_id != reference_vectors.trace_id
+            and trace.kind != "lines"
+        ):
+            axis_nm, values_trace, values_ref = viewport_alignment(
+                trace.to_vectors(), reference_vectors, viewport
+            )
+            if axis_nm is None or values_trace is None or values_ref is None:
+                continue
+            axis_m = wavelength_to_m(axis_nm, "nm")
+            df = pd.DataFrame(
+                {
+                    "wavelength_m": axis_m,
+                    "wavelength_nm": axis_nm,
+                    "flux": values_trace - values_ref,
+                }
+            )
+
+        converted, _ = _convert_wavelength(df["wavelength_m"], display_units)
+        df = df.assign(wavelength=converted, flux=df["flux"].astype(float))
+        df = df.dropna(subset=["wavelength", "flux"])
+        if df.empty:
+            continue
+
+        y_values = df["flux"].to_numpy(dtype=float)
+        mirrored = False
+        if trace.axis == "absorption":
+            finite = y_values[np.isfinite(y_values)]
+            if finite.size and np.mean(finite < 0) > 0.5:
+                y_values = -y_values
+                mirrored = True
+
         if display_mode != "Flux (raw)":
-            scaled = apply_normalization(scaled, "max")
-        for wavelength_value, flux_value in zip(converted, scaled):
+            y_values = apply_normalization(y_values, "max")
+            flux_unit = "normalized"
+        elif normalization_mode and normalization_mode != "none" and trace.kind != "lines":
+            y_values = apply_normalization(y_values, normalization_mode)
+            flux_unit = trace.flux_unit
+        else:
+            flux_unit = trace.flux_unit
+
+        for wavelength_value, flux_value in zip(df["wavelength"], y_values):
             if not math.isfinite(float(wavelength_value)) or not math.isfinite(float(flux_value)):
                 continue
             rows.append(
@@ -683,12 +967,31 @@ def _export_current_view(
                     "wavelength": float(wavelength_value),
                     "unit": display_units,
                     "flux": float(flux_value),
+                    "flux_unit": flux_unit,
+                    "axis": trace.axis,
                     "display_mode": display_mode,
                 }
             )
+
+        manifest_traces.append(
+            {
+                "label": trace.label,
+                "provider": trace.provider,
+                "kind": trace.kind,
+                "points": int(len(df)),
+                "axis": trace.axis,
+                "flux_unit": trace.flux_unit,
+                "flux_kind": trace.flux_kind,
+                "metadata": trace.metadata,
+                "provenance": trace.provenance,
+                "mirrored": mirrored,
+            }
+        )
+
     if not rows:
         st.warning("Nothing to export in the current viewport.")
         return
+
     df_export = pd.DataFrame(rows)
     timestamp = time.strftime("%Y%m%d-%H%M%S")
     csv_path = EXPORT_DIR / f"spectra_export_{timestamp}.csv"
@@ -705,7 +1008,12 @@ def _export_current_view(
         display_mode=display_mode,
         exported_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         viewport={"low_nm": viewport[0], "high_nm": viewport[1]},
+        traces=manifest_traces,
     )
+    manifest.setdefault("transformations", {})["normalization_mode"] = normalization_mode
+    manifest["transformations"]["differential_mode"] = differential_mode
+    if reference is not None:
+        manifest["transformations"]["reference"] = reference.label
     manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
     st.success(f"Exported: {csv_path.name}, {png_path.name}, {manifest_path.name}")
 
@@ -816,9 +1124,10 @@ def _convert_nist_payload(data: Dict[str, object]) -> Optional[Dict[str, object]
         return None
     provenance = dict(meta)
     provenance["archive"] = "NIST"
+    wavelength_m = wavelength_to_m(wavelengths, "nm")
     payload = {
         "label": meta.get("label") or "NIST ASD",
-        "wavelength_nm": wavelengths,
+        "wavelength_m": wavelength_m,
         "flux": flux,
         "provider": "NIST",
         "summary": f"{len(wavelengths)} NIST ASD lines",
@@ -826,9 +1135,13 @@ def _convert_nist_payload(data: Dict[str, object]) -> Optional[Dict[str, object]
         "metadata": {
             "lines": lines,
             "query": meta.get("query"),
+            "flux_unit_input": "relative_intensity",
+            "axis": "emission",
         },
         "provenance": provenance,
         "hover": hover,
+        "flux_unit": "dimensionless",
+        "flux_kind": "dimensionless",
     }
     return payload
 
@@ -895,7 +1208,16 @@ def _render_overlay_tab(version_info: Dict[str, str]) -> None:
         _render_overlay_table(overlays)
     with action_col:
         if st.button("Export view", key="export_view"):
-            _export_current_view(fig, overlays, display_units, display_mode, viewport)
+            _export_current_view(
+                fig,
+                overlays,
+                display_units,
+                display_mode,
+                viewport,
+                normalization,
+                differential_mode,
+                reference,
+            )
         st.caption(f"Axis: {axis_title}")
 
     cache: SimilarityCache = st.session_state["similarity_cache"]
@@ -908,6 +1230,7 @@ def _render_overlay_tab(version_info: Dict[str, str]) -> None:
         reference_id=st.session_state.get("reference_trace_id"),
     )
     render_similarity_panel(visible_vectors, viewport, options, cache)
+    _render_metadata_summary([trace for trace in overlays if trace.visible])
     _render_line_tables(overlays)
 
 
@@ -982,6 +1305,8 @@ def render() -> None:
     st.title("Spectra App")
     st.caption(f"Build {version_info.get('version', 'v?')} • {version_info.get('date_utc', '')}")
     st.info(f"Patch: {patch_note}")
+
+    _render_upload_panel()
 
     _render_reference_section()
     st.sidebar.divider()

--- a/app/utils/units.py
+++ b/app/utils/units.py
@@ -1,49 +1,396 @@
 from __future__ import annotations
-from typing import Sequence, Optional, Tuple
+
+import math
+import re
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
 import numpy as np
 
-class LogSink:
-    def __init__(self):
-        self.events = []
-    def add(self, op: str, **kwargs):
-        self.events.append({"op": op, **kwargs})
-    def to_list(self):
-        return list(self.events)
+SPEED_OF_LIGHT = 299_792_458.0  # m s^-1
 
-def resolve_units(header_unit: Optional[str]) -> Tuple[str, float | None]:
-    u = (header_unit or "").strip()
-    if u in {"nm", "nanometer", "nanometers"}: return "nm", 1.0
-    if u in {"Å", "A", "Angstrom", "angstrom"}: return "Å", 0.1
-    if u in {"um", "µm", "micrometer", "micrometers"}: return "µm", 1000.0
-    if u in {"cm^-1", "wavenumber"}: return "cm^-1", None
-    return "nm", 1.0
 
-def convert_array_to_nm(wl: Sequence[float], unit: str, sink: Optional[LogSink]=None):
-    wl = np.asarray(wl)
-    if unit == "nm":
-        out = wl.astype(float)
-    elif unit in {"Å","A"}:
-        out = wl.astype(float) * 0.1
-    elif unit in {"um","µm"}:
-        out = wl.astype(float) * 1000.0
-    elif unit == "cm^-1":
-        wl_cm = 1.0 / wl.astype(float)
-        out = wl_cm * 1e7  # cm -> nm
+# ---------------------------------------------------------------------------
+# Provenance helpers
+
+
+@dataclass
+class ConversionEvent:
+    """Single provenance record describing a unit conversion."""
+
+    stage: str
+    original_unit: str
+    target_unit: str
+    formula: str
+    context: Dict[str, object] = field(default_factory=dict)
+
+    def as_dict(self) -> Dict[str, object]:
+        payload = {
+            "stage": self.stage,
+            "from": self.original_unit,
+            "to": self.target_unit,
+            "formula": self.formula,
+        }
+        if self.context:
+            payload["context"] = dict(self.context)
+        return payload
+
+
+class ConversionLog:
+    """Collect provenance events during ingestion."""
+
+    def __init__(self) -> None:
+        self._events: List[ConversionEvent] = []
+
+    def add(
+        self,
+        stage: str,
+        original_unit: str,
+        target_unit: str,
+        formula: str,
+        **context: object,
+    ) -> None:
+        self._events.append(
+            ConversionEvent(
+                stage=stage,
+                original_unit=original_unit,
+                target_unit=target_unit,
+                formula=formula,
+                context=context,
+            )
+        )
+
+    def extend(self, events: Iterable[ConversionEvent]) -> None:
+        for event in events:
+            self._events.append(event)
+
+    def to_records(self) -> List[Dict[str, object]]:
+        return [event.as_dict() for event in self._events]
+
+    def __bool__(self) -> bool:  # pragma: no cover - trivial
+        return bool(self._events)
+
+
+# Backwards compatible alias used by legacy code.
+LogSink = ConversionLog
+
+
+# ---------------------------------------------------------------------------
+# Wavelength parsing & conversion
+
+
+@dataclass(frozen=True)
+class _WavelengthUnit:
+    key: str
+    kind: str  # 'length' or 'wavenumber'
+    to_si: float  # multiply value in this unit by to_si to obtain SI base
+    display: str
+
+
+# Canonical definitions (aliases are populated below)
+_LENGTH_UNITS: Dict[str, _WavelengthUnit] = {
+    "m": _WavelengthUnit("m", "length", 1.0, "m"),
+    "nm": _WavelengthUnit("nm", "length", 1e-9, "nm"),
+    "um": _WavelengthUnit("µm", "length", 1e-6, "µm"),
+    "µm": _WavelengthUnit("µm", "length", 1e-6, "µm"),
+    "mm": _WavelengthUnit("mm", "length", 1e-3, "mm"),
+    "cm": _WavelengthUnit("cm", "length", 1e-2, "cm"),
+    "Å": _WavelengthUnit("Å", "length", 1e-10, "Å"),
+    "ang": _WavelengthUnit("Å", "length", 1e-10, "Å"),
+}
+_WAVENUMBER_UNITS: Dict[str, _WavelengthUnit] = {
+    "cm^-1": _WavelengthUnit("cm^-1", "wavenumber", 100.0, "cm⁻¹"),
+    "cm-1": _WavelengthUnit("cm^-1", "wavenumber", 100.0, "cm⁻¹"),
+    "1/cm": _WavelengthUnit("cm^-1", "wavenumber", 100.0, "cm⁻¹"),
+    "m^-1": _WavelengthUnit("m^-1", "wavenumber", 1.0, "m⁻¹"),
+}
+
+# Populate alias map
+_WAVELENGTH_ALIASES: Dict[str, _WavelengthUnit] = {}
+for canonical in list(_LENGTH_UNITS.values()) + list(_WAVENUMBER_UNITS.values()):
+    _WAVELENGTH_ALIASES[canonical.key.casefold()] = canonical
+
+_ADDITIONAL_WAVELENGTH_ALIASES = {
+    "meter": "m",
+    "meters": "m",
+    "metre": "m",
+    "metres": "m",
+    "micron": "µm",
+    "microns": "µm",
+    "micrometer": "µm",
+    "micrometers": "µm",
+    "micrometre": "µm",
+    "micrometres": "µm",
+    "angstrom": "Å",
+    "ångström": "Å",
+    "ångstrom": "Å",
+    "a": "Å",
+    "aa": "Å",
+    "pm": "pm",
+}
+_LENGTH_UNITS["pm"] = _WavelengthUnit("pm", "length", 1e-12, "pm")
+for alias, target in _ADDITIONAL_WAVELENGTH_ALIASES.items():
+    if target in _LENGTH_UNITS:
+        _WAVELENGTH_ALIASES[alias] = _LENGTH_UNITS[target]
+
+
+def _resolve_wavelength_unit(unit: str | None) -> _WavelengthUnit:
+    token = (unit or "m").strip()
+    token = token.replace("μ", "µ")
+    if not token:
+        token = "m"
+    lookup = token.casefold()
+    if lookup in _WAVELENGTH_ALIASES:
+        return _WAVELENGTH_ALIASES[lookup]
+    if lookup in _WAVENUMBER_UNITS:
+        return _WAVENUMBER_UNITS[lookup]
+    raise ValueError(f"Unsupported wavelength unit: {unit}")
+
+
+def detect_wavelength_unit(label: str | None) -> Optional[str]:
+    """Infer a wavelength unit from a column label or FITS keyword."""
+
+    if not label:
+        return None
+    cleaned = label.replace("μ", "µ")
+    if "cm^-1" in cleaned or "cm-1" in cleaned or "1/cm" in cleaned:
+        return "cm^-1"
+    tokens = re.findall(r"[A-Za-zµÅ]+(?:-?\^?-?\d+)?", cleaned)
+    for token in tokens:
+        try:
+            resolved = _resolve_wavelength_unit(token)
+        except ValueError:
+            continue
+        if resolved.kind == "length":
+            return resolved.display
+    return None
+
+
+def wavelength_to_m(
+    values: Sequence[float],
+    unit: str | None,
+    log: Optional[ConversionLog] = None,
+    stage: str = "wavelength",
+) -> np.ndarray:
+    info = _resolve_wavelength_unit(unit)
+    arr = np.asarray(values, dtype=float)
+    if info.kind == "wavenumber":
+        sigma = arr * info.to_si
+        with np.errstate(divide="ignore", invalid="ignore"):
+            converted = np.where(sigma != 0.0, 1.0 / sigma, np.nan)
+        formula = "λ = 1 / σ"
     else:
-        out = wl.astype(float)
-    if sink is not None:
-        sink.add("unit_convert_to_nm", from_unit=unit, to_unit="nm")
-    return out
+        converted = arr * info.to_si
+        formula = "λ_m = λ_unit × factor"
+    if log is not None:
+        log.add(
+            stage,
+            original_unit=info.display,
+            target_unit="m",
+            formula=formula,
+            factor=info.to_si,
+        )
+    return converted
 
-def convert_nm_to_display(wl_nm: Sequence[float], unit: str):
-    x = np.asarray(wl_nm, dtype=float)
-    if unit == "nm":
-        return x
-    if unit in {"Å","A"}:
-        return x * 10.0
-    if unit in {"um","µm"}:
-        return x / 1000.0
-    if unit == "cm^-1":
-        wl_cm = x * 1e-7
-        return 1.0 / wl_cm
-    return x
+
+def wavelength_from_m(values: Sequence[float], unit: str) -> np.ndarray:
+    info = _resolve_wavelength_unit(unit)
+    arr = np.asarray(values, dtype=float)
+    if info.kind == "wavenumber":
+        with np.errstate(divide="ignore", invalid="ignore"):
+            sigma = np.where(arr != 0.0, 1.0 / arr, np.nan)
+        return sigma / info.to_si
+    return arr / info.to_si
+
+
+# ---------------------------------------------------------------------------
+# Flux parsing & conversion
+
+
+@dataclass(frozen=True)
+class _FluxUnit:
+    key: str
+    kind: str  # 'F_lambda', 'F_nu', 'dimensionless', 'counts'
+    to_si: float
+    display: str
+
+
+_FLUX_UNIT_ALIASES: Dict[str, _FluxUnit] = {
+    "w/m^2/m": _FluxUnit("W m⁻² m⁻¹", "F_lambda", 1.0, "W m⁻² m⁻¹"),
+    "w/m^2/nm": _FluxUnit("W m⁻² nm⁻¹", "F_lambda", 1e9, "W m⁻² m⁻¹"),
+    "w/m^2/um": _FluxUnit("W m⁻² µm⁻¹", "F_lambda", 1e6, "W m⁻² m⁻¹"),
+    "w/m^2/µm": _FluxUnit("W m⁻² µm⁻¹", "F_lambda", 1e6, "W m⁻² m⁻¹"),
+    "w/m^2/a": _FluxUnit("W m⁻² Å⁻¹", "F_lambda", 1e10, "W m⁻² m⁻¹"),
+    "erg/s/cm^2/a": _FluxUnit("erg s⁻¹ cm⁻² Å⁻¹", "F_lambda", 1e7, "W m⁻² m⁻¹"),
+    "erg/s/cm^2/nm": _FluxUnit("erg s⁻¹ cm⁻² nm⁻¹", "F_lambda", 1e6, "W m⁻² m⁻¹"),
+    "erg/s/cm^2/cm": _FluxUnit("erg s⁻¹ cm⁻² cm⁻¹", "F_lambda", 1e5, "W m⁻² m⁻¹"),
+    "erg/s/cm^2/m": _FluxUnit("erg s⁻¹ cm⁻² m⁻¹", "F_lambda", 1e3, "W m⁻² m⁻¹"),
+    "jy": _FluxUnit("Jy", "F_nu", 1e-26, "W m⁻² Hz⁻¹"),
+    "jansk": _FluxUnit("Jy", "F_nu", 1e-26, "W m⁻² Hz⁻¹"),
+    "mjy": _FluxUnit("mJy", "F_nu", 1e-29, "W m⁻² Hz⁻¹"),
+    "µjy": _FluxUnit("µJy", "F_nu", 1e-32, "W m⁻² Hz⁻¹"),
+    "ujy": _FluxUnit("µJy", "F_nu", 1e-32, "W m⁻² Hz⁻¹"),
+    "erg/s/cm^2/hz": _FluxUnit("erg s⁻¹ cm⁻² Hz⁻¹", "F_nu", 1e-3, "W m⁻² Hz⁻¹"),
+    "counts": _FluxUnit("counts", "counts", 1.0, "counts"),
+    "adu": _FluxUnit("ADU", "counts", 1.0, "ADU"),
+    "dimensionless": _FluxUnit("unitless", "dimensionless", 1.0, "unitless"),
+    "transmission": _FluxUnit("transmission", "dimensionless", 1.0, "transmission"),
+}
+
+
+def _normalise_flux_unit(text: str | None) -> Optional[_FluxUnit]:
+    if not text:
+        return None
+    cleaned = text.strip().lower().replace("μ", "µ")
+    cleaned = cleaned.replace(" ", "")
+    cleaned = cleaned.replace("per", "/")
+    for key, unit in _FLUX_UNIT_ALIASES.items():
+        if key in cleaned:
+            return unit
+    if cleaned in {"", "flux"}:
+        return None
+    return None
+
+
+def detect_flux_unit(label: str | None) -> Optional[str]:
+    if not label:
+        return None
+    # Look inside parentheses first.
+    match = re.search(r"\(([^)]+)\)", label)
+    if match:
+        unit = _normalise_flux_unit(match.group(1))
+        if unit:
+            return unit.key
+    tokens = re.findall(r"[A-Za-zµ/^-]+", label.replace("μ", "µ"))
+    for token in tokens:
+        unit = _normalise_flux_unit(token)
+        if unit:
+            return unit.key
+    return None
+
+
+def _resolve_flux_unit(unit: str | None) -> _FluxUnit:
+    resolved = _normalise_flux_unit(unit)
+    if resolved is not None:
+        return resolved
+    # Default to arbitrary F_lambda if unknown.
+    return _FLUX_UNIT_ALIASES["w/m^2/m"]
+
+
+def flux_to_f_lambda(
+    values: Sequence[float],
+    wavelength_m: Sequence[float],
+    unit: str | None,
+    log: Optional[ConversionLog] = None,
+    stage: str = "flux",
+) -> Tuple[np.ndarray, str, str]:
+    info = _resolve_flux_unit(unit)
+    arr = np.asarray(values, dtype=float)
+    wl = np.asarray(wavelength_m, dtype=float)
+
+    if info.kind == "F_lambda":
+        converted = arr * info.to_si
+        formula = "Fλ_SI = Fλ_unit × factor"
+        target = "W m⁻² m⁻¹"
+        flux_kind = "F_lambda"
+    elif info.kind == "F_nu":
+        spectral = arr * info.to_si
+        with np.errstate(divide="ignore", invalid="ignore"):
+            converted = np.where(wl > 0.0, spectral * (wl ** 2) / SPEED_OF_LIGHT, np.nan)
+        formula = "Fλ = Fν × λ² / c"
+        target = "W m⁻² m⁻¹"
+        flux_kind = "F_lambda"
+    elif info.kind == "dimensionless":
+        converted = arr
+        formula = "Dimensionless quantity (no conversion)"
+        target = info.display
+        flux_kind = "dimensionless"
+    else:  # counts or unknown
+        converted = arr
+        formula = "Counts retained"
+        target = info.display
+        flux_kind = info.kind
+
+    if log is not None:
+        log.add(
+            stage,
+            original_unit=info.key,
+            target_unit=target,
+            formula=formula,
+            factor=getattr(info, "to_si", 1.0),
+        )
+    return converted, target, flux_kind
+
+
+def convert_uncertainty(
+    uncertainty: Sequence[float] | None,
+    wavelength_m: Sequence[float],
+    original_unit: str | None,
+    flux_kind: str,
+    log: Optional[ConversionLog] = None,
+) -> Optional[np.ndarray]:
+    if uncertainty is None:
+        return None
+    arr = np.asarray(uncertainty, dtype=float)
+    if flux_kind == "F_lambda":
+        converted, _, _ = flux_to_f_lambda(arr, wavelength_m, original_unit, log, stage="uncertainty")
+        return converted
+    if log is not None and original_unit:
+        log.add(
+            "uncertainty",
+            original_unit=original_unit,
+            target_unit=original_unit,
+            formula="Uncertainty left unchanged",
+        )
+    return arr
+
+
+def infer_axis_assignment(values: Sequence[float], flux_kind: str) -> str:
+    arr = np.asarray(values, dtype=float)
+    finite = arr[np.isfinite(arr)]
+    if flux_kind in {"dimensionless"}:
+        return "absorption"
+    if finite.size == 0:
+        return "emission"
+    if np.nanmedian(finite) < 0:
+        return "absorption"
+    negative_fraction = np.mean(finite < 0) if finite.size else 0.0
+    if negative_fraction > 0.5:
+        return "absorption"
+    return "emission"
+
+
+def format_flux_unit(unit: str) -> str:
+    if not unit:
+        return ""
+    if unit in {"W m⁻² m⁻¹", "W/m^2/m"}:
+        return "W m⁻² m⁻¹"
+    return unit
+
+
+def convert_wavelength_for_display(wavelength_m: Sequence[float], unit: str) -> Tuple[np.ndarray, str]:
+    converted = wavelength_from_m(wavelength_m, unit)
+    if unit == "Å":
+        return converted, "Wavelength (Å)"
+    if unit in {"µm", "um"}:
+        return converted, "Wavelength (µm)"
+    if unit in {"cm^-1", "cm⁻¹", "cm-1"}:
+        return converted, "Wavenumber (cm⁻¹)"
+    return converted, "Wavelength (nm)" if unit == "nm" else f"Wavelength ({unit})"
+
+
+__all__ = [
+    "ConversionEvent",
+    "ConversionLog",
+    "LogSink",
+    "SPEED_OF_LIGHT",
+    "detect_wavelength_unit",
+    "wavelength_to_m",
+    "wavelength_from_m",
+    "detect_flux_unit",
+    "flux_to_f_lambda",
+    "convert_uncertainty",
+    "infer_axis_assignment",
+    "format_flux_unit",
+    "convert_wavelength_for_display",
+]

--- a/tests/test_continuity.py
+++ b/tests/test_continuity.py
@@ -62,3 +62,5 @@ def test_build_manifest_includes_continuity():
     assert manifest['global_units']['wavelength'] == 'nm'
     assert manifest['global_units']['intensity_mode'] == 'Flux (raw)'
     assert manifest['exported_at'] == '2025-09-21T00:00:00Z'
+    assert manifest['transformations']['rows_exported'] == len(rows)
+    assert manifest['traces'] == []


### PR DESCRIPTION
## Summary
- normalize unit utilities with provenance logging and Fν↔Fλ conversion helpers
- add ingestion pipeline for CSV/TXT/FITS uploads, dual-axis plotting, and metadata summaries in the UI
- extend export manifest with detailed trace records and conversion provenance

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf4cf1b43083298ef4603b42c58618