### PR TITLE
Relocate example quick-add controls into sidebar

### DIFF
--- a/PATCHLOG.txt
+++ b/PATCHLOG.txt
@@ -16,3 +16,4 @@ Spectra App — Patch Log (append-only)
 - v1.2.0e (REF 1.2.0e-A01): align the app header caption with active patch metadata and extend UI coverage to prevent regressions.
 - v1.2.0f (REF 1.2.0f-A01): normalise example browser provider defaults before the multiselect renders, silencing rerun warnings and preserving cached filters.
 - v1.2.0g (REF 1.2.0g-A01): relocate the NIST line catalog tools into the sidebar controls, refresh the library copy, and add regression coverage for the new placement.
+- v1.2.0h (REF 1.2.0h-A01): move the example quick-add controls into the sidebar stack, streamline the Library tab messaging, update the UI contract, and extend regression coverage.

--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.0g",
-  "date_utc": "2025-10-03T00:00:00Z",
-  "summary": "Move NIST line catalog tools into the sidebar controls with regression coverage."
+  "version": "v1.2.0h",
+  "date_utc": "2025-10-04T00:00:00Z",
+  "summary": "Relocate example quick-add controls into the sidebar and refresh the library guidance."
 }

--- a/docs/PATCH_NOTES/v1.2.0h.txt
+++ b/docs/PATCH_NOTES/v1.2.0h.txt
@@ -1,0 +1,3 @@
+Spectra App — v1.2.0h
+- Move the examples quick-add controls into the sidebar beneath the display settings and trim the Library tab copy to point at the new placement.
+- Update the UI contract, add sidebar-specific regression coverage, and refresh continuity collateral.

--- a/docs/ai_log/2025-10-04.md
+++ b/docs/ai_log/2025-10-04.md
@@ -1,0 +1,23 @@
+# AI Log — 2025-10-04
+
+## Tasking — v1.2.0h
+- Move the example quick-add workflows into the sidebar beneath the display controls.
+- Keep the Library tab focused on guidance while preserving targets and uploads tooling.
+- Update regression coverage and continuity artefacts (version, brains, patch notes, patch log, UI contract, AI log).
+
+## Actions & Decisions
+- Re-read the v1.2+ handoff blueprint to confirm the sidebar and continuity requirements before touching the UI. 【F:docs/ai_handoff/Spectra App v1.2+ – Handoff Protocol & Task Blueprint.txt†L1-L35】
+- Refactored `_render_examples_group` with compact expanders and sidebar-friendly widgets, then invoked it from `_render_settings_group` immediately after the display controls so quick-add tools live with other session settings. 【F:app/ui/main.py†L811-L902】【F:app/ui/main.py†L1097-L1118】
+- Replaced the Library tab's embedded examples panel with an informational callout that points users to the sidebar controls, avoiding duplicate widgets. 【F:app/ui/main.py†L2534-L2557】
+- Added Streamlit AppTest coverage that validates the sidebar forms and the updated Library copy, and refreshed the UI contract to enumerate the new "Examples library" section. 【F:tests/ui/test_sidebar_examples.py†L1-L52】【F:docs/ui_contract.json†L1-L37】
+- Bumped the app version and regenerated continuity artefacts (patch notes, plaintext summary, brains entry, brains index, patch log) to record the relocation. 【F:app/version.json†L1-L4】【F:docs/patch_notes/v1.2.0h.md†L1-L22】【F:docs/PATCH_NOTES/v1.2.0h.txt†L1-L3】【F:docs/brains/brains_v1.2.0h.md†L1-L21】【F:docs/brains/brains_INDEX.md†L1-L40】【F:PATCHLOG.txt†L18-L19】
+
+## Verification
+- `pytest tests/ui/test_sidebar_examples.py tests/ui/test_sidebar_line_catalog.py` 【1c12f7†L1-L4】
+
+## Outstanding Follow-ups
+- Explore a sidebar compact mode once we revisit the SIMBAD resolver backlog so multiple expanders can co-exist without excessive scrolling.
+- Restore the FAISS-backed docs index service to satisfy the standing RAG requirement called out in prior logs.
+
+## Docs Consulted
+- Spectra App v1.2+ – Handoff Protocol & Task Blueprint. 【F:docs/ai_handoff/Spectra App v1.2+ – Handoff Protocol & Task Blueprint.txt†L1-L35】

--- a/docs/brains/brains_INDEX.md
+++ b/docs/brains/brains_INDEX.md
@@ -1,6 +1,6 @@
 # MAKE NEW BRAINS EACH TIME YOU MAKE A CHANGE. DO NOT OVER WRITE PREVIOUS BRAINS * unless needed
 # Spectra App — Brains Index
-_Last updated: 2025-10-03T03:30:00Z_
+_Last updated: 2025-10-04T00:00:00Z_
 
 This index is the mandated entry point before touching the codebase.
 It tracks the latest continuity documents and the required cross-links between them.
@@ -14,6 +14,7 @@ It tracks the latest continuity documents and the required cross-links between t
 ## Continuity Table
 | Version | Brains Log | Patch Notes | AI Handoff |
 | --- | --- | --- | --- |
+| v1.2.0h | [docs/brains/brains_v1.2.0h.md](brains_v1.2.0h.md) | [docs/patch_notes/v1.2.0h.md](../patch_notes/v1.2.0h.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md) |
 | v1.2.0g | [docs/brains/brains_v1.2.0g.md](brains_v1.2.0g.md) | [docs/patch_notes/v1.2.0g.md](../patch_notes/v1.2.0g.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md) |
 | v1.2.0f | [docs/brains/brains_v1.2.0f.md](brains_v1.2.0f.md) | [docs/patch_notes/v1.2.0f.md](../patch_notes/v1.2.0f.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md) |
 | v1.2.0e | [docs/brains/brains_v1.2.0e.md](brains_v1.2.0e.md) | [docs/patch_notes/v1.2.0e.md](../patch_notes/v1.2.0e.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md) |
@@ -33,6 +34,8 @@ It tracks the latest continuity documents and the required cross-links between t
 
 Older releases remain in `docs/brains/` and `docs/patches/` for archeology, but the table above is the active continuity contract.
 
+- Patch notes (md) for v1.2.0h: docs/patch_notes/v1.2.0h.md
+- Patch notes (txt) for v1.2.0h: docs/PATCH_NOTES/v1.2.0h.txt
 - Patch notes (md) for v1.2.0g: docs/patch_notes/v1.2.0g.md
 - Patch notes (txt) for v1.2.0g: docs/PATCH_NOTES/v1.2.0g.txt
 - Patch notes (md) for v1.2.0f: docs/patch_notes/v1.2.0f.md

--- a/docs/brains/brains_v1.2.0h.md
+++ b/docs/brains/brains_v1.2.0h.md
@@ -1,0 +1,21 @@
+# Brains — v1.2.0h
+
+## Release focus
+- **REF 1.2.0h-A01**: Surface the curated example quick-add tools directly in the sidebar controls so loading spectra no longer requires switching tabs.
+
+## Implementation notes
+- Insert the examples quick-add button, favourites, recents, and reference trace tools beneath the display controls in `_render_settings_group`, collapsing optional lists into expanders for breathing room.
+- Replace the Library tab's embedded examples panel with sidebar-focused guidance so users learn where the controls moved.
+- Update the UI contract JSON to include the new "Examples library" sidebar section and bump the contract version tag.
+- Add Streamlit AppTest coverage for the sidebar panel plus a regression that the Library tab copy points to the sidebar.
+
+## Testing
+- `pytest tests/ui/test_sidebar_examples.py`
+- `pytest tests/ui/test_sidebar_line_catalog.py`
+
+## Outstanding work
+- Extend the example browser sheet with richer previews once the sidebar layout stabilises.
+- Consider a compact mode toggle for the sidebar when multiple expanders are open simultaneously.
+
+## Continuity updates
+- Version bumped to v1.2.0h with refreshed patch notes (md/txt), patch log, UI contract, and AI activity log entries.

--- a/docs/patch_notes/v1.2.0h.md
+++ b/docs/patch_notes/v1.2.0h.md
@@ -1,0 +1,22 @@
+# Patch Notes — v1.2.0h
+
+## Summary
+- Move the curated example quick-add controls into the sidebar session stack and streamline the Library tab copy.
+- Expand UI regression coverage for the relocated examples panel and document the new sidebar contract.
+
+## Details
+1. **Sidebar refresh**
+   - Render the examples quick-add button, favourites, and recents within the sidebar beneath the display controls, with compact expanders for optional lists.
+   - Replace the Library tab's embedded examples panel with guidance that points users to the sidebar controls.
+2. **Contract and coverage**
+   - Update the UI contract to enumerate the "Examples library" sidebar section.
+   - Add Streamlit AppTest coverage to ensure the sidebar exposes the quick-add forms and that the Library tab copy references the sidebar move.
+3. **Continuity**
+   - Bump the app version and refresh continuity artefacts (brains, patch notes, UI contract, patch log, AI log) for v1.2.0h.
+
+## Verification
+- `pytest tests/ui/test_sidebar_examples.py`
+- `pytest tests/ui/test_sidebar_line_catalog.py`
+
+## Continuity
+- Version bumped to v1.2.0h with updates to the brains index/log, UI contract, AI log, and plaintext patch notes.

--- a/docs/ui_contract.json
+++ b/docs/ui_contract.json
@@ -2,6 +2,7 @@
   "sidebar": [
     "Session controls",
     "Display & viewport",
+    "Examples library",
     "Differential & normalization",
     "Similarity settings",
     "Line catalogs"
@@ -21,7 +22,7 @@
   "plot": [
     "legend_non_empty"
   ],
-  "v": "v1.2.0g",
+  "v": "v1.2.0h",
   "must_have": [
     "Overlay tab present",
     "Differential tab present",

--- a/tests/ui/test_sidebar_examples.py
+++ b/tests/ui/test_sidebar_examples.py
@@ -1,0 +1,52 @@
+from streamlit.testing.v1 import AppTest
+
+
+def _render_sidebar_entrypoint() -> None:
+    import streamlit as st  # noqa: F401  # Re-exported for AppTest serialization
+
+    from app.ui.main import _ensure_session_state, _render_settings_group
+
+    _ensure_session_state()
+    container = st.sidebar.container()
+    _render_settings_group(container)
+
+
+def _render_library_entrypoint() -> None:
+    import streamlit as st  # noqa: F401  # Re-exported for AppTest serialization
+
+    from app.ui.main import _ensure_session_state, _render_library_tab
+
+    _ensure_session_state()
+    _render_library_tab()
+
+
+def test_sidebar_examples_controls_render():
+    app = AppTest.from_function(_render_sidebar_entrypoint)
+    app.session_state.network_available = True
+    app.session_state.example_favourites = ["sirius-stis"]
+    app.session_state.example_recent = ["sirius-stis"]
+
+    app.run()
+
+    button_labels = [button.label for button in app.sidebar.button]
+    assert "Browse example library" in button_labels
+
+    form_blocks = app.sidebar.get("form")
+    form_ids = {block.proto.form.form_id for block in form_blocks}
+    assert "example_quick_add_form" in form_ids
+    assert "example_favourites_form" in form_ids
+    assert "example_recent_form" in form_ids
+
+
+def test_library_tab_points_to_sidebar(monkeypatch):
+    import app.ui.main as main
+
+    monkeypatch.setattr(main, "render_targets_panel", lambda *_, **__: None)
+    monkeypatch.setattr(main, "_render_uploads_group", lambda container: container.write("Uploads"))
+
+    app = AppTest.from_function(_render_library_entrypoint)
+
+    app.run()
+
+    info_messages = {info.body for info in app.info}
+    assert any("examples" in message.lower() and "sidebar" in message.lower() for message in info_messages)


### PR DESCRIPTION
## Summary
- move the examples quick-add, favourites, recents, and overlay controls into the sidebar beneath the display settings with compact expanders
- streamline the Library tab copy, update the UI contract, and add AppTest coverage for the relocated examples panel
- bump version metadata and refresh patch notes, brains, patch log, and AI log for v1.2.0h

## Testing
- pytest tests/ui/test_sidebar_examples.py tests/ui/test_sidebar_line_catalog.py

------
https://chatgpt.com/codex/tasks/task_e_68dc8c7eede483298b19019c5fb6fee0