### PR TITLE
Add flux-weighted auto viewport and reuse percentile helper

### DIFF
--- a/app/server/fetchers/eso.py
+++ b/app/server/fetchers/eso.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timezone
 import hashlib
-import math
 import unicodedata
 import re
 from pathlib import Path
@@ -17,6 +16,7 @@ from astropy.io import fits
 import requests
 
 from app._version import get_version_info
+from app.utils.flux import flux_percentile_range
 
 __all__ = ["fetch", "EsoFetchError", "available_spectra"]
 
@@ -185,7 +185,7 @@ def fetch(
         _download_file(spec.access_url, local_path)
 
     spectrum = _parse_xshooter_spectrum(local_path)
-    effective_range = _flux_percentile_range(
+    effective_range = flux_percentile_range(
         spectrum["wavelength_nm"], spectrum["flux"], coverage=0.985
     )
 
@@ -341,60 +341,6 @@ def _parse_xshooter_spectrum(path: Path) -> Dict[str, np.ndarray]:
                 "flux": bunit,
             },
         }
-
-
-def _flux_percentile_range(
-    wavelength_nm: np.ndarray,
-    flux: np.ndarray,
-    *,
-    coverage: float = 0.99,
-) -> Optional[Tuple[float, float]]:
-    if not 0.0 < coverage < 1.0:
-        coverage = 0.99
-
-    wavelengths = np.asarray(wavelength_nm, dtype=float)
-    flux_values = np.asarray(flux, dtype=float)
-    mask = np.isfinite(wavelengths) & np.isfinite(flux_values)
-    if mask.sum() < 2:
-        return None
-
-    wavelengths = wavelengths[mask]
-    flux_values = np.abs(flux_values[mask])
-    order = np.argsort(wavelengths)
-    wavelengths = wavelengths[order]
-    flux_values = flux_values[order]
-
-    wavelengths, unique_idx = np.unique(wavelengths, return_index=True)
-    flux_values = flux_values[unique_idx]
-    if wavelengths.size < 2:
-        return None
-
-    baseline = wavelengths[0]
-    shifted = wavelengths - baseline
-    span = shifted[-1]
-    if not math.isfinite(span) or span <= 0.0:
-        return None
-
-    scaled = shifted / span
-    segment_weights = 0.5 * (flux_values[:-1] + flux_values[1:]) * np.diff(scaled)
-    total_weight = float(segment_weights.sum())
-    if not math.isfinite(total_weight) or total_weight <= 0.0:
-        return None
-
-    cumulative = np.concatenate([[0.0], np.cumsum(segment_weights)])
-    lower_weight = max(0.0, (1.0 - coverage) / 2.0 * total_weight)
-    upper_weight = min(total_weight, total_weight - lower_weight)
-
-    lower_scaled = float(np.interp(lower_weight, cumulative, scaled))
-    upper_scaled = float(np.interp(upper_weight, cumulative, scaled))
-
-    low = baseline + lower_scaled * span
-    high = baseline + upper_scaled * span
-    if not (math.isfinite(low) and math.isfinite(high)):
-        return None
-    return (min(low, high), max(low, high))
-
-
 def _sha256(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as handle:

--- a/app/server/fetchers/sdss.py
+++ b/app/server/fetchers/sdss.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timezone
 import hashlib
-import math
 import unicodedata
 import re
 from pathlib import Path
@@ -17,6 +16,7 @@ from astropy.io import fits
 import requests
 
 from app._version import get_version_info
+from app.utils.flux import flux_percentile_range
 
 __all__ = ["fetch", "SdssFetchError", "available_targets"]
 
@@ -199,7 +199,7 @@ def fetch(
         remote_url = _remote_url(entry.plate, entry.mjd, entry.fiber)
 
     spectrum = _parse_sdss_spectrum(local_path)
-    effective_range = _flux_percentile_range(
+    effective_range = flux_percentile_range(
         spectrum["wavelength_nm"], spectrum["flux"], coverage=0.98
     )
 
@@ -347,60 +347,6 @@ def _parse_sdss_spectrum(path: Path) -> Dict[str, np.ndarray]:
             "flux": flux_converted.astype(float),
             "uncertainty": None if uncertainty is None else uncertainty.astype(float),
         }
-
-
-def _flux_percentile_range(
-    wavelength_nm: np.ndarray,
-    flux: np.ndarray,
-    *,
-    coverage: float = 0.99,
-) -> Optional[Tuple[float, float]]:
-    if not 0.0 < coverage < 1.0:
-        coverage = 0.99
-
-    wavelengths = np.asarray(wavelength_nm, dtype=float)
-    flux_values = np.asarray(flux, dtype=float)
-    mask = np.isfinite(wavelengths) & np.isfinite(flux_values)
-    if mask.sum() < 2:
-        return None
-
-    wavelengths = wavelengths[mask]
-    flux_values = np.abs(flux_values[mask])
-    order = np.argsort(wavelengths)
-    wavelengths = wavelengths[order]
-    flux_values = flux_values[order]
-
-    wavelengths, unique_idx = np.unique(wavelengths, return_index=True)
-    flux_values = flux_values[unique_idx]
-    if wavelengths.size < 2:
-        return None
-
-    baseline = wavelengths[0]
-    shifted = wavelengths - baseline
-    span = shifted[-1]
-    if not math.isfinite(span) or span <= 0.0:
-        return None
-
-    scaled = shifted / span
-    segment_weights = 0.5 * (flux_values[:-1] + flux_values[1:]) * np.diff(scaled)
-    total_weight = float(segment_weights.sum())
-    if not math.isfinite(total_weight) or total_weight <= 0.0:
-        return None
-
-    cumulative = np.concatenate([[0.0], np.cumsum(segment_weights)])
-    lower_weight = max(0.0, (1.0 - coverage) / 2.0 * total_weight)
-    upper_weight = min(total_weight, total_weight - lower_weight)
-
-    lower_scaled = float(np.interp(lower_weight, cumulative, scaled))
-    upper_scaled = float(np.interp(upper_weight, cumulative, scaled))
-
-    low = baseline + lower_scaled * span
-    high = baseline + upper_scaled * span
-    if not (math.isfinite(low) and math.isfinite(high)):
-        return None
-    return (min(low, high), max(low, high))
-
-
 def _sha256(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as handle:

--- a/app/utils/flux.py
+++ b/app/utils/flux.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import math
+from typing import Optional, Sequence, Tuple
+
+import numpy as np
+
+__all__ = ["flux_percentile_range"]
+
+
+def flux_percentile_range(
+    wavelength_nm: Sequence[float] | np.ndarray,
+    flux: Sequence[float] | np.ndarray,
+    *,
+    coverage: float = 0.99,
+) -> Optional[Tuple[float, float]]:
+    """Return the flux-weighted percentile wavelength bounds.
+
+    The percentile window is calculated using the trapezoidal integral of the
+    absolute flux and trimmed symmetrically until the requested coverage of the
+    cumulative weight remains.
+    """
+
+    if not 0.0 < coverage < 1.0:
+        coverage = 0.99
+
+    wavelengths = np.asarray(wavelength_nm, dtype=float)
+    flux_values = np.asarray(flux, dtype=float)
+    mask = np.isfinite(wavelengths) & np.isfinite(flux_values)
+    if mask.sum() < 2:
+        return None
+
+    wavelengths = wavelengths[mask]
+    flux_values = np.abs(flux_values[mask])
+    order = np.argsort(wavelengths)
+    wavelengths = wavelengths[order]
+    flux_values = flux_values[order]
+
+    wavelengths, unique_idx = np.unique(wavelengths, return_index=True)
+    flux_values = flux_values[unique_idx]
+    if wavelengths.size < 2:
+        return None
+
+    baseline = wavelengths[0]
+    shifted = wavelengths - baseline
+    span = shifted[-1]
+    if not math.isfinite(span) or span <= 0.0:
+        return None
+
+    scaled = shifted / span
+    segment_weights = 0.5 * (flux_values[:-1] + flux_values[1:]) * np.diff(scaled)
+    total_weight = float(segment_weights.sum())
+    if not math.isfinite(total_weight) or total_weight <= 0.0:
+        return None
+
+    cumulative = np.concatenate([[0.0], np.cumsum(segment_weights)])
+    lower_weight = max(0.0, (1.0 - coverage) / 2.0 * total_weight)
+    upper_weight = min(total_weight, total_weight - lower_weight)
+
+    lower_scaled = float(np.interp(lower_weight, cumulative, scaled))
+    upper_scaled = float(np.interp(upper_weight, cumulative, scaled))
+
+    low = baseline + lower_scaled * span
+    high = baseline + upper_scaled * span
+    if not (math.isfinite(low) and math.isfinite(high)):
+        return None
+    return (min(low, high), max(low, high))

--- a/tests/ui/test_auto_viewport.py
+++ b/tests/ui/test_auto_viewport.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+from app.ui.main import OverlayTrace, _auto_viewport_range
+
+
+def test_auto_viewport_trims_long_tail():
+    wavelengths = np.linspace(500.0, 1500.0, 1000)
+    flux = np.concatenate([np.ones(100), np.full(900, 1e-3)])
+
+    overlay = OverlayTrace(
+        trace_id="tail",
+        label="Synthetic tail",
+        wavelength_nm=tuple(float(v) for v in wavelengths),
+        flux=tuple(float(v) for v in flux),
+    )
+
+    auto_range = _auto_viewport_range([overlay])
+    assert auto_range is not None
+
+    auto_low, auto_high = auto_range
+    raw_low = float(np.min(wavelengths))
+    raw_high = float(np.max(wavelengths))
+    raw_span = raw_high - raw_low
+    auto_span = auto_high - auto_low
+
+    # Ensure the automatic window remains within the data bounds.
+    assert raw_low <= auto_low <= raw_high
+    assert raw_low <= auto_high <= raw_high
+
+    # Long, low-flux tails should be trimmed to focus on the core signal.
+    assert auto_span < raw_span * 0.6


### PR DESCRIPTION
## Summary
- factor the fetcher percentile-window logic into `app.utils.flux.flux_percentile_range` and reuse it across the DOI, ESO, MAST, and SDSS fetchers
- compute a flux-weighted automatic viewport in the UI, applying it to the initial Plotly axis, slider defaults, status bar, exports, and similarity calculations
- add a regression test that exercises the auto viewport helper on a synthetic long-tail spectrum

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d096e62c7883299559a0db887639e4