### PR TITLE
Relocate NIST line catalog controls to the sidebar

### DIFF
--- a/PATCHLOG.txt
+++ b/PATCHLOG.txt
@@ -15,3 +15,4 @@ Spectra App — Patch Log (append-only)
 - v1.2.0d (REF 1.2.0d-A01): wired the Docs tab banner to current patch metadata so release summaries track `app/version.json`, added regression coverage, and refreshed continuity collateral.
 - v1.2.0e (REF 1.2.0e-A01): align the app header caption with active patch metadata and extend UI coverage to prevent regressions.
 - v1.2.0f (REF 1.2.0f-A01): normalise example browser provider defaults before the multiselect renders, silencing rerun warnings and preserving cached filters.
+- v1.2.0g (REF 1.2.0g-A01): relocate the NIST line catalog tools into the sidebar controls, refresh the library copy, and add regression coverage for the new placement.

--- a/app/ui/main.py
+++ b/app/ui/main.py
@@ -1096,6 +1096,8 @@ def _render_settings_group(container: DeltaGenerator) -> None:
     _render_differential_section(container)
     with container.expander("Similarity settings", expanded=False) as similarity_panel:
         _render_similarity_sidebar(similarity_panel)
+    container.divider()
+    _render_line_catalog_group(container)
 
 
 def _render_example_browser() -> None:
@@ -2514,7 +2516,7 @@ def _render_differential_tab() -> None:
 def _render_library_tab() -> None:
     st.header("Data library")
     st.caption(
-        "Browse curated examples, target manifests, line catalogs, and upload policies "
+        "Browse curated examples, target manifests, and upload policies "
         "from a single workspace panel."
     )
 
@@ -2528,11 +2530,6 @@ def _render_library_tab() -> None:
         render_targets_panel(expanded=True, sidebar=targets_container)
     except RegistryUnavailableError as exc:
         targets_container.info(str(exc))
-
-    st.divider()
-
-    line_catalog_container = st.container()
-    _render_line_catalog_group(line_catalog_container)
 
     st.divider()
 

--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.0f",
+  "version": "v1.2.0g",
   "date_utc": "2025-10-03T00:00:00Z",
-  "summary": "Example browser provider filters initialise defaults without reassigning Streamlit-owned state."
+  "summary": "Move NIST line catalog tools into the sidebar controls with regression coverage."
 }

--- a/docs/PATCH_NOTES/v1.2.0g.txt
+++ b/docs/PATCH_NOTES/v1.2.0g.txt
@@ -1,0 +1,3 @@
+Spectra App — v1.2.0g
+- Move the NIST line catalog fetch form into the sidebar session controls so it sits with the network and display toggles.
+- Drop the Library tab container for line catalogs, update the tab copy, and add regression coverage for the sidebar placement and offline notice.

--- a/docs/ai_log/2025-10-01.md
+++ b/docs/ai_log/2025-10-01.md
@@ -17,3 +17,20 @@
 
 ## Outstanding Follow-ups
 - Extend `_product_overlay_support` once 2-D reduction pipelines can provide 1-D slices so library overlays can surface those assets without manual downloads.
+
+## Tasking
+- Relocate the NIST line catalog controls from the Library tab into the sidebar session controls per the hotfix request.
+- Add regression coverage to ensure the sidebar renders the NIST form online and shows the offline notice when archive fetchers are disabled.
+- Refresh the v1.2 continuity artefacts (version, brains, patch notes, UI contract, patch log) after the sidebar change.
+
+## Actions & Decisions
+- Reviewed the astroquery NIST query reference to confirm our form parameters still align before moving the UI. 【F:docs/mirrored/astroquery/nist/nist.meta.json†L1-L4】
+- Updated `_render_settings_group` to render `_render_line_catalog_group` in the sidebar and removed the Library tab container/caption for the line catalog tools. 【F:app/ui/main.py†L1081-L1103】【F:app/ui/main.py†L2525-L2536】
+- Added Streamlit AppTest coverage that asserts the NIST form appears in the sidebar when online and that the offline notice replaces it when fetchers are disabled. 【F:tests/ui/test_sidebar_line_catalog.py†L1-L35】
+- Bumped versioning and refreshed the patch notes, brains log/index, UI contract JSON, plaintext notes, and patch log for v1.2.0g. 【F:app/version.json†L1-L5】【F:docs/patch_notes/v1.2.0g.md†L1-L19】【F:docs/PATCH_NOTES/v1.2.0g.txt†L1-L3】【F:docs/brains/brains_v1.2.0g.md†L1-L18】【F:docs/brains/brains_INDEX.md†L1-L22】【F:docs/ui_contract.json†L1-L20】【F:PATCHLOG.txt†L17-L19】
+
+## Verification
+- `pytest tests/ui/test_sidebar_line_catalog.py` 【894051†L1-L3】
+
+## Outstanding Follow-ups
+- Wire the UI contract JSON into the verification script so automated checks enforce the documented sidebar sections.

--- a/docs/brains/brains_INDEX.md
+++ b/docs/brains/brains_INDEX.md
@@ -1,6 +1,6 @@
 # MAKE NEW BRAINS EACH TIME YOU MAKE A CHANGE. DO NOT OVER WRITE PREVIOUS BRAINS * unless needed
 # Spectra App — Brains Index
-_Last updated: 2025-10-03T02:15:00Z_
+_Last updated: 2025-10-03T03:30:00Z_
 
 This index is the mandated entry point before touching the codebase.
 It tracks the latest continuity documents and the required cross-links between them.
@@ -14,6 +14,7 @@ It tracks the latest continuity documents and the required cross-links between t
 ## Continuity Table
 | Version | Brains Log | Patch Notes | AI Handoff |
 | --- | --- | --- | --- |
+| v1.2.0g | [docs/brains/brains_v1.2.0g.md](brains_v1.2.0g.md) | [docs/patch_notes/v1.2.0g.md](../patch_notes/v1.2.0g.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md) |
 | v1.2.0f | [docs/brains/brains_v1.2.0f.md](brains_v1.2.0f.md) | [docs/patch_notes/v1.2.0f.md](../patch_notes/v1.2.0f.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md) |
 | v1.2.0e | [docs/brains/brains_v1.2.0e.md](brains_v1.2.0e.md) | [docs/patch_notes/v1.2.0e.md](../patch_notes/v1.2.0e.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md) |
 | v1.2.0d | [docs/brains/brains_v1.2.0d.md](brains_v1.2.0d.md) | [docs/patch_notes/v1.2.0d.md](../patch_notes/v1.2.0d.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0d.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0d.md) |
@@ -32,6 +33,8 @@ It tracks the latest continuity documents and the required cross-links between t
 
 Older releases remain in `docs/brains/` and `docs/patches/` for archeology, but the table above is the active continuity contract.
 
+- Patch notes (md) for v1.2.0g: docs/patch_notes/v1.2.0g.md
+- Patch notes (txt) for v1.2.0g: docs/PATCH_NOTES/v1.2.0g.txt
 - Patch notes (md) for v1.2.0f: docs/patch_notes/v1.2.0f.md
 - Patch notes (txt) for v1.2.0f: docs/PATCH_NOTES/v1.2.0f.txt
 - Patch notes (md) for v1.2.0e: docs/patch_notes/v1.2.0e.md

--- a/docs/brains/brains_v1.2.0g.md
+++ b/docs/brains/brains_v1.2.0g.md
@@ -1,0 +1,20 @@
+# Brains — v1.2.0g
+
+## Release focus
+- **REF 1.2.0g-A01**: Keep the NIST line catalog workflow discoverable by relocating it into the sidebar controls and documenting the new placement.
+
+## Implementation notes
+- Moved `_render_line_catalog_group` into the `_render_settings_group` sidebar container so the NIST form sits with network toggles and other fetch-affecting controls.
+- Trimmed the Library tab copy now that line catalogs are no longer rendered there to avoid misleading guidance.
+- Added Streamlit `AppTest` coverage that asserts the sidebar renders the NIST form when online and replaces it with the offline notice once archive fetchers are disabled.
+- Refreshed `docs/ui_contract.json` to enumerate the sidebar sections (including the new Line catalogs entry) and bumped all continuity artefacts for v1.2.0g.
+
+## Testing
+- `pytest tests/ui/test_sidebar_line_catalog.py`
+
+## Outstanding work
+- Extend the UI contract verifier script to parse the JSON artefact directly so docs and automation cannot diverge on required sections.
+- Continue the SIMBAD resolver integration outlined in the v1.2 blueprint once sidebar controls settle.
+
+## Continuity updates
+- Version bumped to v1.2.0g with updates to patch notes (md/txt), patch log, AI log, and the brains index.

--- a/docs/patch_notes/v1.2.0g.md
+++ b/docs/patch_notes/v1.2.0g.md
@@ -1,0 +1,20 @@
+# Patch Notes — v1.2.0g
+
+## Summary
+- Relocate the NIST line catalog tools from the Library tab into the sidebar session controls and validate the new placement.
+- Refresh continuity collateral to record the sidebar update and new regression coverage.
+
+## Details
+1. **Sidebar integration**
+   - Move the NIST form into the sidebar settings container so line catalog fetches live alongside network and display toggles.
+   - Remove the redundant Library tab container and update the tab copy now that line catalogs live in the controls panel.
+2. **Regression coverage**
+   - Add Streamlit AppTest coverage to ensure the sidebar renders the NIST form when online and surfaces the offline notice when archive fetchers are disabled.
+3. **Continuity**
+   - Bump the app version, extend the UI contract artefact with the sidebar section, and refresh brains, patch logs, and AI activity notes per the v1.2 blueprint.
+
+## Verification
+- `pytest tests/ui/test_sidebar_line_catalog.py`
+
+## Continuity
+- Version bumped to v1.2.0g with updates to the brains index/log, UI contract, AI log, and plaintext patch notes.

--- a/docs/ui_contract.json
+++ b/docs/ui_contract.json
@@ -1,14 +1,16 @@
 {
   "sidebar": [
-    "Examples",
-    "Display mode",
-    "Display units",
-    "Export what I see"
+    "Session controls",
+    "Display & viewport",
+    "Differential & normalization",
+    "Similarity settings",
+    "Line catalogs"
   ],
   "tabs": [
     "Overlay",
     "Differential",
-    "Docs"
+    "Library",
+    "Docs & Provenance"
   ],
   "badges": [
     "version_badge_top_right"
@@ -19,15 +21,18 @@
   "plot": [
     "legend_non_empty"
   ],
-  "v": "v1.1.4",
+  "v": "v1.2.0g",
   "must_have": [
     "Overlay tab present",
     "Differential tab present",
+    "Library tab present",
+    "Docs & Provenance tab present",
     "Export what I see produces PNG+CSV+manifest",
     "Unit toggles: nm, \u00c5, \u00b5m, cm^-1 round-trip",
     "Duplicate guard banner with override/purge",
     "Fetch Data section reachable",
     "Export manifest contains fetch_provenance when traces are fetched",
-    "Differential A/B selections persist; epsilon guard toggle exists"
+    "Differential A/B selections persist; epsilon guard toggle exists",
+    "NIST line catalog fetch available from sidebar when online"
   ]
 }

--- a/tests/ui/test_sidebar_line_catalog.py
+++ b/tests/ui/test_sidebar_line_catalog.py
@@ -1,0 +1,38 @@
+from streamlit.testing.v1 import AppTest
+
+
+def _render_sidebar_entrypoint() -> None:
+    import streamlit as st  # noqa: F401  # Re-exported for AppTest serialization
+
+    from app.ui.main import _ensure_session_state, _render_settings_group
+
+    _ensure_session_state()
+    container = st.sidebar.container()
+    _render_settings_group(container)
+
+
+def test_line_catalog_form_moves_to_sidebar():
+    app = AppTest.from_function(_render_sidebar_entrypoint)
+    app.session_state.network_available = True
+
+    app.run()
+
+    form_blocks = app.sidebar.get("form")
+    form_ids = {block.proto.form.form_id for block in form_blocks}
+
+    assert "nist_overlay_form" in form_ids
+
+
+def test_line_catalog_sidebar_respects_offline_toggle():
+    app = AppTest.from_function(_render_sidebar_entrypoint)
+    app.session_state.network_available = False
+
+    app.run()
+
+    form_blocks = app.sidebar.get("form")
+    form_ids = {block.proto.form.form_id for block in form_blocks}
+
+    assert "nist_overlay_form" not in form_ids
+
+    offline_messages = {info.body for info in app.sidebar.info}
+    assert any("offline" in message.lower() for message in offline_messages)


### PR DESCRIPTION
## Summary
- move the NIST line catalog form into the sidebar session controls and trim the library tab copy
- add Streamlit AppTest coverage that checks the sidebar placement and offline notice
- refresh versioning, patch notes, brains, UI contract, and patch log for v1.2.0g

## Testing
- pytest tests/ui/test_sidebar_line_catalog.py

------
https://chatgpt.com/codex/tasks/task_e_68dc8900b858832997512b004aa11cde