### PR TITLE
Handle SIMBAD field renames and guard targets panel

### DIFF
--- a/app/ui/targets.py
+++ b/app/ui/targets.py
@@ -7,7 +7,11 @@ def render_targets_panel(registry_dir="data_registry"):
     if not p.exists():
         st.warning("No registry at data_registry/. Run build_registry.py first.")
         return
-    cat = pd.read_csv(p/"catalog.csv")
+    catalog_path = p / "catalog.csv"
+    if not catalog_path.exists():
+        st.warning("No registry at data_registry/. Run build_registry.py first.")
+        return
+    cat = pd.read_csv(catalog_path)
     with st.expander("Target catalog", expanded=True):
         st.dataframe(cat[["name","sptype","n_planets","has_mast","has_eso","summary"]])
 

--- a/tests/providers/test_simbad_fields.py
+++ b/tests/providers/test_simbad_fields.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from astropy.table import Table
+
+from tools import build_registry
+
+
+def test_resolve_target_vega_has_astrometry(monkeypatch):
+    def fake_query_object(name: str):
+        if name != "Vega":
+            return None
+        return Table(
+            names=(
+                "MAIN_ID",
+                "RA",
+                "DEC",
+                "OTYPES",
+                "SP_TYPE",
+                "RVZ_RADVEL",
+                "PLX_VALUE",
+            ),
+            rows=[
+                (
+                    "Vega",
+                    "18 36 56.33635",
+                    "+38 47 01.2802",
+                    "Star",
+                    "A0V",
+                    -13.5,
+                    130.23,
+                )
+            ],
+        )
+
+    monkeypatch.setattr(build_registry.SIMBAD, "query_object", fake_query_object)
+
+    meta = build_registry.resolve_target("Vega")
+
+    assert meta["parallax_mas"] == 130.23
+    assert meta["rv_kms"] == -13.5


### PR DESCRIPTION
## Summary
- rebuild the SIMBAD client configuration to prefer the new column names and automatically fall back to legacy identifiers when queries fail
- update `resolve_target` to read the renamed radial-velocity column and add a regression test that exercises the Vega metadata path
- ensure the Streamlit targets panel shows a warning when `catalog.csv` is missing so the app does not crash on partial builds

## Testing
- pytest tests/providers/test_simbad_fields.py

------
https://chatgpt.com/codex/tasks/task_e_68d9b8df531c8329a8381f192804e8b5