### PR TITLE
Collapse examples sidebar by default

### DIFF
--- a/app/ui/main.py
+++ b/app/ui/main.py
@@ -606,7 +606,7 @@ def _load_example_preview(spec: ExampleSpec, *, allow_network: bool) -> Optional
 
 
 def _render_examples_group() -> None:
-    with st.sidebar.expander("Examples", expanded=True):
+    with st.sidebar.expander("Examples", expanded=False):
         if not EXAMPLE_LIBRARY:
             st.caption("Example library unavailable.")
             return


### PR DESCRIPTION
## Summary
- open the examples sidebar expander in a collapsed state by default so users opt in to view it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9c9723f28832993169a3494ed21c6