### PR TITLE
Handle plural Angstrom units during FITS ingestion

### DIFF
--- a/PATCHLOG.txt
+++ b/PATCHLOG.txt
@@ -9,3 +9,4 @@ Spectra App — Patch Log (append-only)
 - v1.1.9: fix overlay button keys, respect ledger lock session state, wire the ingest queue into the overlay pipeline, reject metadata-like uploads, and refresh docs for the release.
 - v1.1.9: fix overlay button keys, respect ledger lock session state, wire the ingest queue into the overlay pipeline, and refresh docs for the release.
 - v1.2.0 (REF 1.2.0-A01 / 1.2.0-C01): patched FITS table ingestion to drop non-positive wavenumber samples safely, documented the runtime package set, and rolled continuity collateral for the release.
+- v1.2.0a (REF 1.2.0-A02 / 1.2.0-D01): normalised Angstrom aliases in FITS ingestion, extended regression coverage, and refreshed continuity docs for the hotfix.

--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.0",
-  "date_utc": "2025-09-30T00:00:00Z",
-  "summary": "Fix FITS table ingestion for non-positive wavenumber samples and refresh runtime inventory."
+  "version": "v1.2.0a",
+  "date_utc": "2025-09-30T12:00:00Z",
+  "summary": "Normalise Angstrom aliases during FITS ingestion and refresh continuity collateral."
 }

--- a/docs/PATCH_NOTES/v1.2.0a.txt
+++ b/docs/PATCH_NOTES/v1.2.0a.txt
@@ -1,0 +1,4 @@
+Spectra App v1.2.0a (REF 1.2.0-A02, 1.2.0-D01)
+- Normalise FITS ingestion to treat plural/aliased Angstrom labels as Angstrom.
+- Extend regression coverage and continuity docs for the hotfix.
+- Continuity docs: docs/brains/brains_v1.2.0a.md

--- a/docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0a.md
+++ b/docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0a.md
@@ -1,0 +1,20 @@
+# AI Handoff Prompt — v1.2.0a
+
+## Snapshot
+- Version: v1.2.0a (REF 1.2.0-A02, 1.2.0-D01)
+- Focus: Normalise FITS ingestion for plural Angstrom labels and capture the continuity collateral for the hotfix.
+
+## Completed in this patch
+1. `_normalise_wavelength_unit` strips plural suffixes / alias spellings and falls back to `Angstrom` before deferring to `canonical_unit`, matching the shared alias handling in `app/server/units._as_unit`.
+2. Added `test_parse_fits_table_accepts_angstroms_alias` to cover FITS tables that supply `Angstroms` in both the column metadata and header.
+3. Updated patch notes, brains, AI log, AI handoff brief, and patch log to document v1.2.0a.
+
+## Outstanding priorities
+- Continue the v1.2 roadmap: SIMBAD resolver, ingestion consolidation, provenance enrichment, caching automation, export audits.
+- Restore the FAISS-backed documentation tooling or introduce a lightweight substitute so the docs-first workflow (search endpoint) is available again.
+- Re-run provider verification scripts (e.g., `Verify-Project.ps1`) in a Windows environment to confirm caches and overlays remain valid.
+
+## Suggested next steps
+- Stand up the documentation search stack by packaging FAISS or swapping to an alternate vector backend so AGENTS.md requirements are practical.
+- Extend ingestion regression coverage to additional CALSPEC/MAST samples that advertise other pluralised units (`Microns`, `nanometers`) and ensure provenance remains consistent.
+- Plan UI work to surface unit alias information (tooltip or ingestion summary) so users know when units have been normalised implicitly.

--- a/docs/ai_log/2025-09-30.md
+++ b/docs/ai_log/2025-09-30.md
@@ -14,3 +14,22 @@
 ## Outstanding Follow-ups
 - Rebuild the documentation mirror tooling referenced in historical instructions so `docs/sources.yaml` and related indices can be regenerated once restored.
 - Execute `Verify-Project.ps1` in a Windows environment and confirm ingestion roadmap tasks (SIMBAD resolver, archive consolidation, provenance enrichment) progress in subsequent patches.
+
+---
+
+## Tasking — v1.2.0a
+- Normalise FITS ingestion so plural/aliased Angstrom labels succeed.
+- Extend regression coverage and roll continuity collateral for the hotfix.
+
+## Actions & Decisions
+- Added alias-aware handling in `app/server/ingest_fits.py` and `app/server/units.py` so `canonical_unit` accepts plural Angstrom spellings.
+- Backfilled regression coverage for the "Angstroms" scenario and updated patch notes, brains, AI handoff, and patch log for v1.2.0a.
+- Attempted to start the documentation search server, but it still requires the unavailable `faiss` dependency. 【db955f†L1-L5】
+
+## Verification
+- `pytest tests/server/test_ingest_fits.py -k Angstroms`. 【3d3cce†L1-L16】
+- Manual `parse_fits` run against an "Angstroms" FITS table confirming canonical labelling and nm conversion. 【6e7934†L1-L5】
+
+## Outstanding Follow-ups
+- Restore the FAISS-backed documentation search stack or replace it so docs-first queries succeed.
+- Continue the v1.2 roadmap items (SIMBAD resolver, ingestion consolidation, provenance enrichment, caching) once the tooling gap is resolved.

--- a/docs/brains/brains_INDEX.md
+++ b/docs/brains/brains_INDEX.md
@@ -1,6 +1,6 @@
 # MAKE NEW BRAINS EACH TIME YOU MAKE A CHANGE. DO NOT OVER WRITE PREVIOUS BRAINS * unless needed
 # Spectra App — Brains Index
-_Last updated: 2025-09-30T00:00:00Z_
+_Last updated: 2025-09-30T12:00:00Z_
 
 This index is the mandated entry point before touching the codebase.
 It tracks the latest continuity documents and the required cross-links between them.
@@ -14,6 +14,7 @@ It tracks the latest continuity documents and the required cross-links between t
 ## Continuity Table
 | Version | Brains Log | Patch Notes | AI Handoff |
 | --- | --- | --- | --- |
+| v1.2.0a | [docs/brains/brains_v1.2.0a.md](brains_v1.2.0a.md) | [docs/patch_notes/PATCH_NOTES_v1.2.0a.md](../patch_notes/PATCH_NOTES_v1.2.0a.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0a.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0a.md) |
 | v1.2.0 | [docs/brains/brains_v1.2.0.md](brains_v1.2.0.md) | [docs/patch_notes/PATCH_NOTES_v1.2.0.md](../patch_notes/PATCH_NOTES_v1.2.0.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0.md) |
 | v1.1.9 | [docs/brains/brains_v1.1.9.md](brains_v1.1.9.md) | [docs/patch_notes/PATCH_NOTES_v1.1.9.md](../patch_notes/PATCH_NOTES_v1.1.9.md) | — |
 | v1.1.8 | [docs/brains/brains_v1.1.8.md](brains_v1.1.8.md) | [docs/patch_notes/PATCH_NOTES_v1.1.8.md](../patch_notes/PATCH_NOTES_v1.1.8.md) | [docs/ai_handoff/AI Handoff Prompt — v1.1.8.txt](../ai_handoff/AI%20Handoff%20Prompt%20—%20v1.1.8.txt) |
@@ -24,6 +25,8 @@ It tracks the latest continuity documents and the required cross-links between t
 
 Older releases remain in `docs/brains/` and `docs/patches/` for archeology, but the table above is the active continuity contract.
 
+- Patch notes (md) for v1.2.0a: docs/patch_notes/PATCH_NOTES_v1.2.0a.md
+- Patch notes (txt) for v1.2.0a: docs/PATCH_NOTES/v1.2.0a.txt
 - Patch notes (md) for v1.2.0: docs/patch_notes/PATCH_NOTES_v1.2.0.md
 - Patch notes (txt) for v1.2.0: docs/PATCH_NOTES/v1.2.0.txt
 - Patch notes (md) for v1.1.9: docs/patch_notes/PATCH_NOTES_v1.1.9.md

--- a/docs/brains/brains_v1.2.0a.md
+++ b/docs/brains/brains_v1.2.0a.md
@@ -1,0 +1,21 @@
+# Brains — v1.2.0a
+
+## Release focus
+- **REF 1.2.0-A02**: Normalise FITS ingestion so plural Angstrom labels (e.g., `Angstroms`, `ångströms`) resolve to the canonical unit before converting to nm, ensuring CALSPEC-style tables import without raising `ValueError`.
+- **REF 1.2.0-D01**: Refresh regression coverage and continuity documents (patch notes, patch log, AI log, AI handoff, plaintext notes) to record the hotfix and its verification.
+
+## Implementation notes
+- `_normalise_wavelength_unit` now strips plural suffixes and recognises alias spellings before calling `canonical_unit`, tracking an alias fallback so provenance surfaces the canonical label even if Astropy rejects the raw token.
+- `app/server/units._as_unit` shares the alias logic so any caller leveraging `canonical_unit` benefits from the same handling (plural/suffixed Angstrom strings resolve to `u.AA`).
+- Added `test_parse_fits_table_accepts_angstroms_alias` covering the regression with both column and header units set to `Angstroms`.
+
+## Testing
+- `pytest tests/server/test_ingest_fits.py -k Angstroms`
+- Manual `parse_fits` invocation against the generated regression FITS table (mirrors CALSPEC headers) to confirm provenance labelling and nm conversions.
+
+## Outstanding work
+- Resume the broader v1.2 backlog (SIMBAD resolver, ingestion consolidation, provenance enrichment, caching automation).
+- Restore FAISS-backed documentation search tooling or replace with a lightweight alternative so the docs-first workflow remains actionable.
+
+## Continuity updates
+- Version bumped to v1.2.0a with matching entries in `PATCHLOG.txt`, `docs/patch_notes/PATCH_NOTES_v1.2.0a.md`, `docs/PATCH_NOTES/v1.2.0a.txt`, and `docs/ai_log/2025-09-30.md`.

--- a/docs/patch_notes/PATCH_NOTES_v1.2.0a.md
+++ b/docs/patch_notes/PATCH_NOTES_v1.2.0a.md
@@ -1,0 +1,16 @@
+# Patch Notes — v1.2.0a
+
+## Highlights
+- **REF 1.2.0-A02**: Normalised FITS wavelength unit parsing so plural Angstrom labels and their aliases resolve to the canonical unit before conversion, preventing ingestion failures for CALSPEC tables that advertise "Angstroms" in headers.
+- **REF 1.2.0-D01**: Updated regression coverage, patch log, brains, AI handoff, and summary docs to capture the hotfix and verification steps.
+
+## Follow-up
+- Continue the v1.2 roadmap (SIMBAD resolver, ingestion consolidation, provenance enrichment, caching) as tracked in prior handoffs.
+- Restore documentation mirroring tooling (`tools/mirror_docs.py`, `tools/build_index.py`, `tools/search_server.py`) once FAISS dependencies become available again.
+
+## Verification
+- `pytest tests/server/test_ingest_fits.py -k Angstroms`
+- Manual `parse_fits` run against the synthetic "Angstroms" FITS table used in the regression test to confirm provenance and unit labelling.
+
+## Continuity
+- Updated `app/version.json` to v1.2.0a alongside `PATCHLOG.txt`, brains index/logs, AI log, AI handoff brief, and plaintext patch notes (`docs/PATCH_NOTES/v1.2.0a.txt`).


### PR DESCRIPTION
## Summary
- normalise FITS wavelength parsing to accept plural/aliased Angstrom labels before resolving canonical units
- extend the shared unit parser to recognise Angstrom aliases and add regression coverage for the "Angstroms" table scenario
- bump v1.2.0a continuity collateral (patch notes, brains, AI log, handoff) and log manual ingestion verification

## Testing
- pytest tests/server/test_ingest_fits.py -k Angstroms

------
https://chatgpt.com/codex/tasks/task_e_68dc3a65a2548329b8c034ee206618a2