### PR TITLE
Guard FITS ingestion against non-spectral axes

### DIFF
--- a/app/server/ingest_fits.py
+++ b/app/server/ingest_fits.py
@@ -194,6 +194,51 @@ def _mask_to_bool(mask, size: int) -> np.ndarray:
     return padded
 
 
+_SPECTRAL_AXIS_PREFIXES = {
+    "FREQ",
+    "WAVE",
+    "AWAV",
+    "VWAV",
+    "WAVN",
+    "VRAD",
+    "VELO",
+    "VOPT",
+    "ZOPT",
+    "BETA",
+    "ENER",
+}
+
+
+def _ctype_is_spectral(value: Optional[str]) -> bool:
+    if not value:
+        return False
+    token = str(value).strip()
+    if not token:
+        return False
+    prefix = token.split("-")[0].upper()
+    if len(prefix) < 4:
+        return False
+    return any(prefix.startswith(candidate) for candidate in _SPECTRAL_AXIS_PREFIXES)
+
+
+def _unit_is_wavelength(unit: Optional[str]) -> bool:
+    if not unit:
+        return False
+    try:
+        canonical_unit(str(unit))
+    except ValueError:
+        return False
+    return True
+
+
+def _label_suggests_wavelength(name: str) -> bool:
+    label = name.strip().lower()
+    if not label:
+        return False
+    tokens = ("wave", "lam", "freq", "wn", "ener")
+    return any(token in label for token in tokens)
+
+
 def _detect_table_columns(names: Sequence[str]) -> Tuple[str, str]:
     if len(names) < 2:
         raise ValueError("FITS table must contain at least two columns for wavelength and flux")
@@ -202,8 +247,7 @@ def _detect_table_columns(names: Sequence[str]) -> Tuple[str, str]:
     flux = names[1]
 
     for name in names:
-        label = name.lower()
-        if any(token in label for token in ("wave", "lam", "freq", "wn")):
+        if _label_suggests_wavelength(name):
             wavelength = name
             break
 
@@ -278,11 +322,9 @@ def _extract_table_data(
     wave_idx = column_index_map[wavelength_col]
     flux_idx = column_index_map[flux_col]
 
-    wavelength_unit_hint = (
-        _column_unit(hdu, wave_idx)
-        or hdu.header.get("CUNIT1")
-        or hdu.header.get("XUNIT")
-    )
+    column_unit_hint = _column_unit(hdu, wave_idx)
+    header_unit_hint = hdu.header.get("CUNIT1") or hdu.header.get("XUNIT")
+    wavelength_unit_hint = column_unit_hint or header_unit_hint
 
     flux_unit_column = _column_unit(hdu, flux_idx)
     flux_unit_header = (
@@ -315,7 +357,32 @@ def _extract_table_data(
 
     flux_unit_hint = flux_unit_column or flux_unit_header
 
-    resolved_unit = _normalise_wavelength_unit(wavelength_unit_hint)
+    axis_type = hdu.header.get("CTYPE1")
+    unit_missing = not (wavelength_unit_hint and str(wavelength_unit_hint).strip())
+    assumed_unit: Optional[str] = None
+
+    if unit_missing:
+        if _ctype_is_spectral(axis_type) or _label_suggests_wavelength(wavelength_col):
+            resolved_unit = "nm"
+            assumed_unit = "nm"
+        else:
+            axis_display = _coerce_header_value(axis_type) if axis_type is not None else None
+            raise ValueError(
+                "FITS table column "
+                f"{wavelength_col!r} does not advertise a spectral axis "
+                f"(CTYPE1={axis_display!r})."
+            )
+    else:
+        resolved_unit = _normalise_wavelength_unit(wavelength_unit_hint)
+
+    if not _unit_is_wavelength(resolved_unit):
+        unit_display = _coerce_header_value(wavelength_unit_hint) if wavelength_unit_hint else None
+        axis_display = _coerce_header_value(axis_type) if axis_type is not None else None
+        raise ValueError(
+            "FITS table column "
+            f"{wavelength_col!r} uses unsupported spectral unit "
+            f"{unit_display!r} (CTYPE1={axis_display!r})."
+        )
 
     dropped_nonpositive = 0
     if _is_wavenumber_unit(resolved_unit):
@@ -336,10 +403,9 @@ def _extract_table_data(
             to_nm(wavelength_values.tolist(), resolved_unit), dtype=float
         )
     except ValueError as exc:
-        if _is_wavenumber_unit(resolved_unit):
-            raise ValueError("Unable to convert wavenumber samples to nm.") from exc
-        wavelength_nm = np.array(to_nm(wavelength_values.tolist(), "nm"), dtype=float)
-        resolved_unit = "nm"
+        raise ValueError(
+            f"Unable to convert values from unit {resolved_unit!r} to nm."
+        ) from exc
 
     provenance: Dict[str, object] = {
         "table_columns": column_names,
@@ -351,6 +417,22 @@ def _extract_table_data(
         "mask_applied": bool(wavelength_mask.any() or flux_mask.any()),
         "row_count": int(len(data)),
     }
+
+    unit_resolution: Dict[str, object] = {
+        "column": _coerce_header_value(column_unit_hint) if column_unit_hint else None,
+        "header": _coerce_header_value(header_unit_hint) if header_unit_hint else None,
+        "resolved": resolved_unit,
+    }
+    if axis_type is not None:
+        unit_resolution["axis_type"] = _coerce_header_value(axis_type)
+    if assumed_unit is not None:
+        unit_resolution["assumed"] = assumed_unit
+        if _ctype_is_spectral(axis_type):
+            unit_resolution["assumed_from"] = "ctype1"
+        else:
+            unit_resolution["assumed_from"] = "column_name"
+
+    provenance["wavelength_unit_resolution"] = unit_resolution
 
     if dropped_nonpositive:
         provenance["dropped_nonpositive_wavenumbers"] = dropped_nonpositive
@@ -513,12 +595,16 @@ def _ingest_table_hdu(
         table_provenance,
     ) = _extract_table_data(hdu)
 
+    unit_resolution = table_provenance.get("wavelength_unit_resolution", {})
     unit_inference = {
-        "column": _coerce_header_value(reported_wavelength_unit)
-        if reported_wavelength_unit
-        else None,
-        "resolved": resolved_unit,
+        "column": unit_resolution.get("column"),
+        "header": unit_resolution.get("header"),
+        "resolved": unit_resolution.get("resolved", resolved_unit),
+        "axis_type": unit_resolution.get("axis_type"),
     }
+    if "assumed" in unit_resolution:
+        unit_inference["assumed"] = unit_resolution["assumed"]
+        unit_inference["assumed_from"] = unit_resolution.get("assumed_from")
 
     mask_flag = bool(table_provenance.get("mask_applied", False))
 
@@ -554,9 +640,19 @@ def _ingest_image_hdu(
     if flux_array.size == 0:
         raise ValueError("FITS data array is empty.")
 
+    axis_type = hdu.header.get("CTYPE1")
+    unit_hint_raw = hdu.header.get("CUNIT1") or hdu.header.get("XUNIT")
+    if not (_ctype_is_spectral(axis_type) or _unit_is_wavelength(unit_hint_raw)):
+        axis_display = _coerce_header_value(axis_type) if axis_type is not None else None
+        unit_display = _coerce_header_value(unit_hint_raw) if unit_hint_raw is not None else None
+        raise ValueError(
+            "FITS image HDU does not describe a spectral axis "
+            f"(CTYPE1={axis_display!r}, CUNIT1={unit_display!r})."
+        )
+
     wavelengths_raw, wcs_meta = _compute_wavelengths(flux_array.size, hdu.header)
     resolved_unit = _normalise_wavelength_unit(
-        hdu.header.get("CUNIT1") or hdu.header.get("XUNIT")
+        unit_hint_raw
     )
 
     wavelength_nm = np.array(to_nm(wavelengths_raw.tolist(), resolved_unit), dtype=float)

--- a/tests/server/test_ingest_fits.py
+++ b/tests/server/test_ingest_fits.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from astropy.io import fits
 
 from app.server.ingest_fits import parse_fits
@@ -109,3 +110,97 @@ def test_parse_fits_collapses_image_data(tmp_path):
     collapse_meta = result["provenance"].get("image_collapse", {})
     assert collapse_meta.get("original_shape") == [2, 4]
     assert collapse_meta.get("collapsed_axes") == [0]
+
+
+def test_parse_fits_rejects_nonspectral_image_axis(tmp_path):
+    flux_values = np.array([1.0, 2.0, 3.0], dtype=float)
+
+    sci_header = fits.Header()
+    sci_header["CRVAL1"] = -1.0
+    sci_header["CDELT1"] = 1.0
+    sci_header["CRPIX1"] = 1.0
+    sci_header["CTYPE1"] = "RA---TAN"
+
+    sci_hdu = fits.ImageHDU(data=flux_values, header=sci_header, name="SCI")
+    hdul = fits.HDUList([fits.PrimaryHDU(), sci_hdu])
+    fits_path = tmp_path / "ra_axis_image.fits"
+    hdul.writeto(fits_path, overwrite=True)
+    hdul.close()
+
+    with pytest.raises(ValueError) as excinfo:
+        parse_fits(str(fits_path))
+
+    message = str(excinfo.value)
+    assert "does not describe a spectral axis" in message
+    assert "CTYPE1='RA---TAN'" in message
+
+
+def test_parse_fits_accepts_convertible_units_without_spectral_ctype(tmp_path):
+    flux_values = np.array([1.0, 2.0, 3.0], dtype=float)
+
+    sci_header = fits.Header()
+    sci_header["CRVAL1"] = 1000.0
+    sci_header["CDELT1"] = 1.0
+    sci_header["CRPIX1"] = 1.0
+    sci_header["CTYPE1"] = "LINEAR"
+    sci_header["CUNIT1"] = "angstrom"
+
+    sci_hdu = fits.ImageHDU(data=flux_values, header=sci_header, name="SCI")
+    hdul = fits.HDUList([fits.PrimaryHDU(), sci_hdu])
+    fits_path = tmp_path / "linear_angstrom.fits"
+    hdul.writeto(fits_path, overwrite=True)
+    hdul.close()
+
+    result = parse_fits(str(fits_path))
+
+    expected_wavelength_nm = [100.0 + i * 0.1 for i in range(flux_values.size)]
+    assert result["wavelength_nm"] == pytest.approx(expected_wavelength_nm)
+
+
+def test_parse_fits_rejects_table_with_nonspectral_units(tmp_path):
+    time = np.array([0.0, 1.0, 2.0], dtype=float)
+    flux = np.array([10.0, 11.0, 12.0], dtype=float)
+
+    columns = [
+        fits.Column(name="TIME", array=time, format="D", unit="BJD - 2457000, days"),
+        fits.Column(name="SAP_FLUX", array=flux, format="D", unit="e-/s"),
+    ]
+
+    table_hdu = fits.BinTableHDU.from_columns(columns)
+    hdul = fits.HDUList([fits.PrimaryHDU(), table_hdu])
+    fits_path = tmp_path / "tess_like_lightcurve.fits"
+    hdul.writeto(fits_path, overwrite=True)
+    hdul.close()
+
+    with pytest.raises(ValueError) as excinfo:
+        parse_fits(str(fits_path))
+
+    message = str(excinfo.value)
+    assert "TIME" in message
+    assert "BJD" in message
+
+
+def test_parse_fits_assumes_nm_for_wavelength_column_without_units(tmp_path):
+    wavelengths = np.array([400.0, 500.0, 600.0], dtype=float)
+    flux = np.array([1.0, 2.0, 3.0], dtype=float)
+
+    columns = [
+        fits.Column(name="WAVE", array=wavelengths, format="D"),
+        fits.Column(name="FLUX", array=flux, format="D"),
+    ]
+
+    table_hdu = fits.BinTableHDU.from_columns(columns)
+    hdul = fits.HDUList([fits.PrimaryHDU(), table_hdu])
+    fits_path = tmp_path / "unitless_wavelength_table.fits"
+    hdul.writeto(fits_path, overwrite=True)
+    hdul.close()
+
+    result = parse_fits(str(fits_path))
+
+    assert result["wavelength_nm"] == wavelengths.tolist()
+    assert result["metadata"]["original_wavelength_unit"] == "nm"
+    assert result["metadata"].get("reported_wavelength_unit") is None
+
+    unit_resolution = result["provenance"].get("wavelength_unit_resolution", {})
+    assert unit_resolution.get("assumed") == "nm"
+    assert unit_resolution.get("assumed_from") == "column_name"


### PR DESCRIPTION
## Summary
- ensure FITS image HDUs advertise a spectral axis before converting their WCS coordinates to wavelengths
- keep accepting images that rely on convertible wavelength units even if CTYPE1 is generic
- record wavelength-unit inference details for table HDUs and reject tables that lack spectral units or advertise unsupported units

## Testing
- pytest tests/server/test_ingest_fits.py

------
https://chatgpt.com/codex/tasks/task_e_68db450c9a608329aa23fe1d0ee07fe4