### PR TITLE
Collapse target catalog by default and render in main flow

### DIFF
--- a/app/ui/main.py
+++ b/app/ui/main.py
@@ -2183,6 +2183,7 @@ def render() -> None:
     _render_example_browser()
     _render_examples_group()
     _render_line_catalog_group()
+    render_targets_panel(expanded=False)
     _render_uploads_group()
     _render_settings_group()
 
@@ -2201,9 +2202,6 @@ def render() -> None:
 
 def main() -> None:
     render()
-
-# Sidebar: Catalog
-render_targets_panel("data_registry")
 
 if __name__ == "__main__":
     main()

--- a/app/ui/targets.py
+++ b/app/ui/targets.py
@@ -2,7 +2,7 @@
 import json, pandas as pd, streamlit as st
 from pathlib import Path
 
-def render_targets_panel(registry_dir="data_registry"):
+def render_targets_panel(registry_dir="data_registry", *, expanded: bool = False):
     p = Path(registry_dir)
     if not p.exists():
         st.warning("No registry at data_registry/. Run build_registry.py first.")
@@ -12,7 +12,7 @@ def render_targets_panel(registry_dir="data_registry"):
         st.warning("No registry at data_registry/. Run build_registry.py first.")
         return
     cat = pd.read_csv(catalog_path)
-    with st.expander("Target catalog", expanded=True):
+    with st.expander("Target catalog", expanded=expanded):
         st.dataframe(cat[["name","sptype","n_planets","has_mast","has_eso","summary"]])
 
     name = st.selectbox("Pick a target", sorted(cat["name"].tolist()))


### PR DESCRIPTION
## Summary
- add an `expanded` option to the target catalog panel and default it to collapsed
- invoke the target catalog panel from the main render routine so it stays with the other sidebar groups

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9c972e3c88329a6c5c6db65d821a4