### PR TITLE
Fix duplicate differential submit button

### DIFF
--- a/app/ui/main.py
+++ b/app/ui/main.py
@@ -2307,36 +2307,38 @@ def _render_differential_tab() -> None:
 
     sample_default = int(st.session_state.get("differential_sample_points", 2000))
 
-    with st.form("differential_compute_form"):
-        col_a, col_b = st.columns(2)
-        trace_a_id = col_a.selectbox(
-            "Trace A",
-            options,
-            index=options.index(default_a),
-            format_func=_trace_label,
-        )
-        trace_b_id = col_b.selectbox(
-            "Trace B",
-            options,
-            index=options.index(default_b),
-            format_func=_trace_label,
-        )
-        col_op, col_samples = st.columns(2)
-        operation_label = col_op.selectbox(
-            "Operation",
-            operation_labels,
-            index=operation_labels.index(default_operation),
-        )
-        sample_points = col_samples.slider(
-            "Resample points",
-            min_value=300,
-            max_value=8000,
-            step=100,
-            value=sample_default,
-        )
-        submitted = st.form_submit_button(
-            "Compute differential", use_container_width=True
-        )
+    form = st.form("differential_compute_form")
+    col_a, col_b = form.columns(2)
+    trace_a_id = col_a.selectbox(
+        "Trace A",
+        options,
+        index=options.index(default_a),
+        format_func=_trace_label,
+    )
+    trace_b_id = col_b.selectbox(
+        "Trace B",
+        options,
+        index=options.index(default_b),
+        format_func=_trace_label,
+    )
+    col_op, col_samples = form.columns(2)
+    operation_label = col_op.selectbox(
+        "Operation",
+        operation_labels,
+        index=operation_labels.index(default_operation),
+    )
+    sample_points = col_samples.slider(
+        "Resample points",
+        min_value=300,
+        max_value=8000,
+        step=100,
+        value=sample_default,
+    )
+    submitted = form.form_submit_button(
+        "Compute differential",
+        use_container_width=True,
+        key="differential_compute_submit",
+    )
 
 
     result = st.session_state.get("differential_result")

--- a/tests/ui/test_differential_form.py
+++ b/tests/ui/test_differential_form.py
@@ -36,3 +36,18 @@ def test_differential_form_has_single_submit_button():
 
     # The form should render without raising a DuplicateWidgetID error from
     # multiple submit buttons with identical labels/keys.
+
+    from collections import deque
+
+    button_nodes = []
+    queue: deque = deque([app._tree.root])
+    while queue:
+        node = queue.popleft()
+        node_type = getattr(node, "type", None)
+        if node_type == "button" and getattr(node, "form_id", None) == "differential_compute_form":
+            button_nodes.append(node)
+        children = getattr(node, "children", None)
+        if isinstance(children, dict):
+            queue.extend(children.values())
+
+    assert len(button_nodes) == 1


### PR DESCRIPTION
## Summary
- ensure the differential analysis form builds its controls from a single Streamlit form instance and gives the submit button a unique key
- extend the differential form integration test to confirm only one submit control is rendered

## Testing
- pytest tests/ui/test_differential_form.py -q

------
https://chatgpt.com/codex/tasks/task_e_68da1fa2f31883299d99702dea79dbbe