### PR TITLE
Fix overlay ingest fallback when remote helper is unavailable

### DIFF
--- a/app/ui/main.py
+++ b/app/ui/main.py
@@ -436,13 +436,6 @@ def _process_ingest_queue() -> None:
                 continue
 
             response = requests.get(resolved_url, timeout=60)
-
-
-            _add_overlay_from_url(url, label=label)
-            continue
-
-            response = requests.get(url, timeout=60)
-
             response.raise_for_status()
 
             filename = derived_name or f"overlay-{uuid.uuid4().hex[:8]}"


### PR DESCRIPTION
## Summary
- prevent the overlay queue fallback from calling an unavailable remote ingest helper when processing FITS URLs

## Testing
- pytest tests/ui/test_example_browser.py tests/ui/test_metadata_summary.py

------
https://chatgpt.com/codex/tasks/task_e_68db361e758c8329b58c1eeaf4f137ba