### PR TITLE
Handle SIMBAD main_id column rename in build_registry

### DIFF
--- a/tools/build_registry.py
+++ b/tools/build_registry.py
@@ -208,7 +208,8 @@ def resolve_target(name):
         return None
     c = SkyCoord(ra, dec, unit=unit)
 
-    canonical = _decode_if_bytes(r["MAIN_ID"][0])
+    canonical_value = _get_first_value(r, "main_id")
+    canonical = _decode_if_bytes(canonical_value) if canonical_value is not None else name
     otype = _decode_if_bytes(_get_first_value(r, "otypes"))
     sptype = _decode_if_bytes(_get_first_value(r, "sp_type", "sptype"))
     parallax = _get_first_value(r, "plx_value", "plx")


### PR DESCRIPTION
## Summary
- use the helper getter when retrieving the SIMBAD canonical identifier so the code works whether the column is exposed as MAIN_ID or main_id

## Testing
- python tools/build_registry.py --roster targets.yaml --out data_registry_test --sleep 0 *(interrupted after prolonged wait on remote query)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c97d221c8329b3a0ff647b551f38