### PR TITLE
Gate overlays to supported MAST dataproducts

### DIFF
--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.0c",
-  "date_utc": "2025-10-01T00:00:00Z",
-  "summary": "Fix example browser provider filter session persistence and remove redundant widget warning."
+  "version": "v1.2.0d",
+  "date_utc": "2025-10-01T01:15:00Z",
+  "summary": "Restrict MAST overlay actions to supported 1-D products and annotate images/cubes."
 }

--- a/docs/PATCH_NOTES/v1.2.0d.txt
+++ b/docs/PATCH_NOTES/v1.2.0d.txt
@@ -1,0 +1,1 @@
+v1.2.0d — Overlay buttons now activate only for 1-D spectra, SEDs, or time-series; image/cube products render a disabled control with context and new tests assert the annotation.

--- a/docs/ai_log/2025-10-01.md
+++ b/docs/ai_log/2025-10-01.md
@@ -1,0 +1,19 @@
+# AI Log — 2025-10-01
+
+## Tasking
+- Restrict the target library overlay action to MAST products that provide 1-D spectra, SEDs, or time-series and give users feedback on unsupported entries.
+- Add regression coverage proving image/cube manifest rows are annotated instead of queued for overlay.
+- Roll the Spectra App v1.2 continuity collateral (brains, patch notes, overlay workspace doc, patch log, version) for the hotfix.
+
+## Actions & Decisions
+- Consulted the astroquery MAST observation query reference to confirm the `dataproduct_type` vocabulary before gating overlays. 【F:docs/mirrored/astroquery/mast/mast_obsquery.meta.json†L1-L7】
+- Added `SUPPORTED_OVERLAY_TYPES` and `_product_overlay_support` in the targets panel so only eligible 1-D entries append to the ingest queue; images/cubes now render a disabled button with an explanatory caption. 【F:app/ui/targets.py†L19-L150】
+- Authored regression coverage that exercises supported (spectrum/time-series) and unsupported (image/missing type) cases. 【F:tests/ui/test_targets_overlay_support.py†L1-L40】
+- Updated the overlay workspace guide plus continuity docs (brains, patch notes, patch log, version metadata) to describe the new gating rules. 【F:docs/app/overlay_workspace.md†L21-L28】【F:docs/brains/brains_v1.2.0d.md†L1-L9】【F:docs/patch_notes/v1.2.0d.md†L1-L15】【F:docs/patch_notes/PATCHLOG.txt†L18-L26】【F:app/version.json†L1-L5】
+- Attempted to query the local docs search service per protocol, but the FAISS server is not running in this environment. 【d3b2a6†L1-L2】
+
+## Verification
+- `pytest tests/ui/test_targets_overlay_support.py` 【7128e4†L1-L8】
+
+## Outstanding Follow-ups
+- Extend `_product_overlay_support` once 2-D reduction pipelines can provide 1-D slices so library overlays can surface those assets without manual downloads.

--- a/docs/app/overlay_workspace.md
+++ b/docs/app/overlay_workspace.md
@@ -22,7 +22,10 @@ The **Overlay visibility** form lists every loaded trace, including those
 fetched from archives or generated in the differential tab. Select which traces
 should remain visible and apply the change to update the chart in one go. The
 summary table above the form records label, type, provenance source, and point
-count for quick triage.
+count for quick triage. Entries sourced from the target library only appear here
+if they advertise a 1-D dataproduct (spectra, SEDs, or time-series); image/cube
+rows stay in the library list with a disabled Overlay button so users know why
+they cannot be enqueued.
 
 Use **Remove overlays** to delete one or more traces when the workspace gets
 crowded. Removing an overlay also clears any cached similarity scores that

--- a/docs/brains/brains_INDEX.md
+++ b/docs/brains/brains_INDEX.md
@@ -1,6 +1,6 @@
 # MAKE NEW BRAINS EACH TIME YOU MAKE A CHANGE. DO NOT OVER WRITE PREVIOUS BRAINS * unless needed
 # Spectra App — Brains Index
-_Last updated: 2025-09-30T18:00:00Z_
+_Last updated: 2025-10-01T01:15:00Z_
 
 This index is the mandated entry point before touching the codebase.
 It tracks the latest continuity documents and the required cross-links between them.
@@ -14,6 +14,8 @@ It tracks the latest continuity documents and the required cross-links between t
 ## Continuity Table
 | Version | Brains Log | Patch Notes | AI Handoff |
 | --- | --- | --- | --- |
+| v1.2.0d | [docs/brains/brains_v1.2.0d.md](brains_v1.2.0d.md) | [docs/patch_notes/v1.2.0d.md](../patch_notes/v1.2.0d.md) | — |
+| v1.2.0c | — | [docs/patch_notes/v1.2.0c.md](../patch_notes/v1.2.0c.md) | — |
 | v1.2.0b | [docs/brains/brains_v1.2.0b.md](brains_v1.2.0b.md) | [docs/patch_notes/v1.2.0b.md](../patch_notes/v1.2.0b.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0b.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0b.md) |
 | v1.2.0a | [docs/brains/brains_v1.2.0a.md](brains_v1.2.0a.md) | [docs/patch_notes/PATCH_NOTES_v1.2.0a.md](../patch_notes/PATCH_NOTES_v1.2.0a.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0a.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0a.md) |
 | v1.2.0 | [docs/brains/brains_v1.2.0.md](brains_v1.2.0.md) | [docs/patch_notes/PATCH_NOTES_v1.2.0.md](../patch_notes/PATCH_NOTES_v1.2.0.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0.md) |
@@ -26,6 +28,10 @@ It tracks the latest continuity documents and the required cross-links between t
 
 Older releases remain in `docs/brains/` and `docs/patches/` for archeology, but the table above is the active continuity contract.
 
+- Patch notes (md) for v1.2.0d: docs/patch_notes/v1.2.0d.md
+- Patch notes (txt) for v1.2.0d: docs/PATCH_NOTES/v1.2.0d.txt
+- Patch notes (md) for v1.2.0c: docs/patch_notes/v1.2.0c.md
+- Patch notes (txt) for v1.2.0c: docs/PATCH_NOTES/v1.2.0c.txt
 - Patch notes (md) for v1.2.0b: docs/patch_notes/v1.2.0b.md
 - Patch notes (txt) for v1.2.0b: docs/PATCH_NOTES/v1.2.0b.txt
 - Patch notes (md) for v1.2.0a: docs/patch_notes/PATCH_NOTES_v1.2.0a.md

--- a/docs/brains/brains_v1.2.0d.md
+++ b/docs/brains/brains_v1.2.0d.md
@@ -1,0 +1,9 @@
+# Brains — v1.2.0d
+
+## REF 1.2.0-A04 — Gate overlays to 1-D products
+- **Problem**: The targets panel allowed overlaying any curated MAST product, including 2-D images/cubes that the overlay renderer cannot plot. This produced ingestion entries that failed later without user guidance.
+- **Decision**: Classify each product via `_product_overlay_support` so only spectra/SEDs/time-series expose an active Overlay button while images/cubes render a disabled control with an explanatory note.
+- **Implementation**: Added `SUPPORTED_OVERLAY_TYPES` and `_product_overlay_support` in `app/ui/targets.py`, wiring the panel loop to respect the helper before appending to `st.session_state['ingest_queue']`. Unsupported entries now show a caption clarifying overlays are 1-D only. 【F:app/ui/targets.py†L19-L150】
+- **Alternatives considered**: Filtering the manifest earlier in the registry build would hide image products entirely, but product review UI feedback requested visibility with clear affordances, so we opted for inline annotations.
+- **Verification**: Added `tests/ui/test_targets_overlay_support.py` to assert spectra/time-series remain eligible and image/missing types are annotated. 【F:tests/ui/test_targets_overlay_support.py†L1-L40】
+- **Follow-ups**: Extend the helper to flag future dataproduct types (e.g., cubes sliced to 1-D) once ingestion pipelines support them, and consider surfacing provider/tooltips describing how to fetch 2-D assets outside the overlay workspace.

--- a/docs/patch_notes/PATCHLOG.txt
+++ b/docs/patch_notes/PATCHLOG.txt
@@ -14,3 +14,13 @@ Next:
 - Implement MAST/ESO/SDSS fetch with provenance.json per dataset.
 - Wire unit resolver and duplicate-upload guard (checksum index).
 - Finish differential alignment, resampling, and logging.
+---
+v1.2.0d — Overlay gating for MAST products
+Date: 2025-10-01 01:15:00Z
+
+Summary:
+- Limit Overlay actions in the targets panel to spectra/SED/time-series entries and annotate images/cubes with a disabled control.
+- Added focused regression coverage for the helper that classifies dataproduct types.
+
+Verification:
+- pytest tests/ui/test_targets_overlay_support.py

--- a/docs/patch_notes/v1.2.0d.md
+++ b/docs/patch_notes/v1.2.0d.md
@@ -1,0 +1,15 @@
+# Patch Notes — v1.2.0d
+
+## Summary
+- Disable overlay ingestion for MAST products that are not 1-D spectra, SEDs, or time-series and surface a helper note for unsupported entries.
+- Add focused regression coverage that proves image-type products are annotated instead of enqueued for overlay.
+
+## Details
+1. **Overlay gating**
+   - Introduced `_product_overlay_support` in `app/ui/targets.py` so image/cube entries render a disabled button with context while 1-D products continue to enqueue traces.
+   - Normalised dataproduct type handling and ensured missing or unknown types are treated as unsupported for overlays.
+2. **Regression coverage**
+   - Added `tests/ui/test_targets_overlay_support.py` to confirm spectra/time-series remain eligible and image rows present the explanatory annotation.
+
+## Verification
+- `pytest tests/ui/test_targets_overlay_support.py`

--- a/tests/ui/test_targets_overlay_support.py
+++ b/tests/ui/test_targets_overlay_support.py
@@ -1,0 +1,40 @@
+"""Tests for overlay eligibility in the targets panel."""
+
+from app.ui.targets import _product_overlay_support
+
+
+def test_spectrum_product_allows_overlay():
+    product = {"dataproduct_type": "spectrum"}
+
+    result = _product_overlay_support(product)
+
+    assert result["supported"] is True
+    assert result["note"] == ""
+
+
+def test_timeseries_with_whitespace_allows_overlay():
+    product = {"dataproduct_type": "  TimeSeries  "}
+
+    result = _product_overlay_support(product)
+
+    assert result["supported"] is True
+    assert result["note"] == ""
+
+
+def test_image_product_displays_annotation():
+    product = {"dataproduct_type": "image"}
+
+    result = _product_overlay_support(product)
+
+    assert result["supported"] is False
+    assert "Images" in result["note"]
+    assert "1-D" in result["note"]
+
+
+def test_missing_dataproduct_type_is_blocked():
+    product = {}
+
+    result = _product_overlay_support(product)
+
+    assert result["supported"] is False
+    assert "does not report" in result["note"]


### PR DESCRIPTION
## Summary
- gate the target catalog overlay button behind a `_product_overlay_support` helper so only spectra/SED/time-series can enqueue traces
- annotate image and cube entries with a disabled overlay control and ship regression coverage for the helper
- roll v1.2.0d continuity collateral (version.json, patch notes, brains index/logs, AI log, overlay workspace docs)

## Testing
- `pytest tests/ui/test_targets_overlay_support.py`


------
https://chatgpt.com/codex/tasks/task_e_68dc7e9513ec832986c0809da17ceac9