### PR TITLE
Enhance local ingestion for diverse spectral files

### DIFF
--- a/app/server/ingest_ascii.py
+++ b/app/server/ingest_ascii.py
@@ -1,11 +1,93 @@
 from __future__ import annotations
 
 import hashlib
-from typing import Dict, Iterable
+import math
+import re
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
 import pandas as pd
 
 from .units import canonical_unit, to_nm
+
+
+HEADER_ALIAS_MAP = {
+    "instrument": "instrument",
+    "instrume": "instrument",
+    "spectrograph": "instrument",
+    "spectrograph_name": "instrument",
+    "spectro": "instrument",
+    "detector": "detector",
+    "telescope": "telescope",
+    "telescop": "telescope",
+    "facility": "telescope",
+    "observatory": "telescope",
+    "observatory_name": "telescope",
+    "object": "target",
+    "object_name": "target",
+    "target": "target",
+    "target_name": "target",
+    "source": "source",
+    "source_name": "source",
+    "title": "title",
+    "label": "title",
+    "name": "title",
+    "program": "program",
+    "programme": "program",
+    "proposal": "program",
+    "prop_id": "program",
+    "observer": "observer",
+    "pi": "principal_investigator",
+    "principal_investigator": "principal_investigator",
+    "exptime": "exposure",
+    "exposure": "exposure",
+    "airmass": "airmass",
+    "slit": "slit",
+    "aperture": "aperture",
+    "grating": "grating",
+    "grism": "grating",
+    "filter": "filter",
+    "mode": "mode",
+    "resolution": "resolution",
+    "resolving_power": "resolution",
+    "r": "resolution",
+    "flux_unit": "flux_unit",
+    "flux_units": "flux_unit",
+    "fluxunits": "flux_unit",
+    "fluxunit": "flux_unit",
+    "bunit": "flux_unit",
+    "unit_flux": "flux_unit",
+    "wavelength_unit": "wavelength_unit",
+    "waveunit": "wavelength_unit",
+    "unit_wavelength": "wavelength_unit",
+    "wavelength_units": "wavelength_unit",
+    "xunit": "wavelength_unit",
+    "xunits": "wavelength_unit",
+    "axis": "axis",
+    "specaxis": "axis",
+    "spectrum_type": "axis",
+    "range": "wavelength_range",
+    "wavelength_range": "wavelength_range",
+    "spectral_range": "wavelength_range",
+    "wave_range": "wavelength_range",
+    "coverage": "wavelength_range",
+    "lambda_min": "wavelength_start",
+    "lambda_max": "wavelength_end",
+    "start": "wavelength_start",
+    "end": "wavelength_end",
+    "date_obs": "observation_date",
+    "date-obs": "observation_date",
+    "dateobs": "observation_date",
+    "date": "observation_date",
+    "observation_date": "observation_date",
+    "utdate": "observation_date",
+    "utc": "observation_date",
+    "time": "observation_date",
+    "mjd": "mjd",
+    "observer_date": "observation_date",
+}
+
+UNIT_PATTERN = re.compile(r"\(([^)]+)\)|\[([^\]]+)\]")
+RANGE_NUMERIC = re.compile(r"[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?")
 
 
 def checksum_bytes(content: bytes) -> str:
@@ -14,45 +96,298 @@ def checksum_bytes(content: bytes) -> str:
     return hashlib.sha256(content).hexdigest()
 
 
-def _detect_columns(columns: Iterable[str]) -> tuple[str, str]:
-    wavelength = next((name for name in columns if "wave" in name.lower()), None)
-    flux = next(
-        (
-            name
-            for name in columns
-            if "intensity" in name.lower() or "flux" in name.lower()
-        ),
-        None,
-    )
-    if wavelength is None or flux is None:
-        raise ValueError("Missing wavelength or intensity/flux column in ASCII data")
-    return wavelength, flux
+def _normalise_header_key(key: str) -> str:
+    cleaned = key.strip().lower().replace("μ", "µ")
+    cleaned = re.sub(r"[^a-z0-9]+", "_", cleaned)
+    cleaned = re.sub(r"_+", "_", cleaned)
+    return cleaned.strip("_")
 
 
-def _infer_unit(column: str, assumed_unit: str) -> str:
-    label = column.lower()
-    if "nm" in label:
-        return "nm"
-    if "ang" in label or "å" in label:
-        return "Å"
-    return assumed_unit
+def _split_header_line(line: str) -> Optional[Tuple[str, str]]:
+    stripped = line.strip()
+    if not stripped:
+        return None
+    stripped = stripped.lstrip("#").strip()
+    if not stripped:
+        return None
+    for sep in (":", "=", "\t"):
+        if sep in stripped:
+            key, value = stripped.split(sep, 1)
+            return key.strip(), value.strip()
+    parts = stripped.split(None, 1)
+    if len(parts) == 2:
+        return parts[0].strip(), parts[1].strip()
+    return None
 
 
-def parse_ascii(fp, content_bytes: bytes, assumed_unit: str = "nm") -> Dict[str, object]:
+def _extract_unit_hint(text: Optional[str]) -> Optional[str]:
+    if not text:
+        return None
+    lowered = str(text).strip()
+    if not lowered:
+        return None
+    lowered = lowered.replace("μ", "µ")
+    candidates: List[str] = []
+    for match in UNIT_PATTERN.findall(lowered):
+        candidates.extend(filter(None, match))
+    pieces = re.split(r"[\s_\-\/]+", lowered)
+    candidates.extend(pieces)
+    for candidate in candidates:
+        norm = candidate.strip().lower()
+        if not norm:
+            continue
+        if "angstrom" in norm or norm in {"å", "a", "ångström", "ångstrom"}:
+            return "Å"
+        if norm in {"nm", "nanometer", "nanometers"}:
+            return "nm"
+        if norm in {"um", "µm", "micron", "microns", "micrometer", "micrometers"}:
+            return "µm"
+        if "cm" in norm and "-1" in norm:
+            return "cm^-1"
+        if norm in {"cm^-1", "cm-1"}:
+            return "cm^-1"
+        if "wavenumber" in norm:
+            return "cm^-1"
+    return None
+
+
+def _parse_range_value(value: str, default_unit: str) -> Optional[Tuple[float, float]]:
+    numbers = [float(part) for part in RANGE_NUMERIC.findall(value)]
+    if len(numbers) < 2:
+        return None
+    low, high = numbers[0], numbers[1]
+    if math.isclose(low, high):
+        return None
+    unit = _extract_unit_hint(value) or default_unit
+    try:
+        converted = to_nm([low, high], unit)
+    except Exception:
+        converted = [low, high]
+    low_nm, high_nm = float(min(converted)), float(max(converted))
+    if not math.isfinite(low_nm) or not math.isfinite(high_nm):
+        return None
+    return low_nm, high_nm
+
+
+def _collect_header_metadata(
+    header_lines: Sequence[str],
+) -> Tuple[Dict[str, object], Dict[str, str], List[str], Optional[str], Optional[str], Optional[str]]:
+    metadata: Dict[str, object] = {}
+    raw: Dict[str, str] = {}
+    label_candidates: List[str] = []
+    axis_hint: Optional[str] = None
+    wavelength_unit_hint: Optional[str] = None
+    flux_unit_hint: Optional[str] = None
+
+    for line in header_lines:
+        pair = _split_header_line(line)
+        if not pair:
+            continue
+        key, value = pair
+        value = value.strip().strip("'\"")
+        norm_key = _normalise_header_key(key)
+        if not norm_key:
+            continue
+        raw[norm_key] = value
+        alias = HEADER_ALIAS_MAP.get(norm_key, norm_key)
+        if alias == "instrument":
+            metadata.setdefault("instrument", value)
+        elif alias == "telescope":
+            metadata.setdefault("telescope", value)
+        elif alias == "target":
+            metadata.setdefault("target", value)
+            label_candidates.append(value)
+        elif alias == "source":
+            metadata.setdefault("source", value)
+            label_candidates.append(value)
+        elif alias == "title":
+            metadata.setdefault("title", value)
+            label_candidates.append(value)
+        elif alias == "observation_date":
+            metadata.setdefault("observation_date", value)
+        elif alias == "flux_unit":
+            metadata.setdefault("flux_unit", value)
+            metadata.setdefault("reported_flux_unit", value)
+            flux_unit_hint = flux_unit_hint or value
+        elif alias == "wavelength_unit":
+            metadata.setdefault("reported_wavelength_unit", value)
+            wavelength_unit_hint = wavelength_unit_hint or _extract_unit_hint(value)
+        elif alias == "axis":
+            metadata.setdefault("axis", value)
+            axis_hint = axis_hint or value
+        elif alias == "wavelength_range":
+            parsed = _parse_range_value(value, "nm")
+            if parsed:
+                metadata.setdefault("wavelength_effective_range_nm", list(parsed))
+        elif alias == "wavelength_start":
+            metadata.setdefault("wavelength_start", value)
+        elif alias == "wavelength_end":
+            metadata.setdefault("wavelength_end", value)
+        else:
+            metadata.setdefault(alias, value)
+
+    return metadata, raw, label_candidates, axis_hint, wavelength_unit_hint, flux_unit_hint
+
+
+def _detect_columns(df: pd.DataFrame) -> Tuple[str, str]:
+    columns = list(df.columns)
+    if len(columns) < 2:
+        raise ValueError("Missing wavelength or flux column in ASCII data")
+
+    wavelength = columns[0]
+    flux = columns[1]
+    for name in columns:
+        label = str(name).lower()
+        if any(keyword in label for keyword in ("wave", "lam", "freq", "wn")):
+            wavelength = name
+            break
+    for name in columns:
+        if name == wavelength:
+            continue
+        label = str(name).lower()
+        if any(keyword in label for keyword in ("flux", "int", "power", "counts", "brightness")):
+            flux = name
+            break
+    if wavelength == flux and len(columns) > 2:
+        flux = next(col for col in columns if col != wavelength)
+    return str(wavelength), str(flux)
+
+
+def _extract_flux_unit_from_label(label: str) -> Optional[str]:
+    matches = UNIT_PATTERN.findall(label)
+    for match in matches:
+        candidate = next((part for part in match if part), None)
+        if candidate:
+            cleaned = candidate.strip()
+            if cleaned:
+                return cleaned
+    return None
+
+
+def _normalise_flux_unit(unit: Optional[str]) -> Tuple[str, str]:
+    if not unit:
+        return "arb", "relative"
+    cleaned = unit.strip()
+    if not cleaned:
+        return "arb", "relative"
+    lowered = cleaned.lower()
+    relative_tokens = {"arb", "arbitrary", "adu", "counts", "count", "relative", "norm"}
+    if any(token in lowered for token in relative_tokens):
+        return cleaned, "relative"
+    return cleaned, "absolute"
+
+
+def _normalise_axis(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+    lowered = value.strip().lower()
+    if not lowered:
+        return None
+    if "abs" in lowered:
+        return "absorption"
+    if "trans" in lowered:
+        return "transmission"
+    if "reflec" in lowered:
+        return "reflection"
+    if "emiss" in lowered:
+        return "emission"
+    return value.strip()
+
+
+def parse_ascii(
+    dataframe: pd.DataFrame,
+    *,
+    content_bytes: bytes,
+    header_lines: Sequence[str] | None = None,
+    column_labels: Sequence[str] | None = None,
+    delimiter: Optional[str] = None,
+    filename: Optional[str] = None,
+    assumed_unit: str = "nm",
+    orientation: Optional[str] = None,
+) -> Dict[str, object]:
     """Parse a CSV/TXT spectrum into the normalised overlay payload format."""
 
-    df = pd.read_csv(fp)
-    wavelength_col, flux_col = _detect_columns(df.columns)
-    unit = _infer_unit(wavelength_col, assumed_unit)
+    header_lines = list(header_lines or [])
+    column_labels = list(column_labels or list(dataframe.columns))
 
-    wavelengths = to_nm(df[wavelength_col].tolist(), unit)
-    flux = df[flux_col].tolist()
+    metadata, raw_headers, label_candidates, axis_hint, header_unit_hint, header_flux_hint = _collect_header_metadata(
+        header_lines
+    )
+
+    provenance: Dict[str, object] = {
+        "format": "ascii",
+        "checksum": checksum_bytes(content_bytes),
+        "columns": list(column_labels),
+    }
+    if orientation:
+        provenance["orientation"] = orientation
+    if filename:
+        provenance["filename"] = filename
+    if delimiter:
+        provenance["delimiter"] = delimiter
+    if header_lines:
+        provenance["header_lines"] = [line for line in header_lines if line.strip()]
+    if raw_headers:
+        provenance["header_fields"] = raw_headers
+
+    wavelength_col, flux_col = _detect_columns(dataframe)
+    provenance["column_mapping"] = {"wavelength": wavelength_col, "flux": flux_col}
+
+    working = dataframe[[wavelength_col, flux_col]].copy()
+    working[wavelength_col] = pd.to_numeric(working[wavelength_col], errors="coerce")
+    working[flux_col] = pd.to_numeric(working[flux_col], errors="coerce")
+    working = working.dropna()
+    if working.empty:
+        raise ValueError("No numeric spectral samples available in ASCII data")
+
+    wavelength_label_unit = _extract_unit_hint(wavelength_col)
+    wavelength_unit = header_unit_hint or wavelength_label_unit or assumed_unit
+    provenance["unit_inference"] = {
+        "header": header_unit_hint,
+        "column": wavelength_label_unit,
+        "assumed": assumed_unit,
+    }
+
+    reported_wavelength_unit = wavelength_unit
+    try:
+        wavelength_nm = to_nm(working[wavelength_col].tolist(), wavelength_unit)
+    except ValueError:
+        wavelength_nm = to_nm(working[wavelength_col].tolist(), assumed_unit)
+        provenance.setdefault("unit_inference", {})["fallback"] = assumed_unit
+        wavelength_unit = assumed_unit
+    metadata.setdefault("reported_wavelength_unit", reported_wavelength_unit)
+
+    flux_values = working[flux_col].tolist()
+    flux_unit_label = header_flux_hint or metadata.get("flux_unit")
+    label_flux_unit = _extract_flux_unit_from_label(flux_col)
+    if label_flux_unit:
+        flux_unit_label = label_flux_unit
+    flux_unit, flux_kind = _normalise_flux_unit(flux_unit_label)
+    metadata["flux_unit"] = flux_unit
+
+    metadata["wavelength_range_nm"] = [float(min(wavelength_nm)), float(max(wavelength_nm))]
+    metadata.setdefault("wavelength_effective_range_nm", metadata["wavelength_range_nm"])
+    try:
+        metadata["original_wavelength_unit"] = canonical_unit(wavelength_unit)
+    except ValueError:
+        metadata["original_wavelength_unit"] = wavelength_unit
+    metadata.setdefault("points", len(wavelength_nm))
+
+    axis = _normalise_axis(axis_hint) or "emission"
+
+    provenance["samples"] = len(wavelength_nm)
+    provenance.setdefault("unit_inference", {})["resolved"] = wavelength_unit
+
+    label_hint = next((candidate for candidate in label_candidates if candidate), None)
 
     return {
-        "wavelength": wavelengths,
-        "flux": flux,
-        "unit_wavelength": "nm",
-        "unit_flux": "arb",
-        "meta": {"original_unit_wavelength": canonical_unit(unit)},
-        "checksum": checksum_bytes(content_bytes),
+        "label_hint": label_hint,
+        "wavelength_nm": [float(value) for value in wavelength_nm],
+        "flux": [float(value) for value in flux_values],
+        "flux_unit": flux_unit,
+        "flux_kind": flux_kind,
+        "metadata": metadata,
+        "provenance": provenance,
+        "axis": axis,
+        "kind": "spectrum",
     }

--- a/app/server/ingest_fits.py
+++ b/app/server/ingest_fits.py
@@ -1,11 +1,45 @@
 from __future__ import annotations
 
-from typing import Dict
+import io
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 from astropy.io import fits
 
+from .ingest_ascii import checksum_bytes  # reuse checksum helper
 from .units import to_nm
+
+
+HeaderInput = Union[str, Path, bytes]
+
+
+HEADER_METADATA_KEYS = {
+    "OBJECT": "target",
+    "TARGET": "target",
+    "SOURCE": "source",
+    "INSTRUME": "instrument",
+    "TELESCOP": "telescope",
+    "OBSERVAT": "telescope",
+    "DATE-OBS": "observation_date",
+    "DATE_OBS": "observation_date",
+    "TIME-OBS": "observation_time",
+    "MJD-OBS": "mjd",
+    "EXPTIME": "exposure",
+    "AIRMASS": "airmass",
+    "PROPOSID": "program",
+    "PROGRAM": "program",
+    "OBSERVER": "observer",
+    "PI": "principal_investigator",
+    "RA_TARG": "target_ra",
+    "DEC_TARG": "target_dec",
+    "SPECSYS": "spectral_reference",
+    "CTYPE1": "wavelength_axis_type",
+    "CUNIT1": "reported_wavelength_unit",
+    "BUNIT": "reported_flux_unit",
+    "BUNIT1": "reported_flux_unit",
+    "FLUXUNIT": "reported_flux_unit",
+}
 
 
 def _ensure_1d(array: np.ndarray) -> np.ndarray:
@@ -24,54 +58,393 @@ def _ensure_1d(array: np.ndarray) -> np.ndarray:
     )
 
 
-def parse_fits(path: str) -> Dict[str, object]:
+def _mask_to_bool(mask, size: int) -> np.ndarray:
+    if mask is np.ma.nomask or mask is False:
+        return np.zeros(size, dtype=bool)
+    arr = np.array(mask, dtype=bool).reshape(-1)
+    if arr.size >= size:
+        return arr[:size]
+    padded = np.zeros(size, dtype=bool)
+    padded[: arr.size] = arr
+    return padded
+
+
+def _detect_table_columns(names: Sequence[str]) -> Tuple[str, str]:
+    if len(names) < 2:
+        raise ValueError("FITS table must contain at least two columns for wavelength and flux")
+
+    wavelength = names[0]
+    flux = names[1]
+
+    for name in names:
+        label = name.lower()
+        if any(token in label for token in ("wave", "lam", "freq", "wn")):
+            wavelength = name
+            break
+
+    for name in names:
+        if name == wavelength:
+            continue
+        label = name.lower()
+        if any(token in label for token in ("flux", "int", "count", "power", "brightness")):
+            flux = name
+            break
+
+    if wavelength == flux:
+        for name in names:
+            if name != wavelength:
+                flux = name
+                break
+
+    return wavelength, flux
+
+
+def _column_unit(hdu, index: int, default: Optional[str] = None) -> Optional[str]:
+    try:
+        unit = hdu.columns[index].unit
+    except (AttributeError, IndexError, KeyError):  # pragma: no cover - defensive
+        unit = None
+    if unit:
+        return str(unit)
+    return hdu.header.get(f"TUNIT{index + 1}", default)
+
+
+def _extract_table_data(
+    hdu: Union[fits.BinTableHDU, fits.TableHDU]
+) -> Tuple[np.ndarray, np.ndarray, str, Optional[str], Optional[str], Dict[str, object]]:
+    data = hdu.data
+    if data is None or len(data) == 0:
+        raise ValueError("FITS table contains no rows for spectral ingestion.")
+
+    column_names = [str(name) for name in (hdu.columns.names or []) if name]
+    wavelength_col, flux_col = _detect_table_columns(column_names)
+
+    wavelength_data = np.ma.array(data[wavelength_col])
+    flux_data = np.ma.array(data[flux_col])
+
+    wavelength_values = _ensure_1d(np.array(np.ma.getdata(wavelength_data), dtype=float))
+    flux_values = _ensure_1d(np.array(np.ma.getdata(flux_data), dtype=float))
+
+    size = min(wavelength_values.size, flux_values.size)
+    wavelength_values = wavelength_values[:size]
+    flux_values = flux_values[:size]
+
+    wavelength_mask = _mask_to_bool(np.ma.getmaskarray(wavelength_data), size)
+    flux_mask = _mask_to_bool(np.ma.getmaskarray(flux_data), size)
+
+    valid = (~wavelength_mask) & (~flux_mask)
+    valid &= np.isfinite(wavelength_values) & np.isfinite(flux_values)
+
+    wavelength_values = wavelength_values[valid]
+    flux_values = flux_values[valid]
+
+    if wavelength_values.size == 0:
+        raise ValueError("FITS table ingestion yielded no valid spectral samples.")
+
+    column_index_map = {name: idx for idx, name in enumerate(column_names)}
+    wave_idx = column_index_map[wavelength_col]
+    flux_idx = column_index_map[flux_col]
+
+    wavelength_unit_hint = (
+        _column_unit(hdu, wave_idx)
+        or hdu.header.get("CUNIT1")
+        or hdu.header.get("XUNIT")
+    )
+
+    flux_unit_hint = (
+        _column_unit(hdu, flux_idx)
+        or hdu.header.get("BUNIT")
+        or hdu.header.get("BUNIT1")
+        or hdu.header.get("FLUXUNIT")
+    )
+
+    resolved_unit = _normalise_wavelength_unit(wavelength_unit_hint)
+    try:
+        wavelength_nm = np.array(to_nm(wavelength_values.tolist(), resolved_unit), dtype=float)
+    except ValueError:
+        wavelength_nm = np.array(to_nm(wavelength_values.tolist(), "nm"), dtype=float)
+        resolved_unit = "nm"
+
+    provenance: Dict[str, object] = {
+        "table_columns": column_names,
+        "column_mapping": {"wavelength": wavelength_col, "flux": flux_col},
+        "column_units": {
+            name: _column_unit(hdu, column_index_map[name])
+            for name in column_names
+        },
+        "mask_applied": bool(wavelength_mask.any() or flux_mask.any()),
+        "row_count": int(len(data)),
+    }
+
+    return wavelength_nm, flux_values, resolved_unit, wavelength_unit_hint, flux_unit_hint, provenance
+def _coerce_header_value(value):
+    if isinstance(value, bytes):
+        try:
+            return value.decode("utf-8", errors="ignore")
+        except Exception:
+            return value
+    if hasattr(value, "item"):
+        try:
+            return value.item()
+        except Exception:
+            return value
+    return value
+
+
+def _normalise_wavelength_unit(unit: Optional[str], default: str = "nm") -> str:
+    if not unit:
+        return default
+    text = str(unit).strip()
+    lowered = text.lower().replace("μ", "µ")
+    if "angstrom" in lowered or lowered in {"a", "å", "ångström", "ångstrom"}:
+        return "Å"
+    if lowered in {"nm", "nanometer", "nanometers"}:
+        return "nm"
+    if lowered in {"um", "µm", "micron", "microns", "micrometer", "micrometers"}:
+        return "µm"
+    if "cm" in lowered and "-1" in lowered:
+        return "cm^-1"
+    if lowered in {"cm^-1", "cm-1"}:
+        return "cm^-1"
+    return text
+
+
+def _normalise_flux_unit(unit: Optional[str]) -> Tuple[str, str]:
+    if not unit:
+        return "arb", "relative"
+    cleaned = str(unit).strip()
+    if not cleaned:
+        return "arb", "relative"
+    lowered = cleaned.lower()
+    relative_tokens = {"arb", "arbitrary", "adu", "counts", "count", "relative", "norm"}
+    if any(token in lowered for token in relative_tokens):
+        return cleaned, "relative"
+    return cleaned, "absolute"
+
+
+def _compute_wavelengths(
+    size: int,
+    header,
+) -> Tuple[np.ndarray, Dict[str, Optional[float]]]:
+    crval1 = header.get("CRVAL1")
+    cdelt1 = header.get("CDELT1", header.get("CD1_1"))
+    crpix1 = header.get("CRPIX1", 1.0)
+    missing = [
+        key
+        for key, value in (("CRVAL1", crval1), ("CDELT1", cdelt1))
+        if value is None
+    ]
+    if missing:
+        joined = ", ".join(missing)
+        raise ValueError(
+            f"Missing WCS keyword(s) {joined} in FITS header for spectral axis."
+        )
+
+    try:
+        crval1 = float(crval1)
+        cdelt1 = float(cdelt1)
+        crpix1 = float(crpix1)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Invalid WCS keyword value in FITS header.") from exc
+
+    pix = np.arange(size, dtype=float)
+    wavelengths = crval1 + (pix - (crpix1 - 1.0)) * cdelt1
+    meta = {
+        "crval1": crval1,
+        "cdelt1": cdelt1,
+        "crpix1": crpix1,
+    }
+    return wavelengths, meta
+
+
+def _open_hdul(
+    content: HeaderInput,
+    filename_hint: Optional[str] = None,
+) -> Tuple[fits.HDUList, Optional[str], Optional[bytes]]:
+    filename: Optional[str] = filename_hint
+    payload: Optional[bytes] = None
+
+    if isinstance(content, (str, Path)):
+        path = Path(content)
+        filename = path.name
+        payload = path.read_bytes()
+        hdul = fits.open(io.BytesIO(payload))
+    elif isinstance(content, bytes):
+        payload = content
+        hdul = fits.open(io.BytesIO(content))
+    else:
+        raise TypeError("Unsupported FITS input; provide a path or bytes-like object.")
+
+    return hdul, filename, payload
+
+
+def _gather_metadata(header, keys: Sequence[str]) -> Dict[str, object]:
+    metadata: Dict[str, object] = {}
+    for key in keys:
+        value = header.get(key)
+        if value is None:
+            continue
+        metadata[key] = _coerce_header_value(value)
+    return metadata
+
+
+def parse_fits(content: HeaderInput, *, filename: Optional[str] = None) -> Dict[str, object]:
     """Extract a spectrum from a FITS file into the normalised payload."""
 
-    with fits.open(path) as hdul:
-        data_hdu = next(
-            (hdu for hdu in hdul if getattr(hdu, "data", None) is not None),
-            None,
-        )
+    hdul, inferred_name, payload = _open_hdul(content, filename_hint=filename)
+    try:
+        data_hdu = None
+        data_index = None
+        for idx, hdu in enumerate(hdul):
+            if getattr(hdu, "data", None) is not None:
+                data_hdu = hdu
+                data_index = idx
+                break
         if data_hdu is None:
             raise ValueError("No array data found in FITS file.")
 
         header = data_hdu.header
-        raw_data = np.ma.getdata(data_hdu.data)
-        flux = _ensure_1d(np.array(raw_data, copy=True))
 
-        if flux.size == 0:
-            raise ValueError("FITS data array is empty.")
+        if isinstance(data_hdu, (fits.BinTableHDU, fits.TableHDU)):
+            (
+                wavelength_nm,
+                flux_array,
+                resolved_unit,
+                reported_wavelength_unit,
+                flux_unit_hint,
+                table_provenance,
+            ) = _extract_table_data(data_hdu)
+            unit_inference = {
+                "column": _coerce_header_value(reported_wavelength_unit) if reported_wavelength_unit else None,
+                "resolved": resolved_unit,
+            }
+            mask_flag = bool(table_provenance.get("mask_applied", False))
+            data_mode = "table"
+            provenance_details = table_provenance
+        else:
+            masked = np.ma.array(data_hdu.data)
+            flux_array = _ensure_1d(np.array(np.ma.getdata(masked), dtype=float))
+            mask_array = np.ma.getmaskarray(masked)
+            if mask_array is np.ma.nomask or np.isscalar(mask_array):
+                mask_flat = np.zeros_like(flux_array, dtype=bool)
+            else:
+                mask_flat = np.array(mask_array, dtype=bool).reshape(flux_array.shape)
 
-        crval1 = header.get("CRVAL1")
-        cdelt1 = header.get("CDELT1")
-        missing = [
-            key
-            for key, value in (("CRVAL1", crval1), ("CDELT1", cdelt1))
-            if value is None
-        ]
-        if missing:
-            joined = ", ".join(missing)
-            raise ValueError(
-                f"Missing WCS keyword(s) {joined} in FITS header for spectral axis."
+            if flux_array.size == 0:
+                raise ValueError("FITS data array is empty.")
+
+            wavelengths_raw, wcs_meta = _compute_wavelengths(flux_array.size, header)
+            resolved_unit = _normalise_wavelength_unit(header.get("CUNIT1") or header.get("XUNIT"))
+
+            wavelength_nm = np.array(to_nm(wavelengths_raw.tolist(), resolved_unit), dtype=float)
+
+            valid = (~mask_flat) & np.isfinite(flux_array) & np.isfinite(wavelength_nm)
+            flux_array = flux_array[valid]
+            wavelength_nm = wavelength_nm[valid]
+            if flux_array.size == 0:
+                raise ValueError("FITS ingestion yielded no valid samples after masking.")
+
+            flux_unit_hint = (
+                header.get("BUNIT")
+                or header.get("BUNIT1")
+                or header.get("FLUXUNIT")
             )
+            unit_inference = {
+                "header": _coerce_header_value(header.get("CUNIT1") or header.get("XUNIT")),
+                "resolved": resolved_unit,
+            }
+            mask_flag = bool(mask_flat.any())
+            data_mode = "image"
+            provenance_details = {
+                "wcs": wcs_meta,
+            }
+            reported_wavelength_unit = header.get("CUNIT1") or header.get("XUNIT")
 
-        try:
-            crval1 = float(crval1)
-            cdelt1 = float(cdelt1)
-            crpix1 = float(header.get("CRPIX1", 1.0))
-        except (TypeError, ValueError) as exc:
-            raise ValueError("Invalid WCS keyword value in FITS header.") from exc
+        flux_unit, flux_kind = _normalise_flux_unit(flux_unit_hint)
 
-        unit = header.get("CUNIT1", "nm")
+        metadata: Dict[str, object] = {
+            "wavelength_range_nm": [float(np.min(wavelength_nm)), float(np.max(wavelength_nm))],
+            "wavelength_effective_range_nm": [float(np.min(wavelength_nm)), float(np.max(wavelength_nm))],
+            "points": int(flux_array.size),
+            "flux_unit": flux_unit,
+            "reported_flux_unit": _coerce_header_value(flux_unit_hint) if flux_unit_hint else None,
+            "reported_wavelength_unit": _coerce_header_value(reported_wavelength_unit) if reported_wavelength_unit else None,
+        }
+        metadata["original_wavelength_unit"] = resolved_unit
 
-        pix = np.arange(flux.size, dtype=float)
-        wavelengths = crval1 + (pix - (crpix1 - 1.0)) * cdelt1
-        wavelength_nm = to_nm(wavelengths.tolist(), unit)
+        if flux_array.size >= 2:
+            metadata["wavelength_step_nm"] = float(wavelength_nm[1] - wavelength_nm[0])
+
+        header_snapshot = _gather_metadata(header, HEADER_METADATA_KEYS.keys())
+        for key, meta_key in HEADER_METADATA_KEYS.items():
+            value = header_snapshot.get(key)
+            if value is None:
+                continue
+            metadata.setdefault(meta_key, value)
+
+        metadata.setdefault("wavelength_axis_type", header.get("CTYPE1"))
+        metadata.setdefault("spectral_reference", header.get("SPECSYS"))
+
+        label_candidates: List[str] = []
+        for field in ("target", "source"):
+            value = metadata.get(field)
+            if isinstance(value, str) and value.strip():
+                label_candidates.append(value.strip())
+
+        label_hint = next((candidate for candidate in label_candidates if candidate), None)
+
+        provenance_details.setdefault("data_mode", data_mode)
+        filtered_unit_inference = {k: v for k, v in unit_inference.items() if v is not None}
+
+        provenance: Dict[str, object] = {
+            "format": "fits",
+            "hdu_index": data_index,
+            "hdu_name": getattr(data_hdu, "name", ""),
+            "mask_applied": mask_flag,
+            "data_mode": data_mode,
+            "samples": int(flux_array.size),
+        }
+        if filtered_unit_inference:
+            provenance["unit_inference"] = filtered_unit_inference
+        provenance.update(provenance_details)
+
+        if payload is not None:
+            provenance["checksum"] = checksum_bytes(payload)
+        if inferred_name:
+            provenance["filename"] = inferred_name
+
+        interesting_cards = [
+            "OBJECT",
+            "INSTRUME",
+            "TELESCOP",
+            "DATE-OBS",
+            "DATE_OBS",
+            "EXPTIME",
+            "AIRMASS",
+            "PROPOSID",
+            "OBSERVER",
+            "BUNIT",
+            "CUNIT1",
+            "CTYPE1",
+        ]
+        provenance["header"] = {
+            key: _coerce_header_value(header.get(key))
+            for key in interesting_cards
+            if header.get(key) is not None
+        }
+
+        axis = "emission"
 
         return {
-            "wavelength": wavelength_nm,
-            "flux": flux.tolist(),
-            "unit_wavelength": "nm",
-            "unit_flux": "arb",
-            "meta": {"original_unit_wavelength": unit},
+            "label_hint": label_hint,
+            "wavelength_nm": [float(value) for value in wavelength_nm.tolist()],
+            "flux": [float(value) for value in flux_array.tolist()],
+            "flux_unit": flux_unit,
+            "flux_kind": flux_kind,
+            "metadata": metadata,
+            "provenance": provenance,
+            "axis": axis,
+            "kind": "spectrum",
         }
+    finally:
+        hdul.close()

--- a/app/server/units.py
+++ b/app/server/units.py
@@ -1,25 +1,113 @@
-SUPPORTED = {'nm':1.0, 'Å':0.1, 'A':0.1, 'um':1000.0, 'µm':1000.0}
+from __future__ import annotations
 
-_ANGSTROM_WORDS = {'angstrom', 'ångström', 'ångstrom'}
-_ANGSTROM_SYMBOLS = {'Å', 'A', 'å'}
+from typing import Callable, Iterable, List
 
 
-def _normalize_unit(unit: str) -> str:
-    """Return the canonical key used for wavelength unit comparisons."""
-    trimmed = unit.strip()
-    casefolded = trimmed.casefold()
-    casefolded = casefolded.replace('μ', 'µ')
-    if casefolded in _ANGSTROM_WORDS or trimmed in _ANGSTROM_SYMBOLS or casefolded == 'å':
-        return 'Å'
-    return casefolded
+def _normalise_lookup_key(unit: str) -> str:
+    cleaned = unit.strip()
+    if not cleaned:
+        raise ValueError("Empty unit provided")
+    return cleaned.casefold().replace("μ", "µ")
 
-def to_nm(values, unit: str):
-    u = _normalize_unit(unit)
-    if u not in SUPPORTED:
-        raise ValueError(f'Unsupported wavelength unit: {unit}')
-    scale = SUPPORTED[u]
-    return [v*scale for v in values]
+
+_UNIT_ALIASES: dict[str, str] = {
+    "nm": "nm",
+    "nanometer": "nm",
+    "nanometers": "nm",
+    "nanometre": "nm",
+    "nanometres": "nm",
+    "nan": "nm",
+    "angstrom": "Å",
+    "ångström": "Å",
+    "ångstrom": "Å",
+    "å": "Å",
+    "a": "Å",
+    "aa": "Å",
+    "ang": "Å",
+    "µm": "µm",
+    "um": "µm",
+    "micron": "µm",
+    "microns": "µm",
+    "micrometer": "µm",
+    "micrometers": "µm",
+    "micrometre": "µm",
+    "micrometres": "µm",
+    "millimeter": "mm",
+    "millimetre": "mm",
+    "millimeters": "mm",
+    "millimetres": "mm",
+    "mm": "mm",
+    "centimeter": "cm",
+    "centimetre": "cm",
+    "centimeters": "cm",
+    "centimetres": "cm",
+    "cm": "cm",
+    "meter": "m",
+    "metre": "m",
+    "meters": "m",
+    "metres": "m",
+    "m": "m",
+    "pm": "pm",
+    "picometer": "pm",
+    "picometre": "pm",
+    "picometers": "pm",
+    "picometres": "pm",
+    "in": "in",
+    "inch": "in",
+    "inches": "in",
+    "cm^-1": "cm^-1",
+    "cm-1": "cm^-1",
+    "1/cm": "cm^-1",
+    "cm**-1": "cm^-1",
+    "wavenumber": "cm^-1",
+    "spatialfrequency": "cm^-1",
+}
+
+
+def _canonicalise(unit: str) -> str:
+    lookup = _normalise_lookup_key(unit)
+    if lookup in _UNIT_ALIASES:
+        return _UNIT_ALIASES[lookup]
+    raise ValueError(f"Unsupported wavelength unit: {unit}")
+
+
+_LINEAR_SCALE: dict[str, float] = {
+    "nm": 1.0,
+    "Å": 0.1,
+    "µm": 1000.0,
+    "mm": 1_000_000.0,
+    "cm": 10_000_000.0,
+    "m": 1_000_000_000.0,
+    "pm": 0.001,
+    "in": 25_400_000.0,
+}
+
+
+def _convert_linear(values: Iterable[float], scale: float) -> List[float]:
+    return [float(value) * scale for value in values]
+
+
+def _cm_to_nm(value: float) -> float:
+    if value == 0:
+        raise ValueError("Cannot convert a zero wavenumber to wavelength")
+    return 1.0e7 / float(value)
+
+
+_SPECIAL_CONVERTERS: dict[str, Callable[[Iterable[float]], List[float]]] = {
+    "cm^-1": lambda vals: [_cm_to_nm(float(value)) for value in vals],
+}
+
+
+def to_nm(values: Iterable[float], unit: str) -> List[float]:
+    canonical = canonical_unit(unit)
+    if canonical in _LINEAR_SCALE:
+        return _convert_linear(values, _LINEAR_SCALE[canonical])
+    if canonical in _SPECIAL_CONVERTERS:
+        converter = _SPECIAL_CONVERTERS[canonical]
+        return converter(values)
+    raise ValueError(f"Unsupported wavelength unit: {unit}")
+
 
 def canonical_unit(unit: str) -> str:
-    return _normalize_unit(unit)
-
+    canonical = _canonicalise(unit)
+    return canonical

--- a/app/utils/io_readers.py
+++ b/app/utils/io_readers.py
@@ -1,38 +1,261 @@
 from __future__ import annotations
-import io, csv, re
-import pandas as pd
-import numpy as np
 
-NUM_RE = re.compile(r'^\s*[-+]?(\d+\.?\d*|\.\d+)([eE][-+]?\d+)?\s*$')
+import csv
+import io
+import re
+from typing import Dict, List, NamedTuple, Sequence, Tuple, Union
+
+import pandas as pd
+
+
+NUM_RE = re.compile(r"^\s*[-+]?(\d+\.?\d*|\.\d+)([eE][-+]?\d+)?\s*$")
+NUMERIC_TOKEN_RE = re.compile(r"[-+]?(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?")
+
+
+class TableReadResult(NamedTuple):
+    """Container describing the parsed table and any leading headers."""
+
+    dataframe: pd.DataFrame
+    header_lines: List[str]
+    column_labels: List[str]
+    delimiter: str
+    orientation: str
+
 
 def sniff_delimiter(sample: str) -> str:
-    dialect = csv.Sniffer().sniff(sample, delimiters=",\t;| ")
-    return dialect.delimiter
+    try:
+        dialect = csv.Sniffer().sniff(sample, delimiters=",\t;| ")
+        return dialect.delimiter
+    except csv.Error:
+        return ","
 
-def find_header_start(lines):
-    # Find first line with at least two numeric-like tokens when split by common delims
-    for i, line in enumerate(lines):
-        for delim in [",","\t",";","|"," "]:
-            toks = [t for t in line.strip().split(delim) if t!=""]
-            if len(toks) >= 2 and NUM_RE.match(toks[0] or "") and NUM_RE.match(toks[1] or ""):
-                return i
+
+def find_header_start(lines: Sequence[str]) -> int:
+    """Return the index of the first numeric row inside ``lines``."""
+
+    for index, line in enumerate(lines):
+        for delim in [",", "\t", ";", "|", " "]:
+            tokens = [token for token in line.strip().split(delim) if token != ""]
+            if len(tokens) < 2:
+                continue
+            if NUM_RE.match(tokens[0] or "") and NUM_RE.match(tokens[1] or ""):
+                return index
     return 0
 
-def read_table(file_bytes: bytes):
-    # Try fast path
-    bio = io.BytesIO(file_bytes)
-    text = bio.read().decode("utf-8", errors="ignore")
+
+def _parse_column_labels(line: str, delimiter: str) -> List[str]:
+    """Attempt to extract column labels from a header row."""
+
+    stripped = line.strip().lstrip("#").strip()
+    if not stripped:
+        return []
+    tokens = [token.strip() for token in stripped.split(delimiter)]
+    tokens = [token for token in tokens if token]
+    if len(tokens) < 2:
+        return []
+    if all(NUM_RE.match(token) for token in tokens[:2]):
+        return []
+    return tokens
+
+
+def _extract_numeric_tokens(text: str) -> List[float]:
+    numbers: List[float] = []
+    for token in NUMERIC_TOKEN_RE.findall(text):
+        try:
+            numbers.append(float(token))
+        except ValueError:
+            continue
+    return numbers
+
+
+def _normalise_vertical_label(label: str, seen: Dict[str, int]) -> str:
+    cleaned = label.strip().lstrip("#").strip()
+    cleaned = cleaned.rstrip(":")
+    cleaned = re.sub(r"\s+", " ", cleaned)
+    if not cleaned:
+        cleaned = "column"
+    base = cleaned
+    counter = seen.get(base, 0)
+    if counter:
+        cleaned = f"{base}_{counter + 1}"
+    seen[base] = counter + 1
+    return cleaned
+
+
+def _parse_vertical_series(lines: Sequence[str]) -> Tuple[pd.DataFrame, List[str]] | None:
+    sections: List[Tuple[str, List[float]]] = []
+    current_label: str | None = None
+    current_values: List[float] = []
+
+    for raw in lines:
+        stripped = raw.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("#"):
+            stripped = stripped.lstrip("#").strip()
+            if not stripped:
+                continue
+
+        label_part: str | None = None
+        numeric_fragment: str = stripped
+
+        for separator in (":", "="):
+            if separator in stripped:
+                left, right = stripped.split(separator, 1)
+                if any(char.isalpha() for char in left):
+                    label_part = left.strip()
+                    numeric_fragment = right.strip()
+                    break
+
+        match = NUMERIC_TOKEN_RE.search(stripped)
+        if label_part is None and match:
+            prefix = stripped[: match.start()]
+            if any(char.isalpha() for char in prefix):
+                label_part = prefix.strip()
+                numeric_fragment = stripped[match.start() :]
+
+        tokens = _extract_numeric_tokens(numeric_fragment)
+
+        if label_part is not None:
+            if current_label and current_values:
+                sections.append((current_label, current_values.copy()))
+            current_label = label_part.strip().rstrip(":")
+            current_values = []
+            if tokens:
+                current_values.extend(tokens)
+            continue
+
+        if tokens:
+            if current_label is None:
+                continue
+            current_values.extend(tokens)
+            continue
+
+        if any(char.isalpha() for char in stripped):
+            if current_label and current_values:
+                sections.append((current_label, current_values.copy()))
+            current_label = stripped
+            current_values = []
+
+    if current_label and current_values:
+        sections.append((current_label, current_values.copy()))
+
+    filtered = [(label, values) for label, values in sections if len(values) >= 2]
+    if len(filtered) < 2:
+        return None
+
+    min_length = min(len(values) for _, values in filtered)
+    seen_labels: Dict[str, int] = {}
+    data: Dict[str, List[float]] = {}
+    column_labels: List[str] = []
+
+    for label, values in filtered:
+        normalised = _normalise_vertical_label(label, seen_labels)
+        truncated = [float(value) for value in values[:min_length]]
+        data[normalised] = truncated
+        column_labels.append(normalised)
+
+    dataframe = pd.DataFrame.from_dict(data, orient="columns")
+    dataframe = dataframe.dropna().reset_index(drop=True)
+
+    if dataframe.shape[1] < 2 or dataframe.empty:
+        return None
+
+    return dataframe, column_labels
+
+
+def read_table(
+    file_bytes: bytes,
+    *,
+    include_header: bool = False,
+) -> Union[pd.DataFrame, TableReadResult]:
+    """Parse tabular ASCII spectral data into a dataframe.
+
+    Parameters
+    ----------
+    file_bytes:
+        Raw file payload.
+    include_header:
+        When ``True`` the return value includes any leading header lines and the
+        detected delimiter in addition to the dataframe.
+    """
+
+    text = io.BytesIO(file_bytes).read().decode("utf-8", errors="ignore")
     lines = text.splitlines()
-    start = find_header_start(lines)
-    sample = "\n".join(lines[start:start+10])
-    delim = sniff_delimiter(sample) if sample.strip() else ","
-    data = "\n".join(lines[start:])
-    df = pd.read_csv(io.StringIO(data), sep=delim, engine="python", comment="#", skip_blank_lines=True, header=None)
-    # Ensure at least 2 columns
-    if df.shape[1] < 2:
-        raise ValueError("Expected at least 2 columns (wavelength, intensity).")
-    # Coerce numeric
-    df[df.columns[0]] = pd.to_numeric(df[df.columns[0]], errors="coerce")
-    df[df.columns[1]] = pd.to_numeric(df[df.columns[1]], errors="coerce")
-    df = df.dropna().reset_index(drop=True)
-    return df
+    if not lines:
+        raise ValueError("No content available for table parsing.")
+
+    start_index = find_header_start(lines)
+    header_lines = lines[:start_index]
+
+    data_start = start_index
+    if start_index == 0:
+        prefix: List[str] = []
+        for line in lines:
+            stripped = line.strip()
+            if not stripped or stripped.startswith(("#", "!", ";")):
+                prefix.append(line)
+                continue
+            break
+        header_lines = prefix
+        data_start = len(prefix)
+
+    data_lines = lines[data_start:]
+    if not any(line.strip() for line in data_lines):
+        raise ValueError("No data rows detected in the ASCII table.")
+
+    sample = "\n".join(data_lines[:10])
+    delimiter = sniff_delimiter(sample) if sample.strip() else ","
+
+    column_labels: List[str] = []
+    if data_start > 0 and data_start <= len(lines):
+        header_index = data_start - 1
+        if header_index >= 0:
+            column_labels = _parse_column_labels(lines[header_index], delimiter)
+
+    orientation = "row"
+    parse_error: Exception | None = None
+
+    try:
+        dataframe = pd.read_csv(
+            io.StringIO("\n".join(data_lines)),
+            sep=delimiter,
+            engine="python",
+            comment="#",
+            skip_blank_lines=True,
+            header=None,
+        )
+        if dataframe.shape[1] < 2:
+            raise ValueError("Expected at least two columns (wavelength and flux).")
+
+        if column_labels and len(column_labels) >= dataframe.shape[1]:
+            dataframe.columns = column_labels[: dataframe.shape[1]]
+        else:
+            dataframe.columns = [str(col) for col in dataframe.columns]
+            column_labels = list(dataframe.columns)
+
+        numeric_cols = dataframe.columns[:2]
+        for column in numeric_cols:
+            dataframe[column] = pd.to_numeric(dataframe[column], errors="coerce")
+
+        dataframe = dataframe.dropna(subset=list(numeric_cols)).reset_index(drop=True)
+        if dataframe.empty:
+            raise ValueError("No numeric samples found in the ASCII table.")
+    except Exception as exc:
+        parse_error = exc
+        column_labels = []
+        dataframe = None  # type: ignore[assignment]
+
+    if parse_error or dataframe is None:
+        vertical = _parse_vertical_series(data_lines)
+        if not vertical:
+            raise parse_error if parse_error else ValueError("Unable to parse ASCII spectral table.")
+        dataframe, column_labels = vertical
+        delimiter = "vertical"
+        orientation = "columnar"
+    else:
+        orientation = "row"
+
+    if include_header:
+        return TableReadResult(dataframe, header_lines, column_labels, delimiter, orientation)
+    return dataframe

--- a/app/utils/local_ingest.py
+++ b/app/utils/local_ingest.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import gzip
+from pathlib import Path
+from typing import Dict, Mapping, Optional, Tuple
+
+from app.server.ingest_ascii import parse_ascii
+from app.server.ingest_fits import parse_fits
+from app.utils.io_readers import read_table
+
+
+SUPPORTED_ASCII_EXTENSIONS = {
+    ".txt",
+    ".text",
+    ".csv",
+    ".tsv",
+    ".ssv",
+    ".dat",
+    ".data",
+    ".tbl",
+    ".tab",
+    ".table",
+    ".ascii",
+    ".rdb",
+    ".ecsv",
+    ".log",
+    ".out",
+    ".spe",
+    ".spec",
+    ".spectrum",
+}
+
+SUPPORTED_FITS_EXTENSIONS = {".fits", ".fit", ".fts"}
+
+
+class LocalIngestError(RuntimeError):
+    """Raised when local spectra ingestion fails."""
+
+
+def _detect_format(name: str, content: bytes) -> str:
+    path = Path(name.lower())
+    suffixes = path.suffixes or [path.suffix]
+    if any(suffix in SUPPORTED_FITS_EXTENSIONS for suffix in suffixes):
+        return "fits"
+    signature = content[:6].upper()
+    if signature.startswith(b"SIMPLE"):
+        return "fits"
+    if any(suffix in SUPPORTED_ASCII_EXTENSIONS for suffix in suffixes if suffix):
+        return "ascii"
+    try:
+        content.decode("utf-8")
+    except UnicodeDecodeError as exc:  # pragma: no cover - defensive path
+        if signature.startswith(b"SIMPLE"):
+            return "fits"
+        raise LocalIngestError(f"Unable to determine file format for {name}.") from exc
+    return "ascii"
+
+
+def _clean_mapping(mapping: Mapping[str, object]) -> Dict[str, object]:
+    cleaned: Dict[str, object] = {}
+    for key, value in mapping.items():
+        if value is None:
+            continue
+        if isinstance(value, list):
+            filtered = [item for item in value if item is not None]
+            if filtered:
+                cleaned[key] = filtered
+            continue
+        cleaned[key] = value
+    return cleaned
+
+
+def _choose_label(name: str, parsed: Mapping[str, object]) -> str:
+    metadata = parsed.get("metadata") or {}
+    candidates = [
+        parsed.get("label_hint"),
+        metadata.get("target"),
+        metadata.get("source"),
+        metadata.get("title"),
+        Path(name).stem,
+    ]
+    for candidate in candidates:
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate.strip()
+    return Path(name).stem or "Spectrum"
+
+
+def _build_summary(sample_count: int, metadata: Mapping[str, object], flux_unit: str) -> str:
+    parts = [f"{sample_count} samples"]
+    wavelength_range = metadata.get("wavelength_range_nm")
+    if isinstance(wavelength_range, (list, tuple)) and len(wavelength_range) == 2:
+        try:
+            low, high = float(wavelength_range[0]), float(wavelength_range[1])
+        except (TypeError, ValueError):  # pragma: no cover - defensive
+            pass
+        else:
+            parts.append(f"{low:.2f}–{high:.2f} nm")
+    if flux_unit:
+        parts.append(f"Flux: {flux_unit}")
+    instrument = metadata.get("instrument")
+    if isinstance(instrument, str) and instrument.strip():
+        parts.append(instrument.strip())
+    observation = metadata.get("observation_date")
+    if isinstance(observation, str) and observation.strip():
+        parts.append(observation.strip())
+    return " • ".join(parts)
+
+
+def _maybe_decompress(name: str, content: bytes) -> Tuple[str, bytes, Optional[Dict[str, object]]]:
+    path = Path(name)
+    suffixes = [suffix.lower() for suffix in path.suffixes]
+    if suffixes and suffixes[-1] in {".gz", ".gzip"}:
+        try:
+            decompressed = gzip.decompress(content)
+        except OSError as exc:
+            raise LocalIngestError(f"Failed to decompress {name}: {exc}") from exc
+        inner_name = path.with_suffix("").name or name
+        info: Dict[str, object] = {
+            "original_size": len(content),
+            "decompressed_size": len(decompressed),
+        }
+        info.setdefault("algorithm", "gzip")
+        return inner_name, decompressed, info
+    return name, content, None
+
+
+def ingest_local_file(name: str, content: bytes) -> Dict[str, object]:
+    """Parse a user-provided spectrum into an overlay payload."""
+
+    if not content:
+        raise LocalIngestError(f"{name} is empty; nothing to ingest.")
+
+    original_name = name
+    processed_name, payload, compression = _maybe_decompress(name, content)
+
+    detected_format = _detect_format(processed_name, payload)
+
+    try:
+        if detected_format == "fits":
+            parsed = parse_fits(payload, filename=processed_name)
+        else:
+            table = read_table(payload, include_header=True)
+            parsed = parse_ascii(
+                table.dataframe,
+                content_bytes=payload,
+                header_lines=table.header_lines,
+                column_labels=table.column_labels,
+                delimiter=table.delimiter,
+                filename=processed_name,
+                orientation=getattr(table, "orientation", None),
+            )
+    except Exception as exc:
+        raise LocalIngestError(f"Failed to ingest {original_name}: {exc}") from exc
+
+    metadata = _clean_mapping(dict(parsed.get("metadata") or {}))
+    provenance = dict(parsed.get("provenance") or {})
+    metadata.setdefault("source", "local upload")
+    metadata.setdefault("filename", original_name)
+    provenance.setdefault("filename", processed_name)
+    if processed_name != original_name:
+        provenance.setdefault("source_filename", original_name)
+    if compression:
+        metadata.setdefault("compression", compression)
+        provenance.setdefault("compression", compression)
+    ingest_info = provenance.setdefault(
+        "ingest",
+        {"method": "local_upload", "format": detected_format},
+    )
+    if compression:
+        ingest_info["compression"] = compression
+
+    label = _choose_label(original_name, parsed)
+    flux_unit = str(parsed.get("flux_unit") or "arb")
+    summary = parsed.get("summary") or _build_summary(
+        len(parsed.get("wavelength_nm") or []), metadata, flux_unit
+    )
+
+    payload = {
+        "label": label,
+        "provider": "LOCAL",
+        "summary": summary,
+        "wavelength_nm": parsed.get("wavelength_nm") or [],
+        "flux": parsed.get("flux") or [],
+        "flux_unit": flux_unit,
+        "flux_kind": parsed.get("flux_kind") or "relative",
+        "metadata": metadata,
+        "provenance": provenance,
+        "kind": parsed.get("kind", "spectrum"),
+        "axis": parsed.get("axis", "emission"),
+    }
+
+    return payload

--- a/tests/server/test_ingest_fits.py
+++ b/tests/server/test_ingest_fits.py
@@ -29,7 +29,9 @@ def test_parse_fits_uses_first_data_extension(tmp_path):
     expected_wavelength = [400.0 + 0.5 * i for i in range(flux_values.size)]
 
     assert result["flux"] == flux_values.tolist()
-    assert result["wavelength"] == expected_wavelength
-    assert result["unit_wavelength"] == "nm"
-    assert result["meta"]["original_unit_wavelength"] == "nm"
-    assert result["unit_flux"] == "arb"
+    assert result["wavelength_nm"] == expected_wavelength
+    assert result["flux_unit"] == "arb"
+    assert result["flux_kind"] == "relative"
+    assert result["metadata"]["original_wavelength_unit"] == "nm"
+    assert result["metadata"]["wavelength_range_nm"] == [400.0, 401.0]
+    assert result["provenance"]["data_mode"] == "image"

--- a/tests/server/test_local_ingest.py
+++ b/tests/server/test_local_ingest.py
@@ -1,0 +1,199 @@
+import gzip
+import io
+from textwrap import dedent
+
+import numpy as np
+import pytest
+from astropy.io import fits
+
+from app.utils.local_ingest import ingest_local_file
+
+
+def test_ingest_local_ascii_populates_metadata():
+    content = dedent(
+        """
+        # Instrument: ExampleSpec
+        # Telescope: ExampleScope
+        # Date-Obs: 2023-08-01T12:34:56Z
+        # Target: Vega
+        # Flux Units: 10^-16 erg/s/cm^2/Å
+        Wavelength (Angstrom),Flux (10^-16 erg/s/cm^2/Å)
+        5000,1.2
+        5005,1.5
+        """
+    ).encode("utf-8")
+
+    payload = ingest_local_file("example.csv", content)
+
+    assert payload["label"] == "Vega"
+    assert payload["provider"] == "LOCAL"
+    assert payload["flux_unit"] == "10^-16 erg/s/cm^2/Å"
+    assert payload["flux_kind"] == "absolute"
+    assert payload["wavelength_nm"] == [500.0, 500.5]
+    assert payload["flux"] == [1.2, 1.5]
+
+    metadata = payload["metadata"]
+    assert metadata["instrument"] == "ExampleSpec"
+    assert metadata["telescope"] == "ExampleScope"
+    assert metadata["observation_date"] == "2023-08-01T12:34:56Z"
+    assert metadata["target"] == "Vega"
+    assert metadata["wavelength_range_nm"] == [500.0, 500.5]
+    assert metadata["filename"] == "example.csv"
+
+    provenance = payload["provenance"]
+    assert provenance["format"] == "ascii"
+    assert provenance["filename"] == "example.csv"
+    assert provenance["orientation"] == "row"
+    assert provenance["ingest"]["method"] == "local_upload"
+
+    summary = payload["summary"]
+    assert "2 samples" in summary
+    assert "500.00–500.50 nm" in summary
+    assert "Flux: 10^-16 erg/s/cm^2/Å" in summary
+
+
+def test_ingest_local_ascii_vertical_layout():
+    content = dedent(
+        """
+        # Instrument: ColumnScope
+        Wavelength (nm):
+        500
+        505
+        510
+
+        Flux (counts)
+        10
+        20
+        30
+        """
+    ).encode("utf-8")
+
+    payload = ingest_local_file("vertical.txt", content)
+
+    assert payload["wavelength_nm"] == [500.0, 505.0, 510.0]
+    assert payload["flux"] == [10.0, 20.0, 30.0]
+    assert payload["flux_unit"] == "counts"
+    assert payload["flux_kind"] == "relative"
+
+    metadata = payload["metadata"]
+    assert metadata["instrument"] == "ColumnScope"
+    assert metadata["filename"] == "vertical.txt"
+
+    provenance = payload["provenance"]
+    assert provenance["orientation"] == "columnar"
+
+
+def test_ingest_local_ascii_wavenumber_converts_to_nm():
+    content = dedent(
+        """
+        # Target: SampleStar
+        Wavenumber (cm^-1),Flux
+        20000,1.0
+        10000,0.5
+        """
+    ).encode("utf-8")
+
+    payload = ingest_local_file("wavenumber.csv", content)
+
+    assert payload["wavelength_nm"] == [500.0, 1000.0]
+    metadata = payload["metadata"]
+    assert metadata["original_wavelength_unit"] == "cm^-1"
+    assert metadata["reported_wavelength_unit"] == "cm^-1"
+
+
+def test_ingest_local_ascii_gzip_round_trip():
+    content = gzip.compress(
+        dedent(
+            """
+            Wavelength (nm),Flux
+            400,1.0
+            405,0.5
+            """
+        ).encode("utf-8")
+    )
+
+    payload = ingest_local_file("compressed.csv.gz", content)
+
+    metadata = payload["metadata"]
+    provenance = payload["provenance"]
+
+    assert metadata["filename"] == "compressed.csv.gz"
+    assert provenance["filename"] == "compressed.csv"
+    assert provenance["source_filename"] == "compressed.csv.gz"
+    assert provenance["ingest"]["compression"]["algorithm"] == "gzip"
+    assert metadata["compression"]["algorithm"] == "gzip"
+
+
+def test_ingest_local_fits_enriches_metadata():
+    flux_values = np.array([1.0, 2.0, 3.0], dtype=float)
+
+    sci_header = fits.Header()
+    sci_header["CRVAL1"] = 4000.0
+    sci_header["CDELT1"] = 2.0
+    sci_header["CRPIX1"] = 1.0
+    sci_header["CUNIT1"] = "Angstrom"
+    sci_header["BUNIT"] = "Jy"
+    sci_header["OBJECT"] = "TestObj"
+    sci_header["INSTRUME"] = "SpecX"
+    sci_header["TELESCOP"] = "ScopeY"
+    sci_header["DATE-OBS"] = "2023-03-01T00:00:00"
+
+    sci_hdu = fits.ImageHDU(data=flux_values, header=sci_header, name="SCI")
+    hdul = fits.HDUList([fits.PrimaryHDU(), sci_hdu])
+    bio = io.BytesIO()
+    hdul.writeto(bio)
+    hdul.close()
+
+    payload = ingest_local_file("spectrum.fits", bio.getvalue())
+
+    assert payload["label"] == "TestObj"
+    assert payload["flux"] == flux_values.tolist()
+    assert payload["wavelength_nm"] == pytest.approx([400.0, 400.2, 400.4])
+    assert payload["flux_unit"] == "Jy"
+    assert payload["flux_kind"] == "absolute"
+
+    metadata = payload["metadata"]
+    assert metadata["instrument"] == "SpecX"
+    assert metadata["telescope"] == "ScopeY"
+    assert metadata["observation_date"] == "2023-03-01T00:00:00"
+    assert metadata["target"] == "TestObj"
+    assert metadata["wavelength_range_nm"] == pytest.approx([400.0, 400.4])
+    assert metadata["wavelength_step_nm"] == pytest.approx(0.2)
+    assert metadata["reported_flux_unit"] == "Jy"
+    assert metadata["reported_wavelength_unit"] == "Angstrom"
+    assert metadata["original_wavelength_unit"] == "Å"
+
+    provenance = payload["provenance"]
+    assert provenance["format"] == "fits"
+    assert provenance["filename"] == "spectrum.fits"
+    assert provenance["hdu_name"] == "SCI"
+    assert provenance["data_mode"] == "image"
+
+
+def test_ingest_local_fits_table_handles_columns():
+    wave = np.array([5000.0, 5005.0, 5010.0], dtype=float)
+    flux = np.array([1.0, 1.1, 1.2], dtype=float)
+
+    col_wave = fits.Column(name="WAVELENGTH", array=wave, format="D", unit="Angstrom")
+    col_flux = fits.Column(name="FLUX", array=flux, format="D", unit="Jy")
+    table_hdu = fits.BinTableHDU.from_columns([col_wave, col_flux], name="SPECTRUM")
+    hdul = fits.HDUList([fits.PrimaryHDU(), table_hdu])
+    bio = io.BytesIO()
+    hdul.writeto(bio)
+    hdul.close()
+
+    payload = ingest_local_file("table_spectrum.fits", bio.getvalue())
+
+    assert payload["wavelength_nm"] == pytest.approx([500.0, 500.5, 501.0])
+    assert payload["flux"] == flux.tolist()
+    assert payload["flux_unit"] == "Jy"
+
+    metadata = payload["metadata"]
+    assert metadata["original_wavelength_unit"] == "Å"
+    assert metadata["reported_wavelength_unit"] == "Angstrom"
+    assert metadata["points"] == 3
+
+    provenance = payload["provenance"]
+    assert provenance["data_mode"] == "table"
+    assert provenance["column_mapping"]["wavelength"] == "WAVELENGTH"
+    assert provenance["column_mapping"]["flux"] == "FLUX"


### PR DESCRIPTION
## Summary
- broaden unit conversion and ASCII ingestion to handle columnar layouts, wavenumber axes, and gzip-compressed uploads
- extend FITS parsing to support table HDUs while enriching provenance with data modes, column metadata, and mask details
- expose the wider format support in the upload UI and add regression tests covering ASCII/FITS edge cases

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d02906a6548329b6946d90e2eb7196