### PR TITLE
Fix example browser provider filter persistence

### DIFF
--- a/PATCHLOG.txt
+++ b/PATCHLOG.txt
@@ -11,3 +11,4 @@ Spectra App — Patch Log (append-only)
 - v1.2.0 (REF 1.2.0-A01 / 1.2.0-C01): patched FITS table ingestion to drop non-positive wavenumber samples safely, documented the runtime package set, and rolled continuity collateral for the release.
 - v1.2.0a (REF 1.2.0-A02 / 1.2.0-D01): normalised Angstrom aliases in FITS ingestion, extended regression coverage, and refreshed continuity docs for the hotfix.
 - v1.2.0b (REF 1.2.0b-A01 / 1.2.0b-D01): taught FITS table ingestion to recognise time-series axes, updated overlay/metadata UX to label time units, refreshed regression coverage, and rolled continuity docs for the release.
+- v1.2.0c (REF 1.2.0c-A01): fixed the example browser provider selector to respect session persistence without triggering Streamlit widget warnings, refreshed UI docs, and logged the QA verification.

--- a/app/ui/example_browser.py
+++ b/app/ui/example_browser.py
@@ -144,16 +144,17 @@ def render_example_browser_sheet(
 
         provider_options = sorted({spec.provider for spec in examples})
         st.session_state.setdefault("example_browser_search", "")
-        stored_providers = [
-            provider
-            for provider in st.session_state.get(
-                "example_browser_provider_filter", provider_options
-            )
-            if provider in provider_options
+        providers_key = "example_browser_provider_filter"
+        session_providers = st.session_state.setdefault(providers_key, provider_options)
+        valid_providers = [
+            provider for provider in session_providers if provider in provider_options
         ]
-        if not stored_providers:
-            stored_providers = provider_options
-        st.session_state["example_browser_provider_filter"] = stored_providers
+        if valid_providers != session_providers:
+            st.session_state[providers_key] = valid_providers
+            session_providers = valid_providers
+        if not session_providers and provider_options:
+            st.session_state[providers_key] = provider_options
+            session_providers = provider_options
         st.session_state.setdefault("example_browser_favourites_only", False)
 
         search_value = st.text_input(
@@ -165,8 +166,7 @@ def render_example_browser_sheet(
         selected_providers = st.multiselect(
             "Providers",
             provider_options,
-            default=stored_providers,
-            key="example_browser_provider_filter",
+            key=providers_key,
         )
         favourites_only = st.checkbox(
             "Show favourites only",

--- a/app/version.json
+++ b/app/version.json
@@ -1,11 +1,5 @@
 {
-
-  "version": "v1.2.0b",
-  "date_utc": "2025-09-30T18:00:00Z",
-  "summary": "Add FITS time-series ingestion support and update UI metadata for time axes."
-
-  "version": "1.2.0a",
-  "date_utc": "2025-09-30T12:00:00Z",
-  "summary": "Normalise Angstrom aliases during FITS ingestion and refresh continuity collateral."
-
+  "version": "v1.2.0c",
+  "date_utc": "2025-10-01T00:00:00Z",
+  "summary": "Fix example browser provider filter session persistence and remove redundant widget warning."
 }

--- a/docs/PATCH_NOTES/v1.2.0c.txt
+++ b/docs/PATCH_NOTES/v1.2.0c.txt
@@ -1,0 +1,1 @@
+v1.2.0c — Fixed the example browser provider filter so persisted selections survive reruns without Streamlit key warnings; updated UI docs, patch log, and AI log for the hotfix.

--- a/docs/ai_log/2025-09-30.md
+++ b/docs/ai_log/2025-09-30.md
@@ -60,3 +60,24 @@
 ### Citations
 - docs/mirrored/astropy/coordinates.meta.json
 
+---
+
+## Tasking — v1.2.0c
+- Stop the example browser from overwriting provider filters on rerun.
+- Eliminate the Streamlit widget warning triggered by reassigning `example_browser_provider_filter` defaults.
+- Refresh documentation (UI review, patch notes, AI log) and record manual verification.
+
+## Actions & Decisions
+- Reordered session-state initialisation in `app/ui/example_browser.py` so provider selections are seeded before rendering the multiselect and sanitised only when provider options change. 【F:app/ui/example_browser.py†L119-L139】
+- Dropped the `default=` argument once session state exists, letting Streamlit reuse persisted selections and preventing the duplicate-key warning. 【F:app/ui/example_browser.py†L141-L144】
+- Updated `docs/library_usage_review.md` with a note about the persistent provider filters and rolled fresh patch notes plus patch log continuity for v1.2.0c. 【F:docs/library_usage_review.md†L31-L33】【F:docs/patch_notes/v1.2.0c.md†L1-L25】【F:PATCHLOG.txt†L17-L18】
+- Attempted to query the local docs search service, but it remains unavailable in this snapshot; noted for future restoration.
+
+## Verification
+- Manual QA: `PYTHONPATH=/workspace/spectra-app streamlit run app/ui/main.py --server.headless true --server.port 8501 --server.address 0.0.0.0 --browser.gatherUsageStats false` (provider filters persist, no widget warning). 【67e5e1†L1-L2】【8c1277†L1-L5】
+- Playwright session confirming only ESO/MAST remain selected after filtering. 【grdnbrgb†L1-L1】
+
+## Outstanding Follow-ups
+- Restore the docs search server tooling so protocol-mandated queries can succeed instead of being noted as unavailable.
+- Consider porting the provider-filter persistence fix into automated UI tests to guard against regressions.
+

--- a/docs/library_usage_review.md
+++ b/docs/library_usage_review.md
@@ -29,6 +29,7 @@ The table below lists the key dependencies and their official documentation sour
 
 - Streamlit allows the team to prototype interactive front-ends quickly. Its markdown support and simple widget API make the example browser easy to implement.
 - The UI code uses dynamic lists of examples and provider filters; it updates UI state without requiring page reloads.
+- Recent hotfix ensures provider multiselect state in the example browser persists via `st.session_state` without triggering widget key warnings.
 
 **Issues:**
 

--- a/docs/patch_notes/v1.2.0c.md
+++ b/docs/patch_notes/v1.2.0c.md
@@ -1,0 +1,19 @@
+# Patch Notes — v1.2.0c
+
+## Summary
+- Ensure the example browser provider multiselect respects stored session filters without raising Streamlit widget warnings.
+- Document the UI fix and record the QA flow for the hotfix.
+
+## Details
+1. **UI persistence**
+   - Pre-seed `example_browser_provider_filter` via `st.session_state.setdefault` and sanitise selections when provider options change.
+   - Remove redundant default arguments so Streamlit keeps the persisted session values without emitting key-collision warnings.
+2. **Documentation**
+   - Added a note to the UI review describing the persistent provider filters.
+   - Logged the fix in the AI activity log and patch log for continuity.
+
+## Verification
+- Manual QA: `PYTHONPATH=/workspace/spectra-app streamlit run app/ui/main.py --server.headless true --server.port 8501 --server.address 0.0.0.0 --browser.gatherUsageStats false` (provider filters persist across reopen, no warning banner).
+
+## Continuity
+- Version bumped to v1.2.0c alongside updated patch notes, plaintext summary, patch log, and AI log entry.


### PR DESCRIPTION
## Summary
- ensure the example browser provider multiselect reads from session state without reassigning defaults each render
- refresh continuity collateral (version metadata, patch notes, patch log, AI log) and document the UI behaviour change
- note the UI review update highlighting the persistent provider filters

## Testing
- PYTHONPATH=/workspace/spectra-app streamlit run app/ui/main.py --server.headless true --server.port 8501 --server.address 0.0.0.0 --browser.gatherUsageStats false


------
https://chatgpt.com/codex/tasks/task_e_68dc497292108329acee32b4906bed3d