### PR TITLE
Integrate CALSPEC data into MAST provider

### DIFF
--- a/app/providers/mast.py
+++ b/app/providers/mast.py
@@ -1,49 +1,225 @@
 from __future__ import annotations
 
-"""Synthetic MAST adapter delivering deterministic preview spectra."""
+"""MAST provider adapter that serves live CALSPEC spectra via the fetcher."""
 
-from typing import Iterable
+from dataclasses import dataclass
+import re
+import unicodedata
+from typing import Dict, Iterable, List, Tuple
 
-import numpy as np
+from app.server.fetchers import mast as mast_fetcher
 
 from .base import ProviderHit, ProviderQuery
 
 
-def _synthetic_spectrum(seed: int, center_nm: float = 550.0) -> tuple[list[float], list[float]]:
-    rng = np.random.default_rng(seed)
-    wavelengths = np.linspace(350.0, 950.0, 320)
-    envelope = np.exp(-0.5 * ((wavelengths - center_nm) / 90.0) ** 2)
-    modulation = 0.35 * np.sin(wavelengths / 35.0 + seed)
-    noise = 0.05 * rng.normal(size=wavelengths.size)
-    flux = envelope * (1.2 + modulation) + noise
-    flux -= flux.min()
-    return wavelengths.tolist(), flux.tolist()
+@dataclass(frozen=True)
+class _TargetInfo:
+    canonical_name: str
+    instrument_label: str
+    spectral_type: str
+    distance_pc: float
+    description: str
+    search_tokens: Tuple[str, ...]
+
+
+_TARGETS: Tuple[_TargetInfo, ...] = ()
+
+
+def refresh_targets() -> None:
+    """Reload cached CALSPEC target metadata from the fetcher."""
+
+    global _TARGETS
+    _TARGETS = _load_targets()
+
+
+def _load_targets() -> Tuple[_TargetInfo, ...]:
+    records: List[_TargetInfo] = []
+    for entry in mast_fetcher.available_targets():
+        tokens = {_normalise_token(entry.get("canonical_name", ""))}
+        for alias in entry.get("aliases", ()):  # type: ignore[assignment]
+            tokens.add(_normalise_token(alias))
+        tokens.discard("")
+        records.append(
+            _TargetInfo(
+                canonical_name=entry.get("canonical_name", ""),
+                instrument_label=entry.get("instrument_label", ""),
+                spectral_type=entry.get("spectral_type", ""),
+                distance_pc=float(entry.get("distance_pc") or 0.0),
+                description=entry.get("description", ""),
+                search_tokens=tuple(sorted(tokens)),
+            )
+        )
+    return tuple(records)
+
+
+def _normalise_token(value: str) -> str:
+    normalised = unicodedata.normalize("NFKD", value or "")
+    ascii_only = normalised.encode("ascii", "ignore").decode("ascii")
+    return re.sub(r"[^a-z0-9]+", "", ascii_only.lower())
+
+
+def _match_targets(query: ProviderQuery) -> List[_TargetInfo]:
+    if not _TARGETS:
+        return []
+
+    search_terms: List[str] = []
+    for value in (query.target, query.text):
+        if value:
+            search_terms.append(value)
+
+    if not search_terms:
+        return list(_TARGETS)
+
+    matches: List[_TargetInfo] = []
+    seen: set[str] = set()
+    for term in search_terms:
+        token = _normalise_token(term)
+        if not token:
+            continue
+        for target in _TARGETS:
+            for alias in target.search_tokens:
+                if not alias:
+                    continue
+                if alias == token or alias.startswith(token) or token.startswith(alias):
+                    if target.canonical_name not in seen:
+                        matches.append(target)
+                        seen.add(target.canonical_name)
+                    break
+    return matches
+
+
+def _safe_float(value: object) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _build_summary(meta: Dict[str, object], target: _TargetInfo) -> str:
+    parts: List[str] = ["CALSPEC flux standard"]
+
+    spectral = meta.get("spectral_type") or target.spectral_type
+    if spectral:
+        parts.append(str(spectral))
+
+    distance = meta.get("distance_pc") or target.distance_pc
+    if isinstance(distance, (int, float)) and distance > 0:
+        parts.append(f"{float(distance):.2f} pc")
+
+    w_min = _safe_float(meta.get("wavelength_min_nm"))
+    w_max = _safe_float(meta.get("wavelength_max_nm"))
+    if w_min is not None and w_max is not None:
+        parts.append(f"{w_min:.0f}–{w_max:.0f} nm")
+
+    return " • ".join(parts)
+
+
+def _build_metadata(meta: Dict[str, object], target: _TargetInfo, instrument_label: str) -> Dict[str, object]:
+    metadata: Dict[str, object] = {
+        "target_name": meta.get("target_name") or target.canonical_name,
+        "instrument": instrument_label,
+    }
+
+    spectral = meta.get("spectral_type") or target.spectral_type
+    if spectral:
+        metadata["spectral_type"] = spectral
+
+    distance = meta.get("distance_pc") or target.distance_pc
+    if isinstance(distance, (int, float)) and distance > 0:
+        metadata["distance_pc"] = float(distance)
+
+    description = meta.get("description") or target.description
+    if description:
+        metadata["description"] = description
+
+    doi = meta.get("doi")
+    if doi:
+        metadata["doi"] = doi
+
+    w_min = _safe_float(meta.get("wavelength_min_nm"))
+    w_max = _safe_float(meta.get("wavelength_max_nm"))
+    if w_min is not None and w_max is not None:
+        metadata["wavelength_range_nm"] = [w_min, w_max]
+
+    return metadata
+
+
+def _build_provenance(meta: Dict[str, object], query: ProviderQuery) -> Dict[str, object]:
+    provenance: Dict[str, object] = {
+        "archive": meta.get("archive"),
+        "access_url": meta.get("access_url"),
+        "fetched_at_utc": meta.get("fetched_at_utc"),
+        "app_version": meta.get("app_version"),
+        "file_hash_sha256": meta.get("file_hash_sha256"),
+        "cache_path": meta.get("cache_path"),
+        "cache_hit": meta.get("cache_hit"),
+        "units_original": meta.get("units_original"),
+        "units_converted": meta.get("units_converted"),
+        "query": query.as_dict(),
+        "meta": meta,
+    }
+    return {key: value for key, value in provenance.items() if value is not None}
+
+
+def _build_hit(payload: Dict[str, object], query: ProviderQuery, target: _TargetInfo) -> ProviderHit:
+    wavelengths = payload.get("wavelength_nm") or []
+    flux = payload.get("intensity") or []
+    meta = dict(payload.get("meta") or {})
+
+    target_name = meta.get("target_name") or target.canonical_name
+    instrument_label = meta.get("instrument") or query.instrument or target.instrument_label or "MAST"
+
+    summary = _build_summary(meta, target)
+    metadata = _build_metadata(meta, target, str(instrument_label))
+    provenance = _build_provenance(meta, query)
+
+    identifier = str(meta.get("obs_id") or meta.get("target_name") or target.canonical_name)
+
+    return ProviderHit(
+        provider="MAST",
+        identifier=identifier,
+        label=f"{target_name} • {instrument_label}",
+        summary=summary,
+        wavelengths_nm=[float(value) for value in wavelengths],
+        flux=[float(value) for value in flux],
+        metadata=metadata,
+        provenance=provenance,
+    )
 
 
 def search(query: ProviderQuery) -> Iterable[ProviderHit]:
-    target = query.target or query.text or "Target"
-    for idx in range(min(max(query.limit, 1), 5)):
-        center = 520.0 + 25.0 * idx
-        wavelengths, flux = _synthetic_spectrum(idx + 3, center)
-        identifier = f"MAST-{target[:6].upper()}-{idx+1:02d}"
-        summary = f"Synthetic preview for {target} centred at {center:.0f} nm"
-        metadata = {
-            "target": target,
-            "instrument": query.instrument or "STIS",
-            "exposure": 1200 + 120 * idx,
-            "preview_center_nm": center,
-        }
-        provenance = {
-            "archive": "MAST",
-            "query": query.as_dict(),
-        }
-        yield ProviderHit(
-            provider="MAST",
-            identifier=identifier,
-            label=f"{target} • STIS • {center:.0f} nm",
-            summary=summary,
-            wavelengths_nm=wavelengths,
-            flux=flux,
-            metadata=metadata,
-            provenance=provenance,
+    """Return CALSPEC spectra matching the query, fetching live data as needed."""
+
+    targets = _match_targets(query)
+    if not targets:
+        search_value = query.target or query.text or ""
+        known = ", ".join(target.canonical_name for target in _TARGETS)
+        raise mast_fetcher.MastFetchError(
+            f"No CALSPEC targets matched '{search_value}'. Known targets: {known}."
         )
+
+    limit = max(1, int(query.limit or 1))
+    yielded = 0
+    errors: List[str] = []
+
+    for target in targets:
+        try:
+            payload = mast_fetcher.fetch(
+                target=target.canonical_name,
+                instrument=query.instrument or "",
+            )
+        except mast_fetcher.MastFetchError as exc:
+            errors.append(str(exc))
+            continue
+
+        yield _build_hit(payload, query, target)
+        yielded += 1
+        if yielded >= limit:
+            break
+
+    if yielded == 0 and errors:
+        raise mast_fetcher.MastFetchError(errors[0])
+
+
+# Initialise target cache on import so interactive sessions have data immediately.
+refresh_targets()
+

--- a/app/server/fetchers/mast.py
+++ b/app/server/fetchers/mast.py
@@ -24,7 +24,7 @@ import requests
 
 from app._version import get_version_info
 
-__all__ = ["fetch", "MastFetchError"]
+__all__ = ["fetch", "MastFetchError", "available_targets"]
 
 
 CALSPEC_INDEX_URL = "https://ssb.stsci.edu/cdbs/calspec/"
@@ -129,6 +129,26 @@ for target in _CALSPEC_TARGETS:
     _ALIAS_LOOKUP[_normalise_token(target.canonical_name)] = target
     for alias in target.aliases:
         _ALIAS_LOOKUP[_normalise_token(alias)] = target
+
+
+def available_targets() -> Tuple[Dict[str, object], ...]:
+    """Return metadata describing the curated CALSPEC targets."""
+
+    records: List[Dict[str, object]] = []
+    for target in _CALSPEC_TARGETS:
+        records.append(
+            {
+                "canonical_name": target.canonical_name,
+                "aliases": tuple(target.aliases),
+                "instrument_label": target.instrument_label,
+                "spectral_type": target.spectral_type,
+                "distance_pc": target.distance_pc,
+                "description": target.description,
+                "preferred_modes": tuple(target.preferred_modes),
+                "fallback_modes": tuple(target.fallback_modes),
+            }
+        )
+    return tuple(records)
 
 
 _CACHED_INDEX: Optional[List[str]] = None

--- a/tests/providers/test_mast_provider.py
+++ b/tests/providers/test_mast_provider.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from typing import List
+
+import pytest
+
+from app.providers.base import ProviderQuery
+from app.providers import mast as provider
+
+
+def _fake_available_targets():
+    return (
+        {
+            "canonical_name": "Sirius A",
+            "aliases": ("Sirius", "Alpha CMa"),
+            "instrument_label": "HST/STIS",
+            "spectral_type": "A1 V",
+            "distance_pc": 2.64,
+            "description": "Bright primary CALSPEC standard",
+            "preferred_modes": ("stis",),
+            "fallback_modes": ("mod",),
+        },
+    )
+
+
+def _fake_payload():
+    return {
+        "wavelength_nm": [400.0, 410.0, 420.0],
+        "intensity": [1.0, 0.95, 1.05],
+        "meta": {
+            "archive": "MAST CALSPEC",
+            "target_name": "Sirius A",
+            "instrument": "HST/STIS",
+            "obs_id": "sirius_stis_003.fits",
+            "doi": "10.1088/0004-6256/147/6/127",
+            "access_url": "https://example.test/sirius",
+            "fetched_at_utc": "2025-01-01T00:00:00Z",
+            "file_hash_sha256": "abc123",
+            "units_original": {"wavelength": "Å", "flux": "erg s^-1 cm^-2 Å^-1"},
+            "units_converted": {"wavelength": "nm", "flux": "erg s^-1 cm^-2 nm^-1"},
+            "app_version": "v1.2.3",
+            "cache_path": "/tmp/sirius.fits",
+            "cache_hit": False,
+            "spectral_type": "A1 V",
+            "distance_pc": 2.64,
+            "description": "Bright primary CALSPEC standard",
+            "wavelength_min_nm": 115.0,
+            "wavelength_max_nm": 2400.0,
+        },
+    }
+
+
+def test_search_fetches_calspec_data(monkeypatch):
+    fetch_calls: List[tuple[str, str]] = []
+
+    def fake_fetch(target: str, instrument: str = "", **kwargs):
+        fetch_calls.append((target, instrument))
+        return _fake_payload()
+
+    monkeypatch.setattr(provider.mast_fetcher, "available_targets", _fake_available_targets)
+    monkeypatch.setattr(provider.mast_fetcher, "fetch", fake_fetch)
+    provider.refresh_targets()
+
+    query = ProviderQuery(target="Sirius", instrument="STIS", limit=1)
+    hits = list(provider.search(query))
+
+    assert len(hits) == 1
+    hit = hits[0]
+    assert hit.provider == "MAST"
+    assert hit.metadata["target_name"] == "Sirius A"
+    assert hit.summary.startswith("CALSPEC")
+    assert hit.provenance["archive"] == "MAST CALSPEC"
+    assert hit.provenance["query"]["instrument"] == "STIS"
+    assert fetch_calls == [("Sirius A", "STIS")]
+
+
+def test_partial_target_and_limit(monkeypatch):
+    fetch_calls: List[str] = []
+
+    def fake_fetch(target: str, instrument: str = "", **kwargs):
+        fetch_calls.append(target)
+        return _fake_payload()
+
+    monkeypatch.setattr(provider.mast_fetcher, "available_targets", _fake_available_targets)
+    monkeypatch.setattr(provider.mast_fetcher, "fetch", fake_fetch)
+    provider.refresh_targets()
+
+    query = ProviderQuery(target="sir", limit=1)
+    hits = list(provider.search(query))
+
+    assert len(hits) == 1
+    assert hits[0].identifier == "sirius_stis_003.fits"
+    assert fetch_calls == ["Sirius A"]
+
+
+def test_unknown_target_raises(monkeypatch):
+    monkeypatch.setattr(provider.mast_fetcher, "available_targets", _fake_available_targets)
+
+    def fake_fetch(*args, **kwargs):  # pragma: no cover - defensive
+        raise AssertionError("Fetch should not be called when target is unknown")
+
+    monkeypatch.setattr(provider.mast_fetcher, "fetch", fake_fetch)
+    provider.refresh_targets()
+
+    query = ProviderQuery(target="Unknown")
+    with pytest.raises(provider.mast_fetcher.MastFetchError):
+        list(provider.search(query))
+
+
+def teardown_module(module):  # pragma: no cover - test cleanup
+    provider.refresh_targets()
+

--- a/tests/server/test_fetch_mast.py
+++ b/tests/server/test_fetch_mast.py
@@ -86,3 +86,11 @@ def test_unknown_target_raises():
     mast.reset_index_cache()
     with pytest.raises(mast.MastFetchError):
         mast.fetch(target="Unknown Star")
+
+
+def test_available_targets_metadata():
+    targets = mast.available_targets()
+    assert {entry["canonical_name"] for entry in targets} >= {"Sirius A", "Vega", "18 Sco"}
+    sirius = next(entry for entry in targets if entry["canonical_name"] == "Sirius A")
+    assert "sirius" in {alias.lower() for alias in sirius["aliases"]}
+    assert sirius["instrument_label"].startswith("HST")


### PR DESCRIPTION
## Summary
- replace the synthetic MAST provider with a CALSPEC-backed adapter that resolves curated targets, fetches spectra via the server fetcher, and surfaces provenance metadata for overlays
- expose mast.available_targets() so the provider can discover the curated CALSPEC set without duplicating configuration
- add regression coverage for the new registry API and for the provider’s live-fetch behaviour

## Testing
- PYTHONPATH=. pytest tests/server/test_fetch_mast.py tests/providers/test_mast_provider.py

------
https://chatgpt.com/codex/tasks/task_e_68cf9c828c208329bdad5df1d9ba7c10