### PR TITLE
Relocate similarity analysis to differential tab

### DIFF
--- a/PATCHLOG.txt
+++ b/PATCHLOG.txt
@@ -18,3 +18,4 @@ Spectra App — Patch Log (append-only)
 - v1.2.0g (REF 1.2.0g-A01): relocate the NIST line catalog tools into the sidebar controls, refresh the library copy, and add regression coverage for the new placement.
 - v1.2.0h (REF 1.2.0h-A01): move the example quick-add controls into the sidebar stack, streamline the Library tab messaging, update the UI contract, and extend regression coverage.
 - v1.2.0i (REF 1.2.0i-A01): relocate the reference trace selector and clear overlays action to the Differential tab, update regression coverage, and refresh continuity collateral.
+- v1.2.0j (REF 1.2.0j-A01): move similarity analysis into the Differential workspace, extend regression coverage, keep overlay metadata/line tables intact, and refresh continuity docs.

--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.0i",
-  "date_utc": "2025-10-05T00:00:00Z",
-  "summary": "Move reference trace selection into the differential workspace with related tools."
+  "version": "v1.2.0j",
+  "date_utc": "2025-10-06T00:00:00Z",
+  "summary": "Relocate similarity analysis into the differential workspace and refresh coverage."
 }

--- a/docs/PATCH_NOTES/v1.2.0j.txt
+++ b/docs/PATCH_NOTES/v1.2.0j.txt
@@ -1,0 +1,3 @@
+Spectra App — v1.2.0j
+- Relocate the similarity analysis panel into the Differential tab alongside comparison tooling.
+- Refresh regression coverage, UI contract guidance, and continuity docs to lock the new placement.

--- a/docs/ai_log/2025-10-06.md
+++ b/docs/ai_log/2025-10-06.md
@@ -1,0 +1,24 @@
+# AI Log — 2025-10-06
+
+## Tasking — v1.2.0j
+- Relocate the similarity analysis panel into the Differential workspace so it only appears when comparison inputs exist.
+- Ensure the Overlay tab still surfaces metadata and line tables after the move.
+- Refresh UI contract, brains, patch notes, and regression coverage per the v1.2 continuity rules.
+
+## Actions & Decisions
+- Reviewed the v1.2+ handoff protocol to confirm continuity requirements before editing UI layout docs and tests. 【F:docs/ai_handoff/Spectra App v1.2+ – Handoff Protocol & Task Blueprint.txt†L1-L35】
+- Moved similarity vector preparation and rendering from `_render_overlay_tab` to `_render_differential_tab`, gating the panel on two or more spectral overlays and reusing the active viewport. 【F:app/ui/main.py†L2215-L2271】【F:app/ui/main.py†L2474-L2528】
+- Extended the differential AppTest to assert the relocated "Similarity analysis" heading, and added an overlay AppTest to ensure metadata and line tables still render. 【F:tests/ui/test_differential_form.py†L1-L86】【F:tests/ui/test_metadata_summary.py†L1-L156】
+- Updated the UI contract, brains index, patch notes (md/txt), patch log, version metadata, and new brains entry to document the change. 【F:docs/ui_contract.json†L1-L29】【F:docs/brains/brains_INDEX.md†L1-L48】【F:docs/patch_notes/v1.2.0j.md†L1-L24】【F:docs/PATCH_NOTES/v1.2.0j.txt†L1-L3】【F:PATCHLOG.txt†L1-L26】【F:app/version.json†L1-L5】【F:docs/brains/brains_v1.2.0j.md†L1-L19】
+
+## Verification
+- `pytest tests/ui/test_differential_form.py`
+- `pytest tests/ui/test_metadata_summary.py`
+
+## Outstanding Follow-ups
+- Add inline guidance in the Differential workspace describing how similarity metrics complement differential curves.
+- Restore the docs search index service noted in earlier continuity logs.
+
+## Docs Consulted
+- Spectra App v1.2+ – Handoff Protocol & Task Blueprint. 【F:docs/ai_handoff/Spectra App v1.2+ – Handoff Protocol & Task Blueprint.txt†L1-L35】
+- NIST Atomic Spectra Database help metadata (for terminology alignment). 【F:docs/mirrored/nist_asd_help/help.meta.json†L1-L6】

--- a/docs/brains/brains_INDEX.md
+++ b/docs/brains/brains_INDEX.md
@@ -1,6 +1,6 @@
 # MAKE NEW BRAINS EACH TIME YOU MAKE A CHANGE. DO NOT OVER WRITE PREVIOUS BRAINS * unless needed
 # Spectra App — Brains Index
-_Last updated: 2025-10-05T00:00:00Z_
+_Last updated: 2025-10-06T00:00:00Z_
 
 This index is the mandated entry point before touching the codebase.
 It tracks the latest continuity documents and the required cross-links between them.
@@ -14,6 +14,7 @@ It tracks the latest continuity documents and the required cross-links between t
 ## Continuity Table
 | Version | Brains Log | Patch Notes | AI Handoff |
 | --- | --- | --- | --- |
+| v1.2.0j | [docs/brains/brains_v1.2.0j.md](brains_v1.2.0j.md) | [docs/patch_notes/v1.2.0j.md](../patch_notes/v1.2.0j.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md) |
 | v1.2.0i | [docs/brains/brains_v1.2.0i.md](brains_v1.2.0i.md) | [docs/patch_notes/v1.2.0i.md](../patch_notes/v1.2.0i.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md) |
 | v1.2.0h | [docs/brains/brains_v1.2.0h.md](brains_v1.2.0h.md) | [docs/patch_notes/v1.2.0h.md](../patch_notes/v1.2.0h.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md) |
 | v1.2.0g | [docs/brains/brains_v1.2.0g.md](brains_v1.2.0g.md) | [docs/patch_notes/v1.2.0g.md](../patch_notes/v1.2.0g.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md) |
@@ -35,6 +36,9 @@ It tracks the latest continuity documents and the required cross-links between t
 
 Older releases remain in `docs/brains/` and `docs/patches/` for archeology, but the table above is the active continuity contract.
 
+- Patch notes (md) for v1.2.0j: docs/patch_notes/v1.2.0j.md
+- Patch notes (txt) for v1.2.0j: docs/PATCH_NOTES/v1.2.0j.txt
+- Patch notes (md) for v1.2.0i: docs/patch_notes/v1.2.0i.md
 - Patch notes (md) for v1.2.0h: docs/patch_notes/v1.2.0h.md
 - Patch notes (txt) for v1.2.0h: docs/PATCH_NOTES/v1.2.0h.txt
 - Patch notes (md) for v1.2.0g: docs/patch_notes/v1.2.0g.md

--- a/docs/brains/brains_v1.2.0j.md
+++ b/docs/brains/brains_v1.2.0j.md
@@ -1,0 +1,20 @@
+# Brains — v1.2.0j
+
+## Release focus
+- **REF 1.2.0j-A01**: Consolidate similarity analysis with differential tooling so users compare spectra from a single workspace.
+
+## Implementation notes
+- Lift the similarity vector prep and `render_similarity_panel` call from `_render_overlay_tab` into `_render_differential_tab`, gating the panel on having at least two spectral overlays.
+- Share the viewport defaults from overlay state so similarity metrics continue to respect the active zoom window.
+- Preserve overlay metadata and line tables by leaving their renderers untouched and adding coverage to detect accidental removal.
+
+## Testing
+- `pytest tests/ui/test_differential_form.py`
+- `pytest tests/ui/test_metadata_summary.py`
+
+## Outstanding work
+- Explore inline guidance in the differential tab to explain how similarity metrics complement the computed differential curve.
+- Continue monitoring doc search service availability noted in earlier logs.
+
+## Continuity updates
+- Version bumped to v1.2.0j with refreshed patch notes, patch log entry, brains index update, and AI activity log section.

--- a/docs/patch_notes/v1.2.0j.md
+++ b/docs/patch_notes/v1.2.0j.md
@@ -1,0 +1,23 @@
+# Patch Notes — v1.2.0j
+
+## Summary
+- Relocate the similarity analysis panel into the Differential workspace so comparison tooling lives together.
+- Refresh UI contract guidance and regression coverage to lock the new layout while keeping overlay metadata tables intact.
+
+## Details
+1. **Differential workspace alignment**
+   - Move similarity vector preparation and the `render_similarity_panel` call from the overlay tab into `_render_differential_tab`.
+   - Only surface the panel when at least two non-line spectra are available, reusing viewport defaults for consistent scoring.
+2. **Overlay continuity**
+   - Leave metadata and line table renderers in place so the overlay tab still reports contextual details without the similarity UI.
+   - Add an AppTest that loads both spectrum and line overlays to assert the tables continue rendering.
+3. **Regression updates**
+   - Extend the differential AppTest to expect the relocated similarity heading.
+   - Update the UI contract version and must-have list to reflect the new panel placement.
+
+## Verification
+- `pytest tests/ui/test_differential_form.py`
+- `pytest tests/ui/test_metadata_summary.py`
+
+## Continuity
+- Version bumped to v1.2.0j with aligned brains index entry, patch notes, patch log, and AI log updates.

--- a/docs/ui_contract.json
+++ b/docs/ui_contract.json
@@ -22,7 +22,7 @@
   "plot": [
     "legend_non_empty"
   ],
-  "v": "v1.2.0h",
+  "v": "v1.2.0j",
   "must_have": [
     "Overlay tab present",
     "Differential tab present",
@@ -34,6 +34,7 @@
     "Fetch Data section reachable",
     "Export manifest contains fetch_provenance when traces are fetched",
     "Differential A/B selections persist; epsilon guard toggle exists",
+    "Similarity analysis panel lives in Differential tab when two spectra loaded",
     "NIST line catalog fetch available from sidebar when online"
   ]
 }

--- a/tests/ui/test_differential_form.py
+++ b/tests/ui/test_differential_form.py
@@ -1,5 +1,6 @@
 from streamlit.testing.v1 import AppTest
 
+from app.similarity import SimilarityCache
 from app.ui.main import OverlayTrace
 
 
@@ -73,3 +74,26 @@ def test_reference_controls_render_in_differential_tab():
 
     button_labels = [button.label for button in app.button]
     assert "Clear overlays" in button_labels
+
+
+def test_similarity_panel_renders_with_differential_inputs():
+    app = AppTest.from_function(_render_differential_tab_entrypoint)
+
+    app.session_state.overlay_traces = [
+        _simple_overlay("a"),
+        _simple_overlay("b"),
+        _simple_overlay("c"),
+    ]
+    app.session_state.reference_trace_id = "a"
+    app.session_state.normalization_mode = "unit"
+    app.session_state.similarity_cache = SimilarityCache()
+    app.session_state.similarity_metrics = ["cosine", "line_match"]
+    app.session_state.similarity_primary_metric = "cosine"
+    app.session_state.similarity_line_peaks = 5
+
+    app.run()
+
+    assert not app.exception
+
+    headings = [block.body for block in app.markdown]
+    assert "### Similarity analysis" in headings


### PR DESCRIPTION
## Summary
- move similarity panel preparation and rendering into the Differential tab so it only appears when enough spectra are available
- leave the Overlay tab focused on metadata/line tables and extend UI regression coverage for both tabs
- refresh UI contract, versioning collateral, brains entry, patch notes, and AI log for v1.2.0j

## Testing
- pytest tests/ui/test_differential_form.py
- pytest tests/ui/test_metadata_summary.py

------
https://chatgpt.com/codex/tasks/task_e_68dc90ac756483299fbca2d663315c2d