### PR TITLE
Implement All Archives combined provider (REF 1.1.7-A01)

### DIFF
--- a/PATCHLOG.txt
+++ b/PATCHLOG.txt
@@ -4,3 +4,4 @@ Spectra App — Patch Log (append-only)
 - v1.1.5b: is this the thing that updates the header lol
 - v1.1.6: replaced synthetic provider shims with live ESO/SDSS/DOI fetchers, expanded CALSPEC targets, and wired example overlays to live archive data.
 - v1.1.6b (REF 1.1.6b-A01): collapse archive metadata/provenance into expanders, drop redundant overlay visibility column, add smoothed+raw solar example with band filters, and formalize unit-aware emission/absorption axes.
+- v1.1.7 (REF 1.1.7-A01): ship the All Archives combined provider, surface the new tab in the archive UI, harden aggregation tests, and refresh continuity docs/versioning for the release.

--- a/app/archive_ui.py
+++ b/app/archive_ui.py
@@ -26,8 +26,9 @@ class ArchiveUI:
             "workspace. Responses stream real spectra with full provenance metadata."
         )
         labels = provider_labels()
-        tabs = st.tabs([labels[name] for name in ("MAST", "ESO", "SDSS", "DOI")])
-        for provider_name, tab in zip(("MAST", "ESO", "SDSS", "DOI"), tabs):
+        provider_order = ("ALL", "MAST", "ESO", "SDSS", "DOI")
+        tabs = st.tabs([labels.get(name, name.title()) for name in provider_order])
+        for provider_name, tab in zip(provider_order, tabs):
             with tab:
                 self._render_provider(provider_name)
 

--- a/app/providers/__init__.py
+++ b/app/providers/__init__.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 """Provider registry and helper functions for archive integration."""
 
-from typing import Dict, List, Sequence
+from types import ModuleType
+from typing import Dict, List, Optional, Sequence
 
 from .base import ProviderHit, ProviderQuery
 from . import doi, eso, mast, sdss
 
-_PROVIDER_MAP = {
+_PROVIDER_MAP: Dict[str, Optional[ModuleType]] = {
+    "ALL": None,
     "MAST": mast,
     "ESO": eso,
     "SDSS": sdss,
@@ -25,7 +27,13 @@ def get_provider(name: str):  # type: ignore[override]
     key = (name or "").upper()
     if key not in _PROVIDER_MAP:
         raise KeyError(f"Unknown provider: {name!r}")
-    return _PROVIDER_MAP[key]
+    provider_module = _PROVIDER_MAP[key]
+    if provider_module is None:
+        from . import combined
+
+        provider_module = combined
+        _PROVIDER_MAP[key] = provider_module
+    return provider_module
 
 
 def search(name: str, query: ProviderQuery) -> List[ProviderHit]:
@@ -39,6 +47,7 @@ def provider_labels() -> Dict[str, str]:
     """Human readable provider titles used in the UI."""
 
     return {
+        "ALL": "All Archives",
         "MAST": "MAST",  # Mikulski Archive for Space Telescopes
         "ESO": "ESO",  # European Southern Observatory
         "SDSS": "SDSS",  # Sloan Digital Sky Survey

--- a/app/providers/combined.py
+++ b/app/providers/combined.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+"""Aggregated provider that queries multiple archives in a single pass."""
+
+import logging
+from typing import Iterable, Tuple
+
+from .base import ProviderHit, ProviderQuery
+from . import eso, mast, sdss
+
+_LOG = logging.getLogger(__name__)
+
+_PROVIDER_SEQUENCE: Tuple[Tuple[str, object], ...] = (
+    ("MAST", mast),
+    ("ESO", eso),
+    ("SDSS", sdss),
+)
+
+
+def search(query: ProviderQuery) -> Iterable[ProviderHit]:
+    """Yield hits from all archive providers, skipping failures."""
+
+    for provider_name, module in _PROVIDER_SEQUENCE:
+        try:
+            for hit in module.search(query):
+                yield hit
+        except Exception as exc:
+            _LOG.warning(
+                "Combined provider failed to fetch results from %s: %s",
+                provider_name,
+                exc,
+                exc_info=True,
+            )
+            continue
+
+    # Future work: when the SIMBAD resolver is implemented the combined provider
+    # will call it here if no curated targets match the query. This keeps the
+    # integration point centralised for upcoming patches.

--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.1.6",
-  "date_utc": "2025-09-22T00:00:00Z",
-  "summary": "Replaced synthetic providers with live archive-backed spectra and expanded CALSPEC coverage."
+  "version": "v1.1.7",
+  "date_utc": "2025-09-22T12:00:00Z",
+  "summary": "Introduced an All Archives combined provider, updated the archive UI, and refreshed continuity docs."
 }

--- a/docs/PATCH_NOTES/v1.1.7.txt
+++ b/docs/PATCH_NOTES/v1.1.7.txt
@@ -1,0 +1,6 @@
+v1.1.7 — All Archives aggregation + continuity refresh (see PATCH_NOTES_v1.1.7.md for full details).
+- Added app/providers/combined.py so All Archives searches concatenate MAST, ESO and SDSS hits while logging provider failures.
+- Registered the ALL provider and surfaced the “All Archives” tab in the archive UI with the standard search form.
+- Introduced regression tests for the combined provider and Streamlit archive tabs.
+- Updated brains/patch notes/AI handoff bridge, PATCHLOG, and version.json to reference v1.1.7.
+- Brains entry: docs/brains/brains_v1.1.7.md

--- a/docs/brains/ai_handoff.md
+++ b/docs/brains/ai_handoff.md
@@ -23,16 +23,24 @@ All contributors must consult the Brains before making changes.
 4. Prepare the AI handoff notes for the next iteration.
 
 # Spectra App — AI Handoff Bridge
-_Last updated: 2025-09-22T01:22:08Z_
+_Last updated: 2025-09-22T12:00:00Z_
 
 This bridge document ties the brains log to the operative AI handoff prompt.
 It is part of the mandated continuity template: Brains → AI Handoff → Patch Notes.
 
 ## Source of Truth
-- Current prompt: `docs/ai_handoff/AI_HANDOFF_PROMPT_v1.1.6b.md`
+- Current prompt: `docs/ai_handoff/AI Handoff Prompt — v1.1.7.txt`
 - Previous prompts remain under `docs/ai_handoff/` for historical context.
 - Next revisions must update both this bridge and `docs/brains/brains_INDEX.md`.
 - Keep handoff prompts UTF-8, versioned, and cross-linked from the paired brains + patch notes.
+
+## Expectations for v1.1.7
+- Execute REF **1.1.7-A01**: deliver the aggregated **All Archives** workflow without regressing overlay, differential, or export behaviour.
+- Implement `app/providers/combined.py` so a single `ProviderQuery` returns concatenated hits from MAST, ESO, and SDSS even when one provider fails.
+- Register the `ALL` provider in `app/providers/__init__.py` with lazy imports and expose the "All Archives" label to the UI.
+- Update `ArchiveUI` to surface the new tab ahead of MAST/ESO/SDSS, reuse the standard search form, and dispatch `provider_search("ALL", query)`.
+- Extend the test suite to cover combined-provider aggregation, exception handling, and the new UI tab/form behaviour.
+- Refresh continuity docs: brains_v1.1.7.md, patch notes (Markdown + txt), AI handoff references, and patch log/version metadata.
 
 ## Expectations for v1.1.6b
 - Execute REF **1.1.6b-A01**: collapse archive metadata/provenance behind closed expanders while keeping “Add to overlay” accessible.
@@ -40,7 +48,6 @@ It is part of the mandated continuity template: Brains → AI Handoff → Patch 
 - Ingest a telescope-observed solar spectrum as the default example, serving smoothed data by default with raw toggles and wavelength-band filters.
 - Extend overlay traces with explicit unit semantics so emission/absorption render on dedicated, correctly labeled axes.
 - Cache processed solar datasets and memoize loads to protect performance while maintaining provenance for smoothed and raw variants.
-
 ## Expectations for v1.1.5a (legacy reference)
 - Do **not** regenerate the entire prompt—extend it incrementally.
 - Include guidance about the continuity manifest field and provider directory requirements.
@@ -48,6 +55,6 @@ It is part of the mandated continuity template: Brains → AI Handoff → Patch 
 
 ## Checklist Before Shipping Changes
 1. Read the latest brains entry and confirm the scope still matches.
-2. Verify `docs/patch_notes/PATCH_NOTES_v1.1.6b.md` and `docs/PATCH_NOTES/v1.1.6b.txt` list the same continuity obligations.
+2. Verify `docs/patch_notes/PATCH_NOTES_v1.1.7.md` and `docs/PATCH_NOTES/v1.1.7.txt` list the same continuity obligations.
 3. Run `RUN_CMDS/Verify-Project.ps1` to confirm reciprocal links and provider directories are intact.
 4. Prepare necessary AI handoff notes for the next iteration.

--- a/docs/brains/brains_INDEX.md
+++ b/docs/brains/brains_INDEX.md
@@ -14,12 +14,14 @@ It tracks the latest continuity documents and the required cross-links between t
 ## Continuity Table
 | Version | Brains Log | Patch Notes | AI Handoff |
 | --- | --- | --- | --- |
+| v1.1.7 | [docs/brains/brains_v1.1.7.md](brains_v1.1.7.md) | [docs/patch_notes/PATCH_NOTES_v1.1.7.md](../patch_notes/PATCH_NOTES_v1.1.7.md) | [docs/ai_handoff/AI Handoff Prompt — v1.1.7.txt](../ai_handoff/AI%20Handoff%20Prompt%20—%20v1.1.7.txt) |
 | v1.1.6b | [docs/brains/brains_v1.1.6b.md](brains_v1.1.6b.md) | [docs/patch_notes/PATCH_NOTES_v1.1.6b.md](../patch_notes/PATCH_NOTES_v1.1.6b.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.1.6b.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.1.6b.md) |
 | v1.1.6 | [docs/brains/brains_v1.1.6.md](brains_v1.1.6.md) | [docs/patch_notes/PATCH_NOTES_v1.1.6.md](../patch_notes/PATCH_NOTES_v1.1.6.md) | [docs/brains/ai_handoff.md](ai_handoff.md) |
 | v1.1.5a | [docs/brains/brains_v1.1.5a.md](brains_v1.1.5a.md) | [docs/PATCH_NOTES/v1.1.5a.txt](../PATCH_NOTES/v1.1.5a.txt) | [docs/brains/ai_handoff.md](ai_handoff.md) |
 
 Older releases remain in `docs/brains/` and `docs/patches/` for archeology, but the table above is the active continuity contract.
 
+- Patch notes (txt) for v1.1.7: docs/PATCH_NOTES/v1.1.7.txt
 - Patch notes (txt) for v1.1.6b: docs/PATCH_NOTES/v1.1.6b.txt
 - Patch notes (txt) for v1.1.6: docs/PATCH_NOTES/v1.1.6.txt
 

--- a/docs/brains/brains_v1.1.7.md
+++ b/docs/brains/brains_v1.1.7.md
@@ -67,6 +67,24 @@ Architecture Decisions
 
     Future star resolver: The SIMBAD fetcher stub must be replaced with a real resolver that queries the CDS Sesame service for RA/DEC given a name and returns metadata. The combined provider will call this resolver when no curated matches exist.
 
+Implementation Summary (REF 1.1.7-A01)
+
+    Implemented `app/providers/combined.py` to iterate across MAST, ESO and SDSS providers, logging and skipping individual failures so aggregated searches continue.
+
+    Updated `app/providers/__init__.py` with a lazily imported `ALL` entry and surfaced the "All Archives" label for UI consumers.
+
+    Extended `app/archive_ui.py` to include the "All Archives" tab ahead of the individual archives, reuse the standard search form and dispatch `provider_search("ALL", query)`.
+
+    Added regression tests covering combined provider aggregation/error handling (`tests/providers/test_combined_provider.py`) and Streamlit tab/search wiring (`tests/ui/test_archive_ui.py`).
+
+    Refreshed continuity collateral: brains index, patch notes (Markdown + txt), AI handoff bridge, `PATCHLOG.txt`, and `app/version.json` now point to v1.1.7.
+
+Verification
+
+    Automated: `pytest` covers the new provider and UI behaviour (see `tests/providers/test_combined_provider.py` and `tests/ui/test_archive_ui.py`).
+
+    Manual: Streamlit smoke test recommended — load the Archive tab, ensure "All Archives" appears first, run a Vega search, and confirm hits from multiple providers appear with intact provenance and overlay actions.
+
 Data Model Impact
 
 The data model defined in v1.1.6 remains unchanged. ProviderHit and ProviderQuery classes continue to carry wavelength arrays, flux arrays, metadata and provenance. The combined provider simply yields more ProviderHit instances. Future work will extend the model to include RA/DEC metadata resolved via SIMBAD.

--- a/docs/patch_notes/PATCH_NOTES_v1.1.7.md
+++ b/docs/patch_notes/PATCH_NOTES_v1.1.7.md
@@ -1,0 +1,29 @@
+# Patch Notes — v1.1.7
+_Last updated: 2025-09-22T12:00:00Z_
+
+## Scope
+v1.1.7 adds an aggregated “All Archives” search path that queries MAST, ESO and SDSS in one action while preserving existing overlay, differential and export guarantees. The release also refreshes continuity collateral so brains, patch notes and AI handoffs stay in sync.
+
+## Highlights
+- Combined provider: `app/providers/combined.py` loops through MAST, ESO and SDSS providers, concatenating hits and logging failures so partial outages do not abort the search.
+- Registry updates: `app/providers/__init__.py` now registers the `ALL` provider identifier with a lazy import and exposes the human-friendly “All Archives” label to the UI.
+- Archive UI: `app/archive_ui.py` gains a leading “All Archives” tab that reuses the standard search form and dispatches `provider_search("ALL", query)`.
+- Regression tests: New suites cover combined-provider success/failure behaviour and ensure the Streamlit archive tabs render and submit correctly.
+- Continuity docs: Brains v1.1.7, patch notes (Markdown + txt), AI handoff bridge, PATCHLOG, and version.json now align on the v1.1.7 release metadata.
+
+## Implementation Sketch
+1. Add `app/providers/combined.py` with a `search()` generator that iterates through the individual providers and yields their hits while logging any exceptions.
+2. Update `app/providers/__init__.py` to register `ALL`, perform a lazy import of the combined provider, and surface the “All Archives” label via `provider_labels()`.
+3. Extend `ArchiveUI.render()` to insert the All Archives tab ahead of existing providers and reuse `_render_provider` for its search form.
+4. Introduce tests: provider aggregation/error handling in `tests/providers/test_combined_provider.py` and Streamlit tab dispatching in `tests/ui/test_archive_ui.py`.
+5. Refresh continuity artefacts (brains index, AI bridge, patch notes txt, PATCHLOG, version.json) to point at v1.1.7 and cite REF 1.1.7-A01.
+
+## Verification
+- Automated: `pytest` (full suite) covering the new combined provider and archive UI regressions.
+- Manual: Run Streamlit, open the Archive tab, ensure “All Archives” appears first, and execute a Vega search to confirm results from multiple providers appear with provenance intact.
+
+## References
+- Brains entry: [docs/brains/brains_v1.1.7.md](../brains/brains_v1.1.7.md)
+- Patch summary (txt): [docs/PATCH_NOTES/v1.1.7.txt](../PATCH_NOTES/v1.1.7.txt)
+- AI handoff prompt: [docs/ai_handoff/AI Handoff Prompt — v1.1.7.txt](../ai_handoff/AI%20Handoff%20Prompt%20—%20v1.1.7.txt)
+- REF: 1.1.7-A01

--- a/tests/providers/test_combined_provider.py
+++ b/tests/providers/test_combined_provider.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+from app.providers.base import ProviderHit, ProviderQuery
+from app.providers import combined
+
+
+def _make_hit(provider: str, identifier: str) -> ProviderHit:
+    return ProviderHit(
+        provider=provider,
+        identifier=identifier,
+        label=f"{provider} {identifier}",
+        summary=f"Summary for {identifier}",
+        wavelengths_nm=(500.0, 510.0),
+        flux=(1.0, 0.9),
+        metadata={"archive": provider, "identifier": identifier},
+        provenance={"archive": provider, "access_url": "https://example.test"},
+    )
+
+
+def test_search_yields_hits_from_each_provider(monkeypatch):
+    query = ProviderQuery(target="Vega", limit=2)
+
+    monkeypatch.setattr(combined.mast, "search", lambda q: [_make_hit("MAST", "mast-1")])
+    monkeypatch.setattr(combined.eso, "search", lambda q: [_make_hit("ESO", "eso-1")])
+    monkeypatch.setattr(combined.sdss, "search", lambda q: [_make_hit("SDSS", "sdss-1")])
+
+    hits = list(combined.search(query))
+
+    assert [hit.provider for hit in hits] == ["MAST", "ESO", "SDSS"]
+    assert all(hit.metadata["identifier"].endswith("-1") for hit in hits)
+
+
+def test_search_continues_when_provider_fails(monkeypatch, caplog):
+    query = ProviderQuery(target="Vega", limit=1)
+
+    def failing_search(_query: ProviderQuery) -> Iterable[ProviderHit]:
+        raise RuntimeError("MAST offline")
+
+    monkeypatch.setattr(combined.mast, "search", failing_search)
+    monkeypatch.setattr(combined.eso, "search", lambda q: [_make_hit("ESO", "eso-2")])
+    monkeypatch.setattr(combined.sdss, "search", lambda q: [_make_hit("SDSS", "sdss-2")])
+
+    with caplog.at_level(logging.WARNING):
+        hits = list(combined.search(query))
+
+    assert [hit.provider for hit in hits] == ["ESO", "SDSS"]
+    assert "MAST offline" in caplog.text

--- a/tests/ui/test_archive_ui.py
+++ b/tests/ui/test_archive_ui.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from typing import Callable, List
+
+from app import archive_ui as archive_ui_module
+from app.providers.base import ProviderHit
+
+
+class _DummyContext:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class _DummyFigure:
+    def add_trace(self, *args, **kwargs):
+        return None
+
+    def update_layout(self, *args, **kwargs):
+        return None
+
+
+def _patch_streamlit(monkeypatch, tabs_callback: Callable[[List[str]], List[_DummyContext]]):
+    st = archive_ui_module.st
+    monkeypatch.setattr(archive_ui_module.go, "Figure", lambda *a, **k: _DummyFigure())
+    monkeypatch.setattr(archive_ui_module.go, "Scatter", lambda *a, **k: object())
+    monkeypatch.setattr(st, "session_state", {}, raising=False)
+    monkeypatch.setattr(st, "subheader", lambda *a, **k: None)
+    monkeypatch.setattr(st, "caption", lambda *a, **k: None)
+    monkeypatch.setattr(st, "tabs", tabs_callback)
+    monkeypatch.setattr(st, "form", lambda *a, **k: _DummyContext())
+    monkeypatch.setattr(st, "text_input", lambda *a, **k: "")
+    monkeypatch.setattr(st, "slider", lambda *a, **k: k.get("value", 3))
+    monkeypatch.setattr(st, "form_submit_button", lambda *a, **k: False)
+    monkeypatch.setattr(st, "info", lambda *a, **k: None)
+    monkeypatch.setattr(st, "dataframe", lambda *a, **k: None)
+    monkeypatch.setattr(st, "expander", lambda *a, **k: _DummyContext())
+    monkeypatch.setattr(st, "plotly_chart", lambda *a, **k: None)
+    monkeypatch.setattr(st, "columns", lambda *a, **k: [_DummyContext(), _DummyContext()])
+    monkeypatch.setattr(st, "button", lambda *a, **k: False)
+    monkeypatch.setattr(st, "write", lambda *a, **k: None)
+    monkeypatch.setattr(st, "json", lambda *a, **k: None)
+    monkeypatch.setattr(st, "success", lambda *a, **k: None)
+    monkeypatch.setattr(st, "warning", lambda *a, **k: None)
+    monkeypatch.setattr(st, "error", lambda *a, **k: None)
+    return st.session_state
+
+
+def test_archive_ui_exposes_all_archives_tab(monkeypatch):
+    captured_labels: List[str] = []
+
+    def fake_tabs(labels: List[str]):
+        captured_labels.extend(labels)
+        return [_DummyContext() for _ in labels]
+
+    _patch_streamlit(monkeypatch, fake_tabs)
+
+    ui = archive_ui_module.ArchiveUI(add_overlay=lambda payload: (True, "ok"))
+    ui.render()
+
+    assert captured_labels[0] == "All Archives"
+    assert captured_labels == [
+        "All Archives",
+        "MAST",
+        "ESO",
+        "SDSS",
+        "DOI",
+    ]
+
+
+def test_archive_ui_all_tab_dispatches_combined_search(monkeypatch):
+    captured_labels: List[str] = []
+
+    def fake_tabs(labels: List[str]):
+        captured_labels.extend(labels)
+        return [_DummyContext() for _ in labels]
+
+    session_state = _patch_streamlit(monkeypatch, fake_tabs)
+
+    text_values = iter(
+        [
+            " Vega ",
+            "STIS",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "10.1234/foo",
+            "Example DOI",
+        ]
+    )
+    slider_values = iter([3, 3, 3, 3])
+    submit_values = iter([True, False, False, False, False])
+
+    st = archive_ui_module.st
+    monkeypatch.setattr(st, "text_input", lambda *a, **k: next(text_values))
+    monkeypatch.setattr(st, "slider", lambda *a, **k: next(slider_values))
+    monkeypatch.setattr(st, "form_submit_button", lambda *a, **k: next(submit_values))
+
+    hits = [
+        ProviderHit(
+            provider="MAST",
+            identifier="mast-1",
+            label="Vega (MAST)",
+            summary="CALSPEC standard",
+            wavelengths_nm=(500.0, 510.0),
+            flux=(1.0, 0.9),
+            metadata={"target_name": "Vega"},
+            provenance={
+                "archive": "MAST",
+                "access_url": "https://example.test/mast",
+                "fetched_at_utc": "2025-09-22T00:00:00Z",
+            },
+        )
+    ]
+
+    provider_calls: List[tuple[str, object]] = []
+
+    def fake_search(name: str, query):
+        provider_calls.append((name, query))
+        return hits
+
+    monkeypatch.setattr(archive_ui_module, "provider_search", fake_search)
+
+    ui = archive_ui_module.ArchiveUI(add_overlay=lambda payload: (True, "ok"))
+    ui.render()
+
+    assert captured_labels[0] == "All Archives"
+    assert provider_calls and provider_calls[0][0] == "ALL"
+    query = provider_calls[0][1]
+    assert query.target == "Vega"
+    assert query.instrument == "STIS"
+    assert query.limit == 3
+    assert session_state["archive_results_all"] == hits
+    assert session_state["archive_query_all"] == {
+        "target": "Vega",
+        "text": "",
+        "instrument": "STIS",
+        "doi": "",
+        "limit": 3,
+        "wavelength_range": (None, None),
+    }


### PR DESCRIPTION
## Summary
- add an All Archives combined provider with lazy registration in the provider registry
- surface the All Archives tab in the archive UI and cover the workflow with provider/UI tests
- refresh continuity docs, patch notes, patch log, and version metadata for v1.1.7

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0dc96e93083299e669144328a3d80