### PR TITLE
Handle missing target registry in sidebar

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,19 +1,11 @@
-this is a last moment addition
+# Repository notes for agents
 
+This codebase tracks the actively maintained v2.x series of the Spectra App. Legacy
+"brains" or atlas assets that may be mentioned in older documentation are now
+out-of-date; rely on the current repository state and accompanying notes instead.
 
-
-you are working on a much more updated version of this app
-
-all past brains and atlas files are much out of date than they may seem.
-
-
-
-the next ai to read this will:
-
-refer to instructions and past versions and notes, but we have a lot more to work with this time. 
-
-take note of whats different, and adjust the documentation as such.
-versions from here on out will be v2.0+
-
-after you read this file, delete my text in here. then rewrite it in a more formal way such that the next ai will know what to do, where to look for stuff, etc.
+When onboarding to a task:
+- Review the documentation in `docs/` and prior changelogs for relevant context.
+- Prefer the current implementation over historical references when discrepancies arise.
+- Update documentation as needed to reflect material differences from older versions.
 

--- a/app/ui/main.py
+++ b/app/ui/main.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
-from app.ui.targets import render_targets_panel
+from app.ui.targets import RegistryUnavailableError, render_targets_panel
 import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
@@ -2209,14 +2209,21 @@ def render() -> None:
     _render_settings_group(controls_panel)
 
     data_panel = sidebar.expander("Data library", expanded=False)
+    registry_warning: Optional[str] = None
     with data_panel:
         _render_examples_group(data_panel)
         data_panel.divider()
-        render_targets_panel(expanded=False, sidebar=data_panel)
+        try:
+            render_targets_panel(expanded=False, sidebar=data_panel)
+        except RegistryUnavailableError as exc:
+            registry_warning = str(exc)
+            data_panel.info(registry_warning)
         data_panel.divider()
         _render_line_catalog_group(data_panel)
         data_panel.divider()
         _render_uploads_group(data_panel)
+    if registry_warning:
+        sidebar.warning(registry_warning)
 
     overlay_tab, diff_tab, archive_tab, docs_tab = st.tabs(["Overlay", "Differential", "Archive", "Docs & Provenance"])
     with overlay_tab:

--- a/app/ui/targets.py
+++ b/app/ui/targets.py
@@ -1,9 +1,19 @@
 # app/ui/targets.py  (new small component)
-import json, pandas as pd, streamlit as st
+import json
 from pathlib import Path
-from typing import Optional, Tuple, List, Dict, Any
+from typing import Any, Dict, List, Optional, Tuple
+
+import pandas as pd
+import streamlit as st
 
 from streamlit.delta_generator import DeltaGenerator
+
+
+class RegistryUnavailableError(RuntimeError):
+    """Raised when the target registry directory or catalog is missing."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
 
 
 def _extract_mast_products(manifest: Dict[str, Any]) -> Tuple[List[Dict[str, Any]], int, bool]:
@@ -30,12 +40,14 @@ def render_targets_panel(
     container = sidebar or st.sidebar
     p = Path(registry_dir)
     if not p.exists():
-        container.warning("No registry at data_registry/. Run build_registry.py first.")
-        return
+        raise RegistryUnavailableError(
+            "No registry at data_registry/. Run build_registry.py first."
+        )
     catalog_path = p / "catalog.csv"
     if not catalog_path.exists():
-        container.warning("No registry at data_registry/. Run build_registry.py first.")
-        return
+        raise RegistryUnavailableError(
+            "No registry at data_registry/. Run build_registry.py first."
+        )
     cat = pd.read_csv(catalog_path)
     expander = container.expander("Target catalog", expanded=expanded)
     with expander:


### PR DESCRIPTION
## Summary
- add a RegistryUnavailableError sentinel in the targets panel when the data registry or catalog is absent
- surface the missing-registry warning on the main sidebar while preserving the existing expander contents
- refresh the repository agent notes to reflect the maintained v2.x application state

## Testing
- python -m compileall app/ui/targets.py
- streamlit run app/ui/main.py --server.headless true --server.port 8501 *(fails: pre-existing syntax error in app/ui/main.py around legacy similarity sidebar helpers)*


------
https://chatgpt.com/codex/tasks/task_e_68d9e0d7d4a48329ad8b601d077941ee