### PR TITLE
Cap manifest MAST products and update UI handling

### DIFF
--- a/tests/providers/test_targets_ui.py
+++ b/tests/providers/test_targets_ui.py
@@ -1,0 +1,34 @@
+from app.ui.targets import _extract_mast_products
+
+
+def test_extract_mast_products_handles_summary_dict():
+    manifest = {
+        "datasets": {
+            "mast_products": {
+                "items": [{"productFilename": "a"}, {"productFilename": "b"}],
+                "total_count": 5,
+                "truncated": True,
+            }
+        }
+    }
+
+    items, total, truncated = _extract_mast_products(manifest)
+    assert len(items) == 2
+    assert total == 5
+    assert truncated is True
+
+
+def test_extract_mast_products_handles_legacy_list():
+    manifest = {
+        "datasets": {
+            "mast_products": [
+                {"productFilename": "legacy-1"},
+                {"productFilename": "legacy-2"},
+            ]
+        }
+    }
+
+    items, total, truncated = _extract_mast_products(manifest)
+    assert len(items) == 2
+    assert total == 2
+    assert truncated is False

--- a/tests/providers/test_write_manifest.py
+++ b/tests/providers/test_write_manifest.py
@@ -32,11 +32,48 @@ def test_write_manifest_normalizes_mast_products(tmp_path):
     )
 
     mast_products = manifest["datasets"]["mast_products"]
-    assert len(mast_products) == 1
-    entry = mast_products[0]
+    assert mast_products["total_count"] == 1
+    assert mast_products["truncated"] is False
+    assert len(mast_products["items"]) == 1
+    entry = mast_products["items"][0]
 
     assert entry["obsid"] == "OBS-1"
     assert entry["productURL"] == "https://example.com/spec.fits"
     assert entry["productFilename"] == "spec.fits"
     assert entry["productType"] == ""
     assert entry["description"] == ""
+
+
+def test_write_manifest_caps_mast_products(tmp_path):
+    total = build_registry.MAX_MAST_PRODUCTS + 5
+    mast_products_tbl = Table(
+        {
+            "obsID": [f"OBS-{i}" for i in range(total)],
+            "productFilename": [f"spec-{i}.fits" for i in range(total)],
+            "dataproduct_type": ["spectrum"] * total,
+            "dataURI": [f"https://example.com/spec-{i}.fits" for i in range(total)],
+        }
+    )
+
+    manifest = build_registry.write_manifest(
+        tmp_path,
+        "Target Star",
+        {
+            "canonical_name": "Target Star",
+            "ra_deg": 10.0,
+            "dec_deg": -5.0,
+        },
+        mast_meta=None,
+        mast_products_tbl=mast_products_tbl,
+        eso_tbl=None,
+        carm_tbl=None,
+        planets_df=pd.DataFrame(),
+        tags=[],
+    )
+
+    mast_products = manifest["datasets"]["mast_products"]
+    assert mast_products["total_count"] == total
+    assert mast_products["truncated"] is True
+    assert len(mast_products["items"]) == build_registry.MAX_MAST_PRODUCTS
+    assert mast_products["items"][0]["obsid"] == "OBS-0"
+    assert mast_products["items"][-1]["obsid"] == f"OBS-{build_registry.MAX_MAST_PRODUCTS - 1}"


### PR DESCRIPTION
## Summary
- cap serialized MAST products at 250 entries and record total counts in the manifest
- update the targets sidebar helper to consume the capped/summary structure and surface truncation info
- add coverage to ensure manifest capping and the UI helper handle both summary and legacy formats

## Testing
- pytest tests/providers -q

------
https://chatgpt.com/codex/tasks/task_e_68d9d2f14d448329b762f43fa096bb16