### PR TITLE
Fix example browser provider defaults and update continuity docs

### DIFF
--- a/PATCHLOG.txt
+++ b/PATCHLOG.txt
@@ -14,3 +14,4 @@ Spectra App — Patch Log (append-only)
 - v1.2.0c (REF 1.2.0c-A01): fixed the example browser provider selector to respect session persistence without triggering Streamlit widget warnings, refreshed UI docs, and logged the QA verification.
 - v1.2.0d (REF 1.2.0d-A01): wired the Docs tab banner to current patch metadata so release summaries track `app/version.json`, added regression coverage, and refreshed continuity collateral.
 - v1.2.0e (REF 1.2.0e-A01): align the app header caption with active patch metadata and extend UI coverage to prevent regressions.
+- v1.2.0f (REF 1.2.0f-A01): normalise example browser provider defaults before the multiselect renders, silencing rerun warnings and preserving cached filters.

--- a/app/version.json
+++ b/app/version.json
@@ -1,11 +1,5 @@
 {
-  "version": "v1.2.0e",
-  "date_utc": "2025-10-02T00:00:00Z",
-  "summary": "App header now mirrors patch metadata to avoid drift."
-  "version": "v1.2.0d",
-  "date_utc": "2025-10-02T00:00:00Z",
-  "summary": "Docs tab banner now reflects the current patch metadata."
-
-  "date_utc": "2025-10-01T01:15:00Z",
-  "summary": "Restrict MAST overlay actions to supported 1-D products and annotate images/cubes."
+  "version": "v1.2.0f",
+  "date_utc": "2025-10-03T00:00:00Z",
+  "summary": "Example browser provider filters initialise defaults without reassigning Streamlit-owned state."
 }

--- a/docs/PATCH_NOTES/v1.2.0f.txt
+++ b/docs/PATCH_NOTES/v1.2.0f.txt
@@ -1,0 +1,3 @@
+Spectra App — v1.2.0f
+- Fix the example browser provider selector by initialising cached defaults before the multiselect renders, preventing Streamlit from warning about reassigned state and keeping filters persistent.
+- Add unit coverage for the provider default normalisation helper.

--- a/docs/ai_log/2025-10-02.md
+++ b/docs/ai_log/2025-10-02.md
@@ -25,6 +25,29 @@
 - Spectra App v1.2+ – Handoff Protocol & Task Blueprint (internal).
 - https://docs.astropy.org/en/latest/io/votable/
 
+## Tasking — v1.2.0f
+- Resolve the Streamlit rerun warning emitted by the example browser provider selector.
+- Preserve cached provider filters and update regression coverage accordingly.
+- Roll continuity artefacts (version, brains, patch notes, AI log, patch log) for the v1.2.0f hotfix.
+
+## Actions & Decisions
+- Reviewed the v1.2+ handoff protocol to reconfirm the continuity checklist before touching the example browser UI. 【F:docs/ai_handoff/Spectra App v1.2+ – Handoff Protocol & Task Blueprint.txt†L1-L120】
+- Consulted the MAST API reference to confirm provider naming conventions while validating fallback behaviour. 【F:docs/mirrored/mast_api.meta.json†L1-L7】
+- Added `_normalise_provider_defaults` and refactored `render_example_browser_sheet` to seed widget defaults without mutating Streamlit-managed keys post-render. 【F:app/ui/example_browser.py†L91-L189】
+- Extended `tests/ui/test_example_browser.py` with helper-focused unit tests covering stale provider removal and default fallbacks. 【F:tests/ui/test_example_browser.py†L31-L67】
+- Bumped `app/version.json` to v1.2.0f and refreshed patch notes (md/txt), brains index/log, and patch log per the v1.2 continuity contract. 【F:app/version.json†L1-L5】【F:docs/patch_notes/v1.2.0f.md†L1-L19】【F:docs/PATCH_NOTES/v1.2.0f.txt†L1-L3】【F:docs/brains/brains_v1.2.0f.md†L1-L18】【F:docs/brains/brains_INDEX.md†L1-L24】【F:PATCHLOG.txt†L1-L21】
+
+## Verification
+- `pytest tests/ui/test_example_browser.py` 【eb5f05†L1-L5】
+
+## Outstanding Follow-ups
+- Expand UI snapshot coverage once Streamlit tooling allows us to assert widget warning-free reruns end-to-end.
+- Audit the duplicated v1.2.0d rows in the brains index during the next documentation cleanup.
+
+## Docs Consulted
+- Spectra App v1.2+ – Handoff Protocol & Task Blueprint (internal).
+- https://mast.stsci.edu/api/v0//
+
 ## Tasking — v1.2.0e
 - Keep the Spectra App header caption aligned with the live patch metadata.
 - Add regression coverage so the header continues to prioritise the patch version.

--- a/docs/brains/brains_INDEX.md
+++ b/docs/brains/brains_INDEX.md
@@ -1,6 +1,6 @@
 # MAKE NEW BRAINS EACH TIME YOU MAKE A CHANGE. DO NOT OVER WRITE PREVIOUS BRAINS * unless needed
 # Spectra App — Brains Index
-_Last updated: 2025-10-02T19:30:00Z_
+_Last updated: 2025-10-03T02:15:00Z_
 
 This index is the mandated entry point before touching the codebase.
 It tracks the latest continuity documents and the required cross-links between them.
@@ -14,6 +14,7 @@ It tracks the latest continuity documents and the required cross-links between t
 ## Continuity Table
 | Version | Brains Log | Patch Notes | AI Handoff |
 | --- | --- | --- | --- |
+| v1.2.0f | [docs/brains/brains_v1.2.0f.md](brains_v1.2.0f.md) | [docs/patch_notes/v1.2.0f.md](../patch_notes/v1.2.0f.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md) |
 | v1.2.0e | [docs/brains/brains_v1.2.0e.md](brains_v1.2.0e.md) | [docs/patch_notes/v1.2.0e.md](../patch_notes/v1.2.0e.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md) |
 | v1.2.0d | [docs/brains/brains_v1.2.0d.md](brains_v1.2.0d.md) | [docs/patch_notes/v1.2.0d.md](../patch_notes/v1.2.0d.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0d.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0d.md) |
 | v1.2.0d | [docs/brains/brains_v1.2.0d.md](brains_v1.2.0d.md) | [docs/patch_notes/v1.2.0d.md](../patch_notes/v1.2.0d.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0d.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0d.md) |
@@ -31,6 +32,8 @@ It tracks the latest continuity documents and the required cross-links between t
 
 Older releases remain in `docs/brains/` and `docs/patches/` for archeology, but the table above is the active continuity contract.
 
+- Patch notes (md) for v1.2.0f: docs/patch_notes/v1.2.0f.md
+- Patch notes (txt) for v1.2.0f: docs/PATCH_NOTES/v1.2.0f.txt
 - Patch notes (md) for v1.2.0e: docs/patch_notes/v1.2.0e.md
 - Patch notes (txt) for v1.2.0e: docs/PATCH_NOTES/v1.2.0e.txt
 - Patch notes (md) for v1.2.0d: docs/patch_notes/v1.2.0d.md

--- a/docs/brains/brains_v1.2.0f.md
+++ b/docs/brains/brains_v1.2.0f.md
@@ -1,0 +1,19 @@
+# Brains — v1.2.0f
+
+## Release focus
+- **REF 1.2.0f-A01**: Stabilise the example browser provider selector so cached filters survive reruns without triggering Streamlit widget warnings.
+
+## Implementation notes
+- Introduced `_normalise_provider_defaults` to compute the multiselect defaults without mutating Streamlit-managed state after widget instantiation.
+- The example browser now seeds `st.multiselect` via the helper and defers to `st.session_state.get` for the search box and favourites toggle, matching Streamlit's widget lifecycle.
+- Added unit tests that cover stale-provider trimming and fallback behaviour for the helper to guard against regressions.
+
+## Testing
+- `pytest tests/ui/test_example_browser.py`
+
+## Outstanding work
+- Expand UI smoke coverage once Streamlit snapshot tooling lands so we can assert the widget emits no warnings during reruns.
+- Follow up on the duplicated rows in `brains_INDEX.md` for earlier v1.2.0d entries during the next documentation tidy.
+
+## Continuity updates
+- Version bumped to v1.2.0f with matching updates to the patch notes (md/txt), patch log, and AI activity log.

--- a/docs/patch_notes/v1.2.0f.md
+++ b/docs/patch_notes/v1.2.0f.md
@@ -1,0 +1,18 @@
+# Patch Notes — v1.2.0f
+
+## Summary
+- Refine the example browser provider selector so cached filter choices load before the widget renders and avoid Streamlit state warnings.
+- Add unit coverage for the provider default normalisation helper.
+
+## Details
+1. **Provider filter defaults**
+   - Initialise provider defaults via a helper that filters stale entries and falls back to all providers when needed.
+   - Pass the defaults to `st.multiselect` without reassigning the Streamlit-managed key, eliminating rerun warnings.
+2. **Regression coverage**
+   - Extend `tests/ui/test_example_browser.py` with unit tests that exercise the provider default normalisation logic.
+
+## Verification
+- `pytest tests/ui/test_example_browser.py`
+
+## Continuity
+- Version bumped to v1.2.0f with updates to the patch log, brains index/log, AI log, and plaintext patch notes.

--- a/tests/ui/test_example_browser.py
+++ b/tests/ui/test_example_browser.py
@@ -48,6 +48,23 @@ def test_filter_examples_supports_search_and_favourites():
     assert results == [spec_b]
 
 
+def test_normalise_provider_defaults_filters_stale_entries():
+    options = ["MAST", "ESO", "NED"]
+    stored = ["ESO", "HST", "ESO"]
+
+    defaults = example_browser._normalise_provider_defaults(options, stored)
+
+    assert defaults == ["ESO"]
+
+
+def test_normalise_provider_defaults_falls_back_to_all_when_empty():
+    options = ["MAST", "ESO"]
+
+    defaults = example_browser._normalise_provider_defaults(options, [])
+
+    assert defaults == options
+
+
 def test_register_example_usage_tracks_recent(monkeypatch):
     import app.ui.main as main
 


### PR DESCRIPTION
## Summary
- normalise the example browser provider defaults before rendering the multiselect so Streamlit retains cached selections without warnings
- add unit coverage for the provider default helper and document the change in the v1.2.0f brains and patch notes
- bump the app version to v1.2.0f and refresh the patch log and AI log per the continuity contract

## Testing
- `pytest tests/ui/test_example_browser.py`


------
https://chatgpt.com/codex/tasks/task_e_68dc869fb6788329af20b3fdfc63987e