### PR TITLE
Filter non-flux columns from additional traces

### DIFF
--- a/app/server/ingest_ascii.py
+++ b/app/server/ingest_ascii.py
@@ -116,10 +116,14 @@ _FLUX_LABEL_KEYWORDS = {
     "irradiance",
     "radiance",
     "luminosity",
+    "luminance",
     "emission",
+    "emittance",
     "fnu",
     "flam",
     "surface",
+    "fluxdensity",
+    "spectralflux",
 }
 
 _FLUX_LABEL_SUBSTRINGS = {
@@ -132,18 +136,22 @@ _FLUX_LABEL_SUBSTRINGS = {
     "irradiance",
     "radiance",
     "luminos",
+    "lumin",
     "emission",
     "fnu",
     "flam",
     "count",
+    "fluxdens",
 }
 
 _FLUX_UNIT_KEYWORDS = {
     "erg",
+    "ergs",
     "jansky",
     "jy",
     "w/",
     "w m",
+    "watt",
     "photon",
     "photons",
     "count",
@@ -153,6 +161,44 @@ _FLUX_UNIT_KEYWORDS = {
     "intens",
     "radiance",
     "irradiance",
+    "nm^-1",
+    "hz^-1",
+    "cm^-2",
+    "sr^-1",
+    "/nm",
+}
+
+_NON_FLUX_LABEL_KEYWORDS = {
+    "airmass",
+    "air",
+    "altitude",
+    "azimuth",
+    "date",
+    "time",
+    "sun",
+    "moon",
+    "earth",
+    "target",
+    "object",
+    "quality",
+    "flag",
+    "mask",
+    "error",
+    "uncertainty",
+    "sigma",
+    "std",
+    "stdev",
+    "velocity",
+    "speed",
+    "km",
+    "kms",
+    "temperature",
+    "temp",
+    "exposure",
+    "seeing",
+    "angle",
+    "index",
+    "ratio",
 }
 
 
@@ -185,6 +231,9 @@ def _is_flux_like_label(label: str) -> bool:
     if not lowered:
         return False
     tokens = [token for token in re.split(r"[^a-z0-9]+", lowered) if token]
+    significant = [token for token in tokens if len(token) > 1]
+    if significant and all(token in _NON_FLUX_LABEL_KEYWORDS for token in significant):
+        return False
     for token in tokens:
         if token in _FLUX_LABEL_KEYWORDS:
             return True

--- a/tests/server/test_local_ingest.py
+++ b/tests/server/test_local_ingest.py
@@ -106,11 +106,11 @@ def test_ingest_local_ascii_multiple_flux_columns():
 def test_ingest_local_ascii_filters_non_flux_numeric_columns():
     content = dedent(
         """
-        Wavelength (nm),Flux (10^-16 erg/s/cm^2/Å),Continuum (10^-16 erg/s/cm^2/Å),Temperature (K),Quality Flag
-        400,0.10,0.12,5000,0
-        405,0.12,0.11,5050,1
-        410,0.08,0.09,5075,0
-        415,0.09,0.10,5100,0
+        Wavelength (nm),Flux (10^-16 erg/s/cm^2/Å),Continuum (10^-16 erg/s/cm^2/Å),Sun,Temperature (K),Quality Flag,Radial Velocity (km/s)
+        400,0.10,0.12,1.0,5000,0,30
+        405,0.12,0.11,1.0,5050,1,32
+        410,0.08,0.09,1.0,5075,0,31
+        415,0.09,0.10,1.0,5100,0,29
         """
     ).strip()
 
@@ -132,7 +132,12 @@ def test_ingest_local_ascii_filters_non_flux_numeric_columns():
     continuum_entry = extras[0]
     assert continuum_entry["flux"] == [0.12, 0.11, 0.09, 0.10]
 
-    non_flux_headers = {"Temperature (K)", "Quality Flag"}
+    non_flux_headers = {
+        "Temperature (K)",
+        "Quality Flag",
+        "Sun",
+        "Radial Velocity (km/s)",
+    }
     for header in non_flux_headers:
         assert header not in labels
 

--- a/tests/ui/test_overlay_additional_traces.py
+++ b/tests/ui/test_overlay_additional_traces.py
@@ -24,11 +24,11 @@ def reset_session_state(monkeypatch):
 def test_add_overlay_payload_handles_additional_traces(reset_session_state):
     content = dedent(
         """
-        Wavelength (nm),Flux (arb),Continuum Flux (arb),Velocity (km/s)
-        400,0.10,0.05,30
-        405,0.12,0.06,32
-        410,0.08,0.07,31
-        415,0.09,0.08,29
+        Wavelength (nm),Flux (arb),Continuum Flux (arb),Sun,Temperature (K),Quality Flag,Velocity (km/s)
+        400,0.10,0.05,1.0,5000,0,30
+        405,0.12,0.06,1.0,5050,1,32
+        410,0.08,0.07,1.0,5075,0,31
+        415,0.09,0.08,1.0,5100,0,29
         """
     ).strip()
 
@@ -54,7 +54,10 @@ def test_add_overlay_payload_handles_additional_traces(reset_session_state):
     }
 
     assert payload["additional_traces"]
-    assert {entry["label"] for entry in payload["additional_traces"]} == {"Continuum Flux (arb)"}
+    labels = {entry["label"] for entry in payload["additional_traces"]}
+    assert labels == {"Continuum Flux (arb)"}
+    assert "Sun" not in labels
+    assert "Temperature (K)" not in labels
 
     added, message = main._add_overlay_payload(payload)
 


### PR DESCRIPTION
## Summary
- tighten flux keyword heuristics and add metadata exclusions when detecting auxiliary traces
- ensure ASCII ingest only exposes true flux series in additional_traces
- update UI regression to confirm extraneous numeric columns are ignored

## Testing
- pytest tests/server/test_local_ingest.py::test_ingest_local_ascii_filters_non_flux_numeric_columns
- pytest tests/ui/test_overlay_additional_traces.py::test_add_overlay_payload_handles_additional_traces

------
https://chatgpt.com/codex/tasks/task_e_68da25b6bf04832983db504a7b4ce342