### PR TITLE
Add full resolution overlay rendering preference

### DIFF
--- a/tests/ui/test_overlay_full_resolution.py
+++ b/tests/ui/test_overlay_full_resolution.py
@@ -1,0 +1,51 @@
+from types import SimpleNamespace
+
+
+import numpy as np
+
+import pytest
+
+from app.ui import main
+
+
+@pytest.fixture(autouse=True)
+def session_state(monkeypatch):
+    state = {"display_full_resolution": True}
+    monkeypatch.setattr(main, "st", SimpleNamespace(session_state=state))
+    yield state
+
+
+def test_full_resolution_preference_returns_all_points(session_state):
+    wavelengths = np.linspace(400.0, 800.0, 15000)
+    flux = np.sin(wavelengths / 20.0)
+
+    trace = main.OverlayTrace(
+        trace_id="full-res",
+        label="High density",
+        wavelength_nm=tuple(float(value) for value in wavelengths.tolist()),
+        flux=tuple(float(value) for value in flux.tolist()),
+    )
+
+    sampled_w, sampled_f, hover, dense = trace.sample(
+        (None, None), max_points=None, include_hover=True
+    )
+
+    assert dense is True
+    assert hover is None
+    assert sampled_f.size == wavelengths.size
+    assert sampled_w.size == wavelengths.size
+
+    fig, _ = main._build_overlay_figure(
+        overlays=[trace],
+        display_units="nm",
+        display_mode="Flux (raw)",
+        normalization_mode="none",
+        viewport=(None, None),
+        reference=None,
+        differential_mode="Off",
+        version_tag="vtest",
+    )
+
+    plotted_trace = fig.data[0]
+    assert len(plotted_trace.x) == wavelengths.size
+    assert len(plotted_trace.y) == wavelengths.size


### PR DESCRIPTION
## Summary
- add a session-level toggle for rendering overlays at full resolution
- ensure overlay sampling and similarity vectors skip downsampling when the preference is enabled
- cover the new behaviour with a high-density overlay regression test
- normalize overlay sampling max-point inputs so the full-resolution path no longer raises when downsampling is disabled

## Testing
- pytest tests/ui/test_overlay_full_resolution.py

------
https://chatgpt.com/codex/tasks/task_e_68db263c54748329aa0fb3994e4120ee