### PR TITLE
Refactor wavelength unit handling and retain quantities

### DIFF
--- a/app/utils/local_ingest.py
+++ b/app/utils/local_ingest.py
@@ -479,6 +479,7 @@ def ingest_local_file(name: str, content: bytes) -> Dict[str, object]:
         "summary": summary,
         "wavelength_nm": wavelengths,
         "wavelength": {"values": wavelengths, "unit": "nm"},
+        "wavelength_quantity": parsed.get("wavelength_quantity"),
         "flux": flux_values,
         "flux_unit": flux_unit,
         "flux_kind": parsed.get("flux_kind") or "relative",

--- a/tests/server/test_units.py
+++ b/tests/server/test_units.py
@@ -1,7 +1,9 @@
 import sys
 from pathlib import Path
 
+import numpy as np
 import pytest
+from astropy import units as u
 
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
@@ -34,3 +36,19 @@ def test_to_nm_accepts_units_with_whitespace(raw_unit, values, expected):
 )
 def test_canonical_unit_normalizes_spacing(raw_unit, expected):
     assert canonical_unit(raw_unit) == expected
+
+
+def test_to_nm_accepts_numpy_arrays():
+    samples = np.array([0.1, 0.2, 0.3], dtype=float)
+    converted = to_nm(samples, u.um)
+    assert isinstance(converted, u.Quantity)
+    assert converted.unit.is_equivalent(u.nm)
+    assert converted.to_value(u.nm) == pytest.approx(samples * 1000.0)
+
+
+def test_to_nm_converts_wavenumber_with_equivalency():
+    values = np.array([1e4, 2e4], dtype=float)
+    converted = to_nm(values, "cm-1")
+    assert converted.unit.is_equivalent(u.nm)
+    expected = (1.0 / (values * u.cm**-1)).to_value(u.nm)
+    assert converted.value == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- rely on astropy Unit/Quantity conversion helpers for canonical unit lookups and nm conversions
- keep wavelength values as Quantity objects through FITS/ASCII ingestion and expose them in payloads and local ingest metadata
- extend unit and ingestion tests to cover array inputs, wavenumber cases, and the new quantity field

## Testing
- pytest tests/server/test_units.py tests/server/test_ingest_fits.py tests/server/test_local_ingest.py

------
https://chatgpt.com/codex/tasks/task_e_68dc10a6da5c83298746d637c232b6ab