### PR TITLE
Handle multi-row spectral vectors in FITS tables

### DIFF
--- a/app/server/ingest_fits.py
+++ b/app/server/ingest_fits.py
@@ -122,8 +122,16 @@ def _extract_table_data(
     wavelength_data = np.ma.array(data[wavelength_col])
     flux_data = np.ma.array(data[flux_col])
 
-    wavelength_values = _ensure_1d(np.array(np.ma.getdata(wavelength_data), dtype=float))
-    flux_values = _ensure_1d(np.array(np.ma.getdata(flux_data), dtype=float))
+    wavelength_values = np.array(np.ma.getdata(wavelength_data), dtype=float)
+    flux_values = np.array(np.ma.getdata(flux_data), dtype=float)
+
+    if wavelength_values.ndim > 1:
+        wavelength_values = wavelength_values.reshape(-1)
+    if flux_values.ndim > 1:
+        flux_values = flux_values.reshape(-1)
+
+    wavelength_values = _ensure_1d(wavelength_values)
+    flux_values = _ensure_1d(flux_values)
 
     size = min(wavelength_values.size, flux_values.size)
     wavelength_values = wavelength_values[:size]


### PR DESCRIPTION
## Summary
- flatten multi-row wavelength and flux columns in table HDUs before validation to keep ingestion 1-D
- preserve mask handling and provenance details when reshaping table data
- add a regression test that covers ingesting a table of vector-valued spectra

## Testing
- pytest tests/server/test_ingest_fits.py

------
https://chatgpt.com/codex/tasks/task_e_68db326fe2648329916c53edf9a3c7d1