### PR TITLE
Add local ingest fallback for dense ASCII parsing failures

### DIFF
--- a/app/utils/local_ingest.py
+++ b/app/utils/local_ingest.py
@@ -148,6 +148,26 @@ def _should_use_dense_parser(name: str, payload: bytes) -> bool:
     return False
 
 
+def _should_fallback_to_table(error: Exception) -> bool:
+    if not isinstance(error, ValueError):
+        return False
+    message = str(error).lower()
+    return "no numeric samples" in message
+
+
+def _parse_ascii_table(filename: str, payload: bytes) -> Dict[str, object]:
+    table = read_table(payload, include_header=True)
+    return parse_ascii(
+        table.dataframe,
+        content_bytes=payload,
+        header_lines=table.header_lines,
+        column_labels=table.column_labels,
+        delimiter=table.delimiter,
+        filename=filename,
+        orientation=getattr(table, "orientation", None),
+    )
+
+
 def _read_zip_segments(name: str, content: bytes) -> List[Tuple[str, bytes]]:
     try:
         archive = zipfile.ZipFile(io.BytesIO(content))
@@ -264,29 +284,37 @@ def ingest_local_file(name: str, content: bytes) -> Dict[str, object]:
             parsed = parse_fits(payload, filename=processed_name)
         elif detected_format == "zip":
             segments = _read_zip_segments(processed_name, payload)
-            parsed = parse_ascii_segments(
-                segments,
-                root_filename=processed_name,
-                chunk_size=_DENSE_CHUNK_SIZE,
-            )
-        else:
-            if _should_use_dense_parser(processed_name, payload):
+            try:
                 parsed = parse_ascii_segments(
-                    [(processed_name, payload)],
+                    segments,
                     root_filename=processed_name,
                     chunk_size=_DENSE_CHUNK_SIZE,
                 )
+            except ValueError as dense_exc:
+                if not (_should_fallback_to_table(dense_exc) and len(segments) == 1):
+                    raise
+                segment_name, segment_payload = segments[0]
+                try:
+                    parsed = _parse_ascii_table(segment_name, segment_payload)
+                except Exception as fallback_exc:
+                    raise fallback_exc from dense_exc
+        else:
+            if _should_use_dense_parser(processed_name, payload):
+                try:
+                    parsed = parse_ascii_segments(
+                        [(processed_name, payload)],
+                        root_filename=processed_name,
+                        chunk_size=_DENSE_CHUNK_SIZE,
+                    )
+                except ValueError as dense_exc:
+                    if not _should_fallback_to_table(dense_exc):
+                        raise
+                    try:
+                        parsed = _parse_ascii_table(processed_name, payload)
+                    except Exception as fallback_exc:
+                        raise fallback_exc from dense_exc
             else:
-                table = read_table(payload, include_header=True)
-                parsed = parse_ascii(
-                    table.dataframe,
-                    content_bytes=payload,
-                    header_lines=table.header_lines,
-                    column_labels=table.column_labels,
-                    delimiter=table.delimiter,
-                    filename=processed_name,
-                    orientation=getattr(table, "orientation", None),
-                )
+                parsed = _parse_ascii_table(processed_name, payload)
     except Exception as exc:
         raise LocalIngestError(f"Failed to ingest {original_name}: {exc}") from exc
 

--- a/tests/data/tab_header.tsv
+++ b/tests/data/tab_header.tsv
@@ -1,0 +1,3 @@
+wavelength (nm)	flux (relative)
+500	1.2
+505	1.3

--- a/tests/server/test_local_ingest.py
+++ b/tests/server/test_local_ingest.py
@@ -243,6 +243,26 @@ def test_ingest_local_dense_ascii_uses_cache(monkeypatch):
     assert cache_path.exists()
 
 
+def test_ingest_local_dense_ascii_falls_back_for_tab_delimited(monkeypatch):
+    monkeypatch.setattr(local_ingest, "_DENSE_SIZE_THRESHOLD", 0)
+    monkeypatch.setattr(local_ingest, "_DENSE_LINE_THRESHOLD", 0)
+
+    def failing_parse_ascii_segments(*args, **kwargs):
+        raise ValueError("No numeric samples detected across ASCII segments")
+
+    monkeypatch.setattr(local_ingest, "parse_ascii_segments", failing_parse_ascii_segments)
+
+    tab_path = Path(__file__).resolve().parents[1] / "data" / "tab_header.tsv"
+    content = tab_path.read_bytes()
+
+    payload = ingest_local_file("tab_header.csv", content)
+
+    assert payload["wavelength_nm"] == [500.0, 505.0]
+    assert payload["flux"] == [1.2, 1.3]
+    assert payload["metadata"]["filename"] == "tab_header.csv"
+    assert payload["provenance"]["filename"] == "tab_header.csv"
+
+
 def test_ingest_local_fits_enriches_metadata():
     flux_values = np.array([1.0, 2.0, 3.0], dtype=float)
 


### PR DESCRIPTION
## Summary
- add a dense ASCII fallback that reroutes "no numeric samples" ValueErrors through the standard table parser for both single files and zip archives
- factor shared ASCII table parsing into a helper used by the new fallback path
- add a tab-delimited sample and unit test to cover the fallback behaviour

## Testing
- pytest tests/server/test_local_ingest.py::test_ingest_local_dense_ascii_falls_back_for_tab_delimited

------
https://chatgpt.com/codex/tasks/task_e_68da00c38f608329b61b3a695453a713