### PR TITLE
Relocate reference controls to differential tab

### DIFF
--- a/PATCHLOG.txt
+++ b/PATCHLOG.txt
@@ -17,3 +17,4 @@ Spectra App — Patch Log (append-only)
 - v1.2.0f (REF 1.2.0f-A01): normalise example browser provider defaults before the multiselect renders, silencing rerun warnings and preserving cached filters.
 - v1.2.0g (REF 1.2.0g-A01): relocate the NIST line catalog tools into the sidebar controls, refresh the library copy, and add regression coverage for the new placement.
 - v1.2.0h (REF 1.2.0h-A01): move the example quick-add controls into the sidebar stack, streamline the Library tab messaging, update the UI contract, and extend regression coverage.
+- v1.2.0i (REF 1.2.0i-A01): relocate the reference trace selector and clear overlays action to the Differential tab, update regression coverage, and refresh continuity collateral.

--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.0h",
-  "date_utc": "2025-10-04T00:00:00Z",
-  "summary": "Relocate example quick-add controls into the sidebar and refresh the library guidance."
+  "version": "v1.2.0i",
+  "date_utc": "2025-10-05T00:00:00Z",
+  "summary": "Move reference trace selection into the differential workspace with related tools."
 }

--- a/docs/PATCH_NOTES/v1.2.0i.txt
+++ b/docs/PATCH_NOTES/v1.2.0i.txt
@@ -1,0 +1,3 @@
+Spectra App — v1.2.0i
+- Relocate the reference trace selector and clear overlays button into the Differential tab so comparison tools share one workspace.
+- Extend differential UI regression coverage and refresh versioning collateral for the release.

--- a/docs/ai_log/2025-10-05.md
+++ b/docs/ai_log/2025-10-05.md
@@ -1,0 +1,25 @@
+# AI Log — 2025-10-05
+
+## Tasking — v1.2.0i
+- Move the reference trace selector and clear action out of the sidebar examples group into the Differential workspace.
+- Ensure session state and regression coverage adapt to the relocated controls.
+- Refresh continuity artefacts (version, brains, patch notes, AI log) per the v1.2+ blueprint.
+
+## Actions & Decisions
+- Re-read the v1.2+ handoff blueprint to confirm continuity expectations before touching the layout. 【F:docs/ai_handoff/Spectra App v1.2+ – Handoff Protocol & Task Blueprint.txt†L1-L35】
+- Added `_render_reference_controls` for reuse inside the Differential tab, wiring the selectbox and clear overlays button alongside comparison inputs while keeping state defaults intact. 【F:app/ui/main.py†L2098-L2142】
+- Removed the reference widgets from `_render_examples_group` so the sidebar only surfaces example and library controls. 【F:app/ui/main.py†L883-L909】
+- Extended the differential AppTest to assert the relocated reference selector and action button render as expected. 【F:tests/ui/test_differential_form.py†L44-L73】
+- Logged the move across the new brains entry, patch notes, and version metadata for v1.2.0i. 【F:docs/brains/brains_v1.2.0i.md†L1-L18】【F:docs/patch_notes/v1.2.0i.md†L1-L20】【F:app/version.json†L1-L5】
+- Reviewed the ASD help reference terminology to confirm user-facing language stays consistent. 【F:docs/mirrored/nist_asd_help/help.meta.json†L1-L6】
+
+## Verification
+- `pytest tests/ui/test_differential_form.py`
+
+## Outstanding Follow-ups
+- Explore inline guidance for how reference traces influence similarity scoring to aid new users.
+- Restore the FAISS-backed docs index service highlighted in prior continuity logs.
+
+## Docs Consulted
+- Spectra App v1.2+ – Handoff Protocol & Task Blueprint. 【F:docs/ai_handoff/Spectra App v1.2+ – Handoff Protocol & Task Blueprint.txt†L1-L35】
+- NIST Atomic Spectra Database help. 【F:docs/mirrored/nist_asd_help/help.meta.json†L1-L6】

--- a/docs/brains/brains_INDEX.md
+++ b/docs/brains/brains_INDEX.md
@@ -1,6 +1,6 @@
 # MAKE NEW BRAINS EACH TIME YOU MAKE A CHANGE. DO NOT OVER WRITE PREVIOUS BRAINS * unless needed
 # Spectra App — Brains Index
-_Last updated: 2025-10-04T00:00:00Z_
+_Last updated: 2025-10-05T00:00:00Z_
 
 This index is the mandated entry point before touching the codebase.
 It tracks the latest continuity documents and the required cross-links between them.
@@ -14,6 +14,7 @@ It tracks the latest continuity documents and the required cross-links between t
 ## Continuity Table
 | Version | Brains Log | Patch Notes | AI Handoff |
 | --- | --- | --- | --- |
+| v1.2.0i | [docs/brains/brains_v1.2.0i.md](brains_v1.2.0i.md) | [docs/patch_notes/v1.2.0i.md](../patch_notes/v1.2.0i.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md) |
 | v1.2.0h | [docs/brains/brains_v1.2.0h.md](brains_v1.2.0h.md) | [docs/patch_notes/v1.2.0h.md](../patch_notes/v1.2.0h.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md) |
 | v1.2.0g | [docs/brains/brains_v1.2.0g.md](brains_v1.2.0g.md) | [docs/patch_notes/v1.2.0g.md](../patch_notes/v1.2.0g.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md) |
 | v1.2.0f | [docs/brains/brains_v1.2.0f.md](brains_v1.2.0f.md) | [docs/patch_notes/v1.2.0f.md](../patch_notes/v1.2.0f.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md) |

--- a/docs/brains/brains_v1.2.0i.md
+++ b/docs/brains/brains_v1.2.0i.md
@@ -1,0 +1,19 @@
+# Brains — v1.2.0i
+
+## Release focus
+- **REF 1.2.0i-A01**: Align the reference trace selector with the Differential workspace so comparison tooling sits together.
+
+## Implementation notes
+- Move the reference trace selectbox and clear overlays button into `_render_differential_tab`, reusing a helper that keeps the sidebar examples panel focused on library actions.
+- Preserve reference state defaults while filtering overlays, ensuring the overlay plot and similarity tooling continue to pick up the chosen anchor trace.
+- Surface the relocation through an AppTest that inspects the differential tab tree for the reference selector and clear action to guard regressions.
+
+## Testing
+- `pytest tests/ui/test_differential_form.py`
+
+## Outstanding work
+- Consider adding per-tab onboarding to explain how reference traces influence similarity scoring and differential math.
+- Revisit the docs index service downtime noted in v1.2.0h once infra availability improves.
+
+## Continuity updates
+- Version bumped to v1.2.0i with refreshed patch notes, brains index entry, and AI activity log.

--- a/docs/patch_notes/v1.2.0i.md
+++ b/docs/patch_notes/v1.2.0i.md
@@ -1,0 +1,21 @@
+# Patch Notes — v1.2.0i
+
+## Summary
+- Relocate the reference trace selector and clear action into the Differential tab so comparison tools live together.
+- Add regression coverage ensuring the new differential controls render alongside the existing form.
+
+## Details
+1. **Differential workspace alignment**
+   - Render the reference trace selector and clear overlays button directly within the Differential tab header.
+   - Keep the selection state in sync with overlay updates so downstream plots and similarity panels continue to respect the chosen reference.
+2. **Sidebar simplification**
+   - Remove the reference controls from the Examples sidebar group, leaving only example/library tooling in that section.
+3. **Coverage and continuity**
+   - Extend the differential UI AppTest to assert the presence and behaviour of the relocated reference controls.
+   - Bump the app version and refresh brains, patch notes, and AI activity logs for v1.2.0i.
+
+## Verification
+- `pytest tests/ui/test_differential_form.py`
+
+## Continuity
+- Version bumped to v1.2.0i with accompanying brains index/log and AI log updates.

--- a/tests/ui/test_differential_form.py
+++ b/tests/ui/test_differential_form.py
@@ -51,3 +51,25 @@ def test_differential_form_has_single_submit_button():
             queue.extend(children.values())
 
     assert len(button_nodes) == 1
+
+
+def test_reference_controls_render_in_differential_tab():
+    app = AppTest.from_function(_render_differential_tab_entrypoint)
+
+    app.session_state.overlay_traces = [
+        _simple_overlay("a"),
+        _simple_overlay("b"),
+    ]
+    app.session_state.reference_trace_id = "b"
+    app.session_state.normalization_mode = "unit"
+
+    app.run()
+
+    reference_select = [
+        select for select in app.selectbox if select.label == "Reference trace"
+    ]
+    assert reference_select, "Reference selectbox should be rendered in differential tab"
+    assert reference_select[0].value == "b"
+
+    button_labels = [button.label for button in app.button]
+    assert "Clear overlays" in button_labels


### PR DESCRIPTION
## Summary
- move the reference trace selector and clear overlays action into a dedicated helper rendered from the Differential tab
- add regression coverage to verify the relocated differential controls
- bump to v1.2.0i and refresh brains, patch notes, AI log, and patch log entries

## Testing
- pytest tests/ui/test_differential_form.py

------
https://chatgpt.com/codex/tasks/task_e_68dc8ebc01b08329b0dfa0b257941154