### PR TITLE
Add full resolution overlay rendering preference

### DIFF
--- a/app/ui/main.py
+++ b/app/ui/main.py
@@ -94,7 +94,7 @@ class OverlayTrace:
         self,
         viewport: Tuple[float | None, float | None],
         *,
-        max_points: int = 8000,
+        max_points: Optional[int] = 8000,
         include_hover: bool = True,
     ) -> Tuple[np.ndarray, np.ndarray, Optional[List[str]], bool]:
         wavelengths = np.asarray(self.wavelength_nm, dtype=float)
@@ -114,6 +114,9 @@ class OverlayTrace:
                 hover_values = [
                     hover for hover, keep in zip(hover_values, mask.tolist()) if keep
                 ]
+
+        if max_points is None:
+            return wavelengths, flux_values, hover_values, True
 
         if wavelengths.size <= max_points:
             return wavelengths, flux_values, hover_values, True
@@ -162,7 +165,7 @@ class OverlayTrace:
             )
         selected_w, selected_f, _, _ = self.sample(
             viewport or (None, None),
-            max_points=max_points or len(self.wavelength_nm),
+            max_points=max_points,
             include_hover=False,
         )
         return TraceVectors(
@@ -322,6 +325,7 @@ def _ensure_session_state() -> None:
     st.session_state.setdefault("overlay_traces", [])
     st.session_state.setdefault("display_units", "nm")
     st.session_state.setdefault("display_mode", "Flux (raw)")
+    st.session_state.setdefault("display_full_resolution", False)
     st.session_state.setdefault("viewport_nm", (None, None))
     st.session_state.setdefault("auto_viewport", True)
     st.session_state.setdefault("normalization_mode", "unit")
@@ -353,6 +357,19 @@ def _ensure_session_state() -> None:
         st.session_state["duplicate_ledger"] = DuplicateLedger()
     if "similarity_cache" not in st.session_state:
         st.session_state["similarity_cache"] = SimilarityCache()
+
+
+def _is_full_resolution_enabled() -> bool:
+    session_state = getattr(st, "session_state", None)
+    if session_state is None:
+        return False
+    getter = getattr(session_state, "get", None)
+    if callable(getter):
+        return bool(getter("display_full_resolution", False))
+    try:
+        return bool(session_state["display_full_resolution"])
+    except (KeyError, TypeError):
+        return False
 
 
 MAST_DOWNLOAD_ENDPOINT = "https://mast.stsci.edu/api/v0.1/Download/file"
@@ -917,6 +934,13 @@ def _render_display_section(container: DeltaGenerator) -> None:
         "Flux scaling", display_mode_options, index=mode_index
     )
 
+    full_resolution = container.checkbox(
+        "Full resolution rendering",
+        value=bool(st.session_state.get("display_full_resolution", False)),
+        help="Render traces using all available points in the current viewport.",
+    )
+    st.session_state["display_full_resolution"] = bool(full_resolution)
+
     overlays = _get_overlays()
     target_overlays = [trace for trace in overlays if trace.visible] or overlays
     min_bound, max_bound = _infer_viewport_bounds(target_overlays)
@@ -1384,8 +1408,12 @@ def _build_overlay_figure(
 ) -> Tuple[go.Figure, str]:
     fig = go.Figure()
     axis_title = "Wavelength (nm)"
+    full_resolution = _is_full_resolution_enabled()
+    max_points = None if full_resolution else 12000
     reference_vectors = (
-        reference.to_vectors(max_points=12000, viewport=viewport) if reference else None
+        reference.to_vectors(max_points=max_points, viewport=viewport)
+        if reference
+        else None
     )
 
     for trace in overlays:
@@ -1407,7 +1435,7 @@ def _build_overlay_figure(
 
         sample_w, sample_flux, sample_hover, _ = trace.sample(
             viewport,
-            max_points=12000,
+            max_points=max_points,
             include_hover=True,
         )
         if sample_w.size == 0:
@@ -2065,8 +2093,10 @@ def _render_overlay_tab(version_info: Dict[str, str]) -> None:
         st.caption(f"Axis: {axis_title}")
 
     cache: SimilarityCache = st.session_state["similarity_cache"]
+    full_resolution = _is_full_resolution_enabled()
+    vector_max_points = None if full_resolution else 15000
     visible_vectors = [
-        trace.to_vectors(max_points=15000, viewport=effective_viewport)
+        trace.to_vectors(max_points=vector_max_points, viewport=effective_viewport)
         for trace in overlays
         if trace.visible
     ]

--- a/tests/ui/test_overlay_full_resolution.py
+++ b/tests/ui/test_overlay_full_resolution.py
@@ -1,0 +1,51 @@
+from types import SimpleNamespace
+
+
+import numpy as np
+
+import pytest
+
+from app.ui import main
+
+
+@pytest.fixture(autouse=True)
+def session_state(monkeypatch):
+    state = {"display_full_resolution": True}
+    monkeypatch.setattr(main, "st", SimpleNamespace(session_state=state))
+    yield state
+
+
+def test_full_resolution_preference_returns_all_points(session_state):
+    wavelengths = np.linspace(400.0, 800.0, 15000)
+    flux = np.sin(wavelengths / 20.0)
+
+    trace = main.OverlayTrace(
+        trace_id="full-res",
+        label="High density",
+        wavelength_nm=tuple(float(value) for value in wavelengths.tolist()),
+        flux=tuple(float(value) for value in flux.tolist()),
+    )
+
+    sampled_w, sampled_f, hover, dense = trace.sample(
+        (None, None), max_points=None, include_hover=True
+    )
+
+    assert dense is True
+    assert hover is None
+    assert sampled_f.size == wavelengths.size
+    assert sampled_w.size == wavelengths.size
+
+    fig, _ = main._build_overlay_figure(
+        overlays=[trace],
+        display_units="nm",
+        display_mode="Flux (raw)",
+        normalization_mode="none",
+        viewport=(None, None),
+        reference=None,
+        differential_mode="Off",
+        version_tag="vtest",
+    )
+
+    plotted_trace = fig.data[0]
+    assert len(plotted_trace.x) == wavelengths.size
+    assert len(plotted_trace.y) == wavelengths.size


### PR DESCRIPTION
## Summary
- add a session-level toggle for rendering overlays at full resolution
- ensure overlay sampling and similarity vectors skip downsampling when the preference is enabled
- cover the new behaviour with a high-density overlay regression test

## Testing
- pytest tests/ui/test_overlay_full_resolution.py

------
https://chatgpt.com/codex/tasks/task_e_68db263c54748329aa0fb3994e4120ee