### PR TITLE
Fix duplicate differential form submit widget

### DIFF
--- a/app/ui/main.py
+++ b/app/ui/main.py
@@ -2307,38 +2307,38 @@ def _render_differential_tab() -> None:
 
     sample_default = int(st.session_state.get("differential_sample_points", 2000))
 
-    form = st.form("differential_compute_form")
-    col_a, col_b = form.columns(2)
-    trace_a_id = col_a.selectbox(
-        "Trace A",
-        options,
-        index=options.index(default_a),
-        format_func=_trace_label,
-    )
-    trace_b_id = col_b.selectbox(
-        "Trace B",
-        options,
-        index=options.index(default_b),
-        format_func=_trace_label,
-    )
-    col_op, col_samples = form.columns(2)
-    operation_label = col_op.selectbox(
-        "Operation",
-        operation_labels,
-        index=operation_labels.index(default_operation),
-    )
-    sample_points = col_samples.slider(
-        "Resample points",
-        min_value=300,
-        max_value=8000,
-        step=100,
-        value=sample_default,
-    )
-    submitted = form.form_submit_button(
-        "Compute differential",
-        use_container_width=True,
-        key="differential_compute_submit",
-    )
+    with st.form(key="differential_compute_form"):
+        col_a, col_b = st.columns(2)
+        trace_a_id = col_a.selectbox(
+            "Trace A",
+            options,
+            index=options.index(default_a),
+            format_func=_trace_label,
+        )
+        trace_b_id = col_b.selectbox(
+            "Trace B",
+            options,
+            index=options.index(default_b),
+            format_func=_trace_label,
+        )
+        col_op, col_samples = st.columns(2)
+        operation_label = col_op.selectbox(
+            "Operation",
+            operation_labels,
+            index=operation_labels.index(default_operation),
+        )
+        sample_points = col_samples.slider(
+            "Resample points",
+            min_value=300,
+            max_value=8000,
+            step=100,
+            value=sample_default,
+        )
+        submitted = st.form_submit_button(
+            "Compute differential",
+            key="differential_compute_submit",
+            use_container_width=True,
+        )
 
 
     result = st.session_state.get("differential_result")


### PR DESCRIPTION
## Summary
- render the differential tab controls within a single `st.form` context so only one submit element is registered
- keep the differential form layout intact while ensuring the submit button uses a dedicated key

## Testing
- pytest tests/ui/test_differential_form.py

------
https://chatgpt.com/codex/tasks/task_e_68db1a3d4244832997de4a142ddbcb07