### PR TITLE
docs: record v1.1.6b continuity plan

### DIFF
--- a/PATCHLOG.txt
+++ b/PATCHLOG.txt
@@ -3,3 +3,4 @@ Spectra App — Patch Log (append-only)
 
 - v1.1.5b: is this the thing that updates the header lol
 - v1.1.6: replaced synthetic provider shims with live ESO/SDSS/DOI fetchers, expanded CALSPEC targets, and wired example overlays to live archive data.
+- v1.1.6b (REF 1.1.6b-A01): collapse archive metadata/provenance into expanders, drop redundant overlay visibility column, add smoothed+raw solar example with band filters, and formalize unit-aware emission/absorption axes.

--- a/docs/PATCH_NOTES/v1.1.6b.txt
+++ b/docs/PATCH_NOTES/v1.1.6b.txt
@@ -1,0 +1,6 @@
+v1.1.6b — Archive UX + solar reference groundwork (see PATCH_NOTES_v1.1.6b.md for full details).
+- Collapse archive metadata/provenance into closed expanders so overlay actions stay visible.
+- Drop the redundant overlay visibility column and rely on the sidebar multiselect for display control.
+- Introduce a telescope-observed solar spectrum example with smoothed-default plotting, raw toggle, and band filters.
+- Extend overlay unit semantics so emission/absorption data use unit-aware, per-axis rendering.
+- Brains entry: docs/brains/brains_v1.1.6b.md

--- a/docs/ai_handoff/AI_HANDOFF_PROMPT_v1.1.6b.md
+++ b/docs/ai_handoff/AI_HANDOFF_PROMPT_v1.1.6b.md
@@ -1,0 +1,31 @@
+# AI Handoff Prompt — v1.1.6b
+_Last updated: 2025-09-22T01:22:08Z_
+
+This is a continuation of the live-archive work. Ship the UX and data upgrades without regressing the existing overlay, differential, export, or continuity contracts.
+
+## Do Not Break
+- Overlay, Differential, Export flows; unit conversions remain idempotent from the canonical nm baseline.
+- Provenance payloads stay attached to every overlay (archive hits, uploads, examples, exports).
+- Duplicate guard, normalization, and provider cache invariants introduced in v1.1.6 stay intact.
+- Continuity docs (`brains`, `patch notes`, `AI handoff`, `PATCHLOG.txt`) stay cross-referenced.
+
+## What to Ship in v1.1.6b (REF 1.1.6b-A01)
+1. **Archive UI**: Wrap metadata/provenance JSON inside closed `st.expander` widgets and keep “Add to overlay” accessible without scrolling. Preserve success/warning toast behavior.
+2. **Overlay visibility**: Remove the `Visible` checkbox column from `_render_overlay_table`; rely on the existing multiselect form for visibility and update helper copy to reflect that single source of truth.
+3. **Solar example**: Acquire a telescope-observed solar spectrum (e.g., NSO/Kitt Peak FTS via VizieR), normalize wavelengths to nm, and store both raw and smoothed datasets plus band tags (IR, near-IR, VIS, UV-VIS, UV...). Default the example to the smoothed trace, surface a toggle for full resolution, and expose band filters in the UI.
+4. **Unit semantics**: Extend overlay trace metadata to capture unit strings and physical quantity types (flux density, spectral radiance, equivalent width, etc.). Plot emission and absorption on distinct, unit-aware y-axes (secondary axis or comparable) so labels stay truthful and toggles/exports propagate the selected units.
+5. **Performance & caching**: Persist processed solar datasets under `data/examples/` (Parquet/Feather). Memoize loads so switching smoothing/band options does not refetch archive data.
+
+## Data & Provenance Requirements
+- Record instrument, archive, observation program/ID, citation, and unit metadata for the solar spectrum. Include both smoothed and raw datasets in exports with explicit provenance blocks.
+- If new conversion helpers are added, keep them dependency-light (NumPy/Pandas acceptable; avoid new third-party packages unless justified).
+
+## Verification
+- Automated: `pytest` (full suite) plus targeted tests for any new preprocessing or overlay helper functions.
+- Manual: Streamlit smoke test — confirm archive metadata expanders stay collapsed by default, overlay visibility toggles run smoothly, solar example loads (smoothed default, raw toggle, band filters), and dual-axis labeling matches the chosen unit semantics.
+
+## Continuity Links
+- Brains: docs/brains/brains_v1.1.6b.md
+- Patch notes: docs/patch_notes/PATCH_NOTES_v1.1.6b.md
+- Patch summary: docs/PATCH_NOTES/v1.1.6b.txt
+- REF: 1.1.6b-A01

--- a/docs/brains/ai_handoff.md
+++ b/docs/brains/ai_handoff.md
@@ -21,25 +21,32 @@ All contributors must consult the Brains before making changes.
 3. Cite the REF in `PATCHLOG.txt`, commit messages, and future handoffs.
 4. Prepare the AI handoff notes for the next iteration.
 
-
 # Spectra App — AI Handoff Bridge
-_Last updated: 2025-09-21T00:00:00Z_
+_Last updated: 2025-09-22T01:22:08Z_
 
 This bridge document ties the brains log to the operative AI handoff prompt.
 It is part of the mandated continuity template: Brains → AI Handoff → Patch Notes.
 
 ## Source of Truth
-- Current prompt: `docs/ai_handoff/AI_HANDOFF_PROMPT_v1.1.4.md`
+- Current prompt: `docs/ai_handoff/AI_HANDOFF_PROMPT_v1.1.6b.md`
+- Previous prompts remain under `docs/ai_handoff/` for historical context.
 - Next revisions must update both this bridge and `docs/brains/brains_INDEX.md`.
 - Keep handoff prompts UTF-8, versioned, and cross-linked from the paired brains + patch notes.
 
-## Expectations for v1.1.5a
+## Expectations for v1.1.6b
+- Execute REF **1.1.6b-A01**: collapse archive metadata/provenance behind closed expanders while keeping “Add to overlay” accessible.
+- Remove the redundant `Visible` checkbox column so the overlay multiselect governs visibility without desyncs.
+- Ingest a telescope-observed solar spectrum as the default example, serving smoothed data by default with raw toggles and wavelength-band filters.
+- Extend overlay traces with explicit unit semantics so emission/absorption render on dedicated, correctly labeled axes.
+- Cache processed solar datasets and memoize loads to protect performance while maintaining provenance for smoothed and raw variants.
+
+## Expectations for v1.1.5a (legacy reference)
 - Do **not** regenerate the entire prompt—extend it incrementally.
 - Include guidance about the continuity manifest field and provider directory requirements.
 - Ensure every future prompt references `docs/brains/brains_v1.1.5a.md` until superseded.
 
 ## Checklist Before Shipping Changes
 1. Read the latest brains entry and confirm the scope still matches.
-2. Verify `docs/PATCH_NOTES/v1.1.5a.txt` lists the same continuity obligations.
+2. Verify `docs/patch_notes/PATCH_NOTES_v1.1.6b.md` and `docs/PATCH_NOTES/v1.1.6b.txt` list the same continuity obligations.
 3. Run `RUN_CMDS/Verify-Project.ps1` to confirm reciprocal links and provider directories are intact.
 4. Prepare necessary AI handoff notes for the next iteration.

--- a/docs/brains/brains_INDEX.md
+++ b/docs/brains/brains_INDEX.md
@@ -1,5 +1,5 @@
 # Spectra App — Brains Index
-_Last updated: 2025-09-21T00:00:00Z_
+_Last updated: 2025-09-22T01:22:08Z_
 
 This index is the mandated entry point before touching the codebase.
 It tracks the latest continuity documents and the required cross-links between them.
@@ -13,11 +13,13 @@ It tracks the latest continuity documents and the required cross-links between t
 ## Continuity Table
 | Version | Brains Log | Patch Notes | AI Handoff |
 | --- | --- | --- | --- |
-| v1.1.6 | [docs/brains/brains_v1.1.6.md](brains_v1.1.6.md) | [docs/PATCH_NOTES/v1.1.6.md](../patch_notes/PATCH_NOTES_v1.1.6.md) | [docs/brains/ai_handoff.md](ai_handoff.md) |
+| v1.1.6b | [docs/brains/brains_v1.1.6b.md](brains_v1.1.6b.md) | [docs/patch_notes/PATCH_NOTES_v1.1.6b.md](../patch_notes/PATCH_NOTES_v1.1.6b.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.1.6b.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.1.6b.md) |
+| v1.1.6 | [docs/brains/brains_v1.1.6.md](brains_v1.1.6.md) | [docs/patch_notes/PATCH_NOTES_v1.1.6.md](../patch_notes/PATCH_NOTES_v1.1.6.md) | [docs/brains/ai_handoff.md](ai_handoff.md) |
 | v1.1.5a | [docs/brains/brains_v1.1.5a.md](brains_v1.1.5a.md) | [docs/PATCH_NOTES/v1.1.5a.txt](../PATCH_NOTES/v1.1.5a.txt) | [docs/brains/ai_handoff.md](ai_handoff.md) |
 
 Older releases remain in `docs/brains/` and `docs/patches/` for archeology, but the table above is the active continuity contract.
 
+- Patch notes (txt) for v1.1.6b: docs/PATCH_NOTES/v1.1.6b.txt
 - Patch notes (txt) for v1.1.6: docs/PATCH_NOTES/v1.1.6.txt
 
 ## Provider Directories

--- a/docs/brains/brains_v1.1.6b.md
+++ b/docs/brains/brains_v1.1.6b.md
@@ -1,0 +1,45 @@
+# Brains — v1.1.6b
+_Last updated (UTC): 2025-09-22T01:22:08Z_
+
+## Purpose
+v1.1.6b carries forward the live-archive foundation from v1.1.6 and targets the UX gaps surfaced during archive browsing. The patch will collapse bulky provenance panels, streamline overlay visibility controls, and introduce a high-density solar spectrum example that defaults to a smoothed view while preserving full-resolution access.
+
+## REF 1.1.6b-A01 — Archive UX, Solar reference, and unit semantics
+- **What**
+  - Collapse archive metadata/provenance readouts behind closed expanders and keep “Add to overlay” actions visible without scrolling.
+  - Remove the redundant `Visible` checkbox column from the overlay table so the multiselect remains the single visibility control.
+  - Seed the examples library with a telescope-observed solar spectrum that defaults to a smoothed trace, exposes a toggle to render the full-resolution dataset, and allows band-based wavelength filtering (IR, near-IR, VIS, UV-VIS, UV, etc.).
+  - Extend overlay traces with explicit unit semantics so emission and absorption data can render on dedicated y-axes with correct labels and conversions.
+- **Why**
+  - Archive result panels currently expand metadata inline, pushing the overlay CTA below the fold and making quick comparisons painful.
+  - Duplicate visibility toggles desynchronize state and create the “hiccups” reported when enabling or disabling overlays.
+  - A solar reference rich in spectral features exercises the performance path; smoothing by default keeps load times reasonable while a raw toggle protects investigative fidelity.
+  - Scientific overlays carry diverse flux units (e.g., W·m⁻²·nm⁻¹, erg·s⁻¹·cm⁻²·Å⁻¹, spectral radiance). Explicit semantics are required so emission peaks and absorption troughs present correctly and axes remain trustworthy.
+- **Where**
+  - UI adjustments: `app/archive_ui.py`, `app/ui/main.py`, associated widgets/helpers.
+  - Example ingestion & caching: `app/examples/`, `data/examples/`, potential preprocessing helpers under `scripts/`.
+  - Overlay data model & plotting: `app/overlay_models.py`, `app/plotting/`, `app/ui/overlays.py` (exact paths to confirm while implementing).
+  - Continuity docs: `PATCHLOG.txt`, `docs/PATCH_NOTES/v1.1.6b.txt`, `docs/patch_notes/PATCH_NOTES_v1.1.6b.md`, `docs/ai_handoff/AI_HANDOFF_PROMPT_v1.1.6b.md`.
+- **How**
+  1. Wrap metadata/provenance JSON blocks inside `st.expander(label, expanded=False)` within `ArchiveUI._render_provider`, keeping success toasts intact and positioning the “Add to overlay” button immediately above the expanders.
+  2. Trim the `Visible` column from `_render_overlay_table`, refresh helper text to clarify the multiselect is authoritative, and ensure session-state updates remain synchronized.
+  3. Acquire a solar spectrum observed by a reputable telescope (e.g., NSO/Kitt Peak FTS via VizieR). Normalize wavelength to nm, persist raw data, and generate a smoothed counterpart (Savitzky–Golay or rolling median) stored alongside band classifications for wavelength-range filtering.
+  4. Extend example loading so the new solar entry becomes the default selection, exposes toggles for smoothed vs full-resolution traces, and leverages precomputed band tags for quick filter switches without re-fetching.
+  5. Expand overlay trace metadata to include unit strings, physical quantity (flux density, spectral radiance, equivalent width, etc.), and a semantic axis type (`emission`, `absorption`, or other). Use Plotly secondary y-axes (or faceting, if cleaner) so emission peaks remain positive while absorption dips can plot on a logically separate axis with descriptive labels.
+  6. Provide unit conversions only when scientifically compatible—e.g., Fλ ↔ Fν using ν = c/λ and the appropriate Jacobian—and surface helper text for unit families that cannot convert cleanly. Update exports to preserve the original and display units.
+  7. Cache processed solar datasets under `data/examples/` (Parquet/Feather) and memoize loads inside Streamlit to keep the UI responsive.
+- **Verification**
+  - Automated: `pytest` (full suite) and any targeted unit tests for new preprocessing or overlay helpers.
+  - Manual: launch Streamlit, confirm archive metadata/provenance expanders are collapsed by default, verify overlay visibility toggles behave smoothly, inspect the solar example (smoothed default, raw toggle, band filters), and ensure dual-axis labeling matches the underlying unit semantics.
+- **Provenance**
+  - User direction (2025-09-22) requesting v1.1.6b to collapse archive metadata, remove redundant overlay checkboxes, add a telescope-observed solar example with smoothing/full-resolution toggles, and document unit handling for emission vs absorption overlays.
+
+## Knowledge Capture
+- **Spectral flux density (Fλ)** expresses energy per unit area, time, and wavelength (e.g., W·m⁻²·nm⁻¹ or erg·s⁻¹·cm⁻²·Å⁻¹). Converting between wavelength and frequency representations requires Jacobian scaling (Fν = Fλ · λ² / c).
+- **Spectral radiance (Iλ)** adds per-steradian context (W·m⁻²·sr⁻¹·nm⁻¹) and should not co-plot with flux density without explicit conversion or annotation.
+- **Emission lines** rise above the continuum baseline, whereas **absorption lines** represent deficits relative to the continuum; plotting them on distinct y-axes (or using sign conventions) prevents misinterpretation when units mix.
+- Band definitions for the solar example can follow approximate wavelength ranges: IR (>700 nm), Near-IR (700–1400 nm), VIS (380–700 nm), UV-VIS (320–380 nm), UV (10–320 nm). Tagging each sample enables quick filtering without recomputation.
+
+## Follow-up Considerations
+- Evaluate whether unit conversion helpers should live in a dedicated module to serve both archives and uploads.
+- Consider capturing instrument/integration metadata in the solar example metadata to reinforce provenance in exports and overlays.

--- a/docs/patch_notes/PATCH_NOTES_v1.1.6b.md
+++ b/docs/patch_notes/PATCH_NOTES_v1.1.6b.md
@@ -1,0 +1,32 @@
+# Patch Notes — v1.1.6b
+_Last updated: 2025-09-22T01:22:08Z_
+
+## Scope
+v1.1.6b focuses on resolving archive/overlay UX friction and delivering a high-density solar reference example that defaults to a smoothed render for performance while preserving raw detail on demand.
+
+## Highlights
+- Collapse archive metadata and provenance JSON behind closed expanders and keep primary actions (Add to overlay) above the fold.
+- Retire the redundant `Visible` checkbox column in the overlay table; rely exclusively on the multiselect control for visibility.
+- Add a telescope-observed solar spectrum example (targeting NSO/Kitt Peak FTS or equivalent) with:
+  - Smoothed data as the default render for fast loading,
+  - A toggle that restores full-resolution samples,
+  - Wavelength-band filters (IR, near-IR, VIS, UV-VIS, UV, etc.) driven by precomputed tags.
+- Teach overlays about flux unit families and semantic axes so emission and absorption data plot on separate, correctly labeled y-axes.
+
+## Implementation Sketch
+1. Update `ArchiveUI._render_provider` to wrap metadata/provenance JSON in `st.expander` widgets (`expanded=False`) and reposition the overlay CTA above them.
+2. Remove the `Visible` column from `_render_overlay_table` and refine helper copy so users treat the multiselect as the single visibility controller.
+3. Pull a solar spectrum from a telescope-backed archive (e.g., NSO FTS via VizieR), normalize wavelength to nm, and generate both raw and smoothed datasets stored under `data/examples/` with provenance metadata.
+4. Extend example-loading helpers so the solar entry becomes the default sidebar example, exposes smoothed/full-resolution toggles, and filters wavelengths by band without reprocessing.
+5. Enrich overlay trace metadata with unit labels, physical quantity classifications, and semantic axis hints; render emission vs absorption on distinct y-axes with accurate unit strings and safe conversions (Fλ ↔ Fν when applicable).
+6. Document behavior in the export manifest if additional metadata is surfaced, ensuring provenance accompanies both smoothed and raw representations.
+
+## Verification
+- Automated: run `pytest` (full suite) plus any new tests covering preprocessing helpers or overlay model/unit utilities.
+- Manual: Streamlit smoke test to confirm collapsed expanders, smooth overlay toggles, solar example defaults/toggles/band filters, and dual-axis labeling.
+
+## References
+- Brains entry: [docs/brains/brains_v1.1.6b.md](../brains/brains_v1.1.6b.md)
+- Patch summary (txt): [docs/PATCH_NOTES/v1.1.6b.txt](../PATCH_NOTES/v1.1.6b.txt)
+- AI handoff prompt: [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.1.6b.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.1.6b.md)
+- REF: 1.1.6b-A01


### PR DESCRIPTION
## Summary
- add Brains entry for v1.1.6b and log REF 1.1.6b-A01 with archive/overlay/solar tasks
- update continuity index, AI handoff bridge, and patch log to reference the new plan
- publish paired patch notes and AI handoff prompt detailing the v1.1.6b scope

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d09fa4692083299db80f24b4c0a343