### PR TITLE
Reject nonpositive FITS table wavelengths during ingestion

### DIFF
--- a/app/server/ingest_fits.py
+++ b/app/server/ingest_fits.py
@@ -409,13 +409,20 @@ def _extract_table_data(
         ) from exc
 
     positive_mask = wavelength_nm > 0
-    dropped_nonpositive_nm = int(positive_mask.size - np.count_nonzero(positive_mask))
-    if dropped_nonpositive_nm:
-        wavelength_nm = wavelength_nm[positive_mask]
-        flux_values = flux_values[positive_mask]
+    positive_count = int(np.count_nonzero(positive_mask))
+    dropped_nonpositive_nm = int(wavelength_nm.size - positive_count)
+    if positive_count == 0:
+        raise ValueError(
+            "FITS table ingestion yielded no positive-wavelength samples after unit conversion."
+        )
+
+    wavelength_nm = wavelength_nm[positive_mask]
+    flux_values = flux_values[positive_mask]
 
     if wavelength_nm.size == 0:
-        raise ValueError("FITS table ingestion yielded no positive-wavelength samples.")
+        raise ValueError(
+            "FITS table ingestion yielded no positive-wavelength samples after unit conversion."
+        )
 
     provenance: Dict[str, object] = {
         "table_columns": column_names,

--- a/tests/server/test_ingest_fits.py
+++ b/tests/server/test_ingest_fits.py
@@ -227,6 +227,32 @@ def test_parse_fits_rejects_table_with_nonpositive_wavelengths(tmp_path):
 
     message = str(excinfo.value)
     assert "positive-wavelength" in message
+    assert "after unit conversion" in message
+
+
+def test_parse_fits_rejects_table_with_negative_wavelengths_after_conversion(tmp_path):
+    wavelengths = np.array([-500.0, -100.0], dtype=float)
+    flux = np.array([1.0, 2.0], dtype=float)
+
+    columns = [
+        fits.Column(name="WAVE", array=wavelengths, format="D", unit="angstrom"),
+        fits.Column(name="FLUX", array=flux, format="D"),
+    ]
+
+    table_hdu = fits.BinTableHDU.from_columns(columns)
+    hdul = fits.HDUList([fits.PrimaryHDU(), table_hdu])
+    fits_path = tmp_path / "negative_wavelength_angstrom_table.fits"
+    hdul.writeto(fits_path, overwrite=True)
+    hdul.close()
+
+    with pytest.raises(ValueError) as excinfo:
+        parse_fits(str(fits_path))
+
+    message = str(excinfo.value)
+    assert (
+        "FITS table ingestion yielded no positive-wavelength samples after unit conversion."
+        in message
+    )
 
 
 def test_parse_fits_rejects_image_with_nonpositive_wavelengths(tmp_path):


### PR DESCRIPTION
## Summary
- filter nonpositive FITS table wavelengths right after conversion to nanometers and raise a clear error when none remain
- record the number of discarded samples in the table ingestion provenance metadata
- add regression coverage for tables whose wavelength column contains negative values

## Testing
- pytest tests/server/test_ingest_fits.py


------
https://chatgpt.com/codex/tasks/task_e_68db5090eefc8329be22a60602ba00ea