### PR TITLE
Replace unit conversions with Astropy helpers

### DIFF
--- a/app/server/ingest_fits.py
+++ b/app/server/ingest_fits.py
@@ -426,11 +426,15 @@ def _extract_table_data(
             )
 
     try:
-        wavelength_quantity = to_nm(wavelength_values, resolved_unit)
+        wavelength_quantity, canonical_resolved_unit = to_nm(
+            wavelength_values, resolved_unit
+        )
     except ValueError as exc:
         raise ValueError(
             f"Unable to convert values from unit {resolved_unit!r} to nm."
         ) from exc
+
+    resolved_unit = canonical_resolved_unit
 
     wavelength_nm_values = np.asarray(wavelength_quantity.to_value(u.nm), dtype=float)
     if wavelength_nm_values.size == 0:

--- a/app/server/units.py
+++ b/app/server/units.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Iterable, Tuple
 
 import numpy as np
 from astropy import units as u
 from astropy.units import Quantity
+from astropy.units import imperial
+from astropy.units import UnitScaleError
 
 
 def _as_unit(unit: str | u.UnitBase | Quantity) -> u.UnitBase:
@@ -17,38 +19,77 @@ def _as_unit(unit: str | u.UnitBase | Quantity) -> u.UnitBase:
     text = str(unit).strip()
     if not text:
         raise ValueError("Empty unit provided")
+    lowered = text.lower()
+    if lowered == "nm":
+        return u.nm
     try:
-        return u.Unit(text)
+        parsed = u.Unit(text)
+        if parsed == u.nmi and lowered == "nm":
+            return u.nm
+        return parsed
     except Exception:
-        lowered = text.lower()
+        with imperial.enable():
+            try:
+                return u.Unit(text)
+            except Exception:
+                pass
         try:
             return u.Unit(lowered)
         except Exception as exc:  # pragma: no cover - astropy specific
-            raise ValueError(f"Unsupported wavelength unit: {unit}") from exc
+            with imperial.enable():
+                try:
+                    return u.Unit(lowered)
+                except Exception as imperial_exc:
+                    raise ValueError(f"Unsupported wavelength unit: {unit}") from imperial_exc
 
 
-def to_nm(values: Iterable[float], unit: str | u.UnitBase | Quantity) -> Quantity:
-    """Convert the provided values into nanometres."""
+def resolve_unit(unit: str | u.UnitBase | Quantity) -> Tuple[u.UnitBase, str]:
+    """Return a parsed unit and its canonical string label."""
 
-    unit_obj = _as_unit(unit)
+    parsed = _as_unit(unit)
     try:
-        quantity = u.Quantity(values, unit_obj, copy=False)
+        canonical = parsed.to_string(format="fits")
+    except UnitScaleError:
+        canonical = parsed.to_string()
+    return parsed, canonical
+
+
+def quantity_from(
+    values: Iterable[float], unit: str | u.UnitBase | Quantity
+) -> Tuple[Quantity, str]:
+    """Return a quantity constructed from ``values`` and its canonical unit."""
+
+    parsed_unit, canonical = resolve_unit(unit)
+    try:
+        quantity = u.Quantity(values, parsed_unit, copy=False)
     except ValueError:
-        quantity = u.Quantity(values, unit_obj)
+        quantity = u.Quantity(values, parsed_unit)
+    return quantity, canonical
+
+
+def to_nm(
+    values: Iterable[float], unit: str | u.UnitBase | Quantity
+) -> Tuple[Quantity, str]:
+    """Convert the provided values into nanometres and return the canonical unit."""
+
+    quantity, canonical = quantity_from(values, unit)
 
     try:
-        return quantity.to(u.nm)
+        converted = quantity.to(u.nm)
     except u.UnitConversionError:
-        if np.any(np.asarray(quantity.to_value(unit_obj)) == 0.0):
+        if quantity.unit.is_equivalent(u.m**-1) and np.any(
+            np.asarray(quantity.value) == 0.0
+        ):
             raise ValueError("Cannot convert a zero wavenumber to wavelength")
         try:
-            return quantity.to(u.nm, equivalencies=u.spectral())
+            converted = quantity.to(u.nm, equivalencies=u.spectral())
         except Exception as exc:  # pragma: no cover - astropy specific
             raise ValueError(f"Unsupported wavelength unit: {unit}") from exc
+
+    return converted, canonical
 
 
 def canonical_unit(unit: str | u.UnitBase | Quantity) -> str:
     """Return the canonical string representation for a unit value."""
 
-    parsed = _as_unit(unit)
-    return parsed.to_string(format="fits")
+    return resolve_unit(unit)[1]

--- a/tests/server/test_units.py
+++ b/tests/server/test_units.py
@@ -13,15 +13,18 @@ from app.server.units import canonical_unit, to_nm
 
 
 @pytest.mark.parametrize(
-    "raw_unit, values, expected",
+    "raw_unit, values, expected, canonical",
     [
-        (" NM", [1.0, 2.0], [1.0, 2.0]),
-        ("Angstrom ", [10.0, 20.0], [1.0, 2.0]),
-        ("Å ", [10.0, 20.0], [1.0, 2.0]),
+        (" NM", [1.0, 2.0], [1.0, 2.0], "nm"),
+        ("Angstrom ", [10.0, 20.0], [1.0, 2.0], "Angstrom"),
+        ("Å ", [10.0, 20.0], [1.0, 2.0], "Angstrom"),
+        ("µm", [0.1, 0.2], [100.0, 200.0], "um"),
+        ("inch", [1.0], [25400000.0], "inch"),
     ],
 )
-def test_to_nm_accepts_units_with_whitespace(raw_unit, values, expected):
-    converted = to_nm(values, raw_unit)
+def test_to_nm_accepts_units_with_whitespace(raw_unit, values, expected, canonical):
+    converted, unit_label = to_nm(values, raw_unit)
+    assert unit_label == canonical
     assert converted.unit.is_equivalent("nm")
     assert converted.value == pytest.approx(expected)
 
@@ -32,6 +35,8 @@ def test_to_nm_accepts_units_with_whitespace(raw_unit, values, expected):
         (" NM", "nm"),
         ("Angstrom ", "Angstrom"),
         ("Å ", "Angstrom"),
+        ("µm", "um"),
+        ("inch", "inch"),
     ],
 )
 def test_canonical_unit_normalizes_spacing(raw_unit, expected):
@@ -40,7 +45,8 @@ def test_canonical_unit_normalizes_spacing(raw_unit, expected):
 
 def test_to_nm_accepts_numpy_arrays():
     samples = np.array([0.1, 0.2, 0.3], dtype=float)
-    converted = to_nm(samples, u.um)
+    converted, unit_label = to_nm(samples, u.um)
+    assert unit_label == "um"
     assert isinstance(converted, u.Quantity)
     assert converted.unit.is_equivalent(u.nm)
     assert converted.to_value(u.nm) == pytest.approx(samples * 1000.0)
@@ -48,7 +54,18 @@ def test_to_nm_accepts_numpy_arrays():
 
 def test_to_nm_converts_wavenumber_with_equivalency():
     values = np.array([1e4, 2e4], dtype=float)
-    converted = to_nm(values, "cm-1")
+    converted, unit_label = to_nm(values, "cm-1")
+    assert unit_label == "cm-1"
     assert converted.unit.is_equivalent(u.nm)
     expected = (1.0 / (values * u.cm**-1)).to_value(u.nm)
     assert converted.value == pytest.approx(expected)
+
+
+def test_to_nm_zero_wavenumber_raises():
+    with pytest.raises(ValueError):
+        to_nm([0.0], "cm^-1")
+
+
+def test_to_nm_invalid_unit_raises():
+    with pytest.raises(ValueError):
+        to_nm([1.0], "not-a-unit")


### PR DESCRIPTION
## Summary
- wrap unit parsing and wavelength conversion around astropy.units so helpers return both quantities and canonical unit strings
- refactor ASCII/FITS ingestion and the NIST fetcher to use the new helpers and remove redundant unit canonicalisation code
- expand unit tests to cover additional unit strings and error conditions

## Testing
- pytest tests/server/test_units.py
- pytest tests/server/test_local_ingest.py

------
https://chatgpt.com/codex/tasks/task_e_68dc235631a883298dd6b810f54288a8