### PR TITLE
Segment overlay viewports by axis kind

### DIFF
--- a/PATCHLOG.txt
+++ b/PATCHLOG.txt
@@ -20,3 +20,4 @@ Spectra App — Patch Log (append-only)
 - v1.2.0i (REF 1.2.0i-A01): relocate the reference trace selector and clear overlays action to the Differential tab, update regression coverage, and refresh continuity collateral.
 - v1.2.0j (REF 1.2.0j-A01): move similarity analysis into the Differential workspace, extend regression coverage, keep overlay metadata/line tables intact, and refresh continuity docs.
 - v1.2.0k (REF 1.2.0k-A01): reorganize the target catalog with search filters, manifest metrics, grouped overlay actions, and new layout regression coverage.
+- v1.2.0l (REF 1.2.0l-A01): split overlay viewports by axis kind, surface mixed-axis warnings, update exports/tests, and refresh continuity docs.

--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.0k",
-  "date_utc": "2025-10-07T00:00:00Z",
-  "summary": "Reorganize the target catalog with search, manifest highlights, and grouped overlay actions."
+  "version": "v1.2.0l",
+  "date_utc": "2025-10-08T00:00:00Z",
+  "summary": "Segment overlay viewports by axis kind so time-series traces no longer clamp spectral plots."
 }

--- a/docs/PATCH_NOTES/v1.2.0l.txt
+++ b/docs/PATCH_NOTES/v1.2.0l.txt
@@ -1,0 +1,1 @@
+v1.2.0l — Split overlay viewport state by axis kind, warn on mixed axes, and update exports/tests accordingly.

--- a/docs/ai_log/2025-10-08.md
+++ b/docs/ai_log/2025-10-08.md
@@ -1,0 +1,22 @@
+# AI Log — 2025-10-08
+
+## Tasking — v1.2.0l
+- Isolate overlay viewport state per axis kind, warn when mixed time/wavelength traces render together, and keep exports/tests in sync.
+- Roll continuity collateral (brains, patch notes, version, AI log) for the new hotfix.
+
+## Actions & Decisions
+- Introduced axis-kind helpers and migrated session state to a `viewport_axes` map so wavelength and time traces keep independent zoom ranges. 【F:app/ui/main.py†L336-L407】【F:app/ui/main.py†L421-L472】
+- Updated the sidebar and overlay tab to select viewports per axis, emit mixed-axis warnings, and pass axis-aware ranges into plot construction. 【F:app/ui/main.py†L1034-L1114】【F:app/ui/main.py†L2411-L2467】
+- Reworked `_build_overlay_figure` and export helpers to honor axis-specific viewports, surface "Mixed axes" titles, and include axis metadata in exported rows. 【F:app/ui/main.py†L1608-L1756】【F:app/ui/main.py†L2086-L2154】
+- Extended UI regression coverage for time-series mixes and added a mixed-axis overlay test. 【F:tests/ui/test_auto_viewport.py†L34-L71】【F:tests/ui/test_overlay_mixed_axes.py†L1-L40】
+- Logged the design rationale in the atlas brain dump and refreshed versioned continuity docs (brains log/index + patch notes). 【F:docs/atlas/brains.md†L1-L4】【F:docs/brains/brains_v1.2.0l.md†L1-L23】【F:docs/brains/brains_INDEX.md†L1-L18】【F:docs/patch_notes/v1.2.0l.md†L1-L23】
+
+## Verification
+- `pytest tests/ui/test_auto_viewport.py tests/ui/test_overlay_full_resolution.py tests/ui/test_overlay_hover.py tests/ui/test_overlay_mixed_axes.py` 【c01f00†L1-L8】
+
+## Outstanding Follow-ups
+- Consider adding an explicit axis selector in the sidebar if future payloads introduce additional axis kinds beyond wavelength/time.
+- Monitor downstream consumers for the new `axis_kind`/`unit` export fields and update docs if schema consumers request clarifications.
+
+## Docs Consulted
+- Astropy time-series overview for axis handling expectations. 【F:docs/mirrored/astropy/timeseries.meta.json†L1-L7】

--- a/docs/atlas/brains.md
+++ b/docs/atlas/brains.md
@@ -1,0 +1,4 @@
+# Axis-aware viewport handling — 2025-10-08
+- Maintain a `viewport_axes` session map keyed by axis kind so wavelength and time traces stop overwriting each other's zoom state.
+- Mixed-axis overlays reuse per-kind ranges during sampling/export while the chart surfaces a "Mixed axes" title and warning instead of forcing a shared x-range.
+- Export payloads now include `axis_kind` + unit metadata, keeping time-series rows intact when spectral viewports tighten.

--- a/docs/brains/brains_INDEX.md
+++ b/docs/brains/brains_INDEX.md
@@ -1,6 +1,6 @@
 # MAKE NEW BRAINS EACH TIME YOU MAKE A CHANGE. DO NOT OVER WRITE PREVIOUS BRAINS * unless needed
 # Spectra App — Brains Index
-_Last updated: 2025-10-07T00:00:00Z_
+_Last updated: 2025-10-08T00:00:00Z_
 
 This index is the mandated entry point before touching the codebase.
 It tracks the latest continuity documents and the required cross-links between them.
@@ -14,6 +14,7 @@ It tracks the latest continuity documents and the required cross-links between t
 ## Continuity Table
 | Version | Brains Log | Patch Notes | AI Handoff |
 | --- | --- | --- | --- |
+| v1.2.0l | [docs/brains/brains_v1.2.0l.md](brains_v1.2.0l.md) | [docs/patch_notes/v1.2.0l.md](../patch_notes/v1.2.0l.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0k.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0k.md) |
 | v1.2.0k | [docs/brains/brains_v1.2.0k.md](brains_v1.2.0k.md) | [docs/patch_notes/v1.2.0k.md](../patch_notes/v1.2.0k.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0k.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0k.md) |
 | v1.2.0j | [docs/brains/brains_v1.2.0j.md](brains_v1.2.0j.md) | [docs/patch_notes/v1.2.0j.md](../patch_notes/v1.2.0j.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md) |
 | v1.2.0i | [docs/brains/brains_v1.2.0i.md](brains_v1.2.0i.md) | [docs/patch_notes/v1.2.0i.md](../patch_notes/v1.2.0i.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md) |

--- a/docs/brains/brains_v1.2.0l.md
+++ b/docs/brains/brains_v1.2.0l.md
@@ -1,0 +1,19 @@
+# Brains — v1.2.0l
+
+## Release focus
+- **REF 1.2.0l-A01**: Decouple overlay viewport state by axis kind so spectral zooming stops clamping time-series plots and mixed overlays declare their axis context.
+
+## Implementation notes
+- Added per-axis viewport helpers that normalize stored tuples, migrate the legacy `viewport_nm` state, and expose axis-aware getters/setters used by the sidebar, overlay tab, exports, and differential panel.
+- Taught `_build_overlay_figure` to select axis-specific viewports, capture axis titles per kind, and emit a "Mixed axes" title without forcing a shared x-range when time and wavelength traces render together.
+- Updated the overlay exporter to include axis kind/unit metadata and refreshed UI tests to cover time-series auto-ranging plus a mixed-axis rendering scenario.
+
+## Testing
+- `pytest tests/ui/test_auto_viewport.py tests/ui/test_overlay_full_resolution.py tests/ui/test_overlay_hover.py tests/ui/test_overlay_mixed_axes.py`
+
+## Outstanding work
+- Evaluate whether we should surface a user-selectable axis toggle for slider control when more than two axis kinds appear in future data releases.
+- Monitor export consumers for compatibility with the new axis metadata payloads.
+
+## Continuity updates
+- Version bumped to v1.2.0l with refreshed patch notes, brains index entry, AI log, and handoff record.

--- a/docs/patch_notes/v1.2.0l.md
+++ b/docs/patch_notes/v1.2.0l.md
@@ -1,0 +1,20 @@
+# Patch Notes — v1.2.0l
+
+## Summary
+- Separate overlay viewport state by axis kind so time-series traces no longer clamp spectral plots and mixed overlays surface a dedicated warning.
+
+## Details
+1. **Viewport segregation**
+   - Maintain per-axis viewport preferences in session state and reuse them across overlay, differential, and export flows.
+   - Exclude time-series overlays when computing spectral auto ranges and pass axis-specific windows into render/export helpers.
+2. **Mixed axis UX**
+   - Label charts with a "Mixed axes" title and sidebar warning when time and wavelength traces coexist, skipping shared x-axis clamps.
+   - Enrich exports with axis kind metadata and preserve time-series points even when the spectral viewport is narrowed.
+3. **Regression coverage**
+   - Extend auto viewport tests for time-series mixes and add a mixed-axis overlay rendering check alongside existing hover/full-resolution cases.
+
+## Verification
+- `pytest tests/ui/test_auto_viewport.py tests/ui/test_overlay_full_resolution.py tests/ui/test_overlay_hover.py tests/ui/test_overlay_mixed_axes.py`
+
+## Continuity
+- Version bumped to v1.2.0l with refreshed brains log/index, patch notes, AI log entry, and handoff summary.

--- a/tests/ui/test_auto_viewport.py
+++ b/tests/ui/test_auto_viewport.py
@@ -29,3 +29,43 @@ def test_auto_viewport_trims_long_tail():
 
     # Long, low-flux tails should be trimmed to focus on the core signal.
     assert auto_span < raw_span * 0.6
+
+
+def test_auto_viewport_filters_to_requested_axis_kind():
+    spectral = OverlayTrace(
+        trace_id="spec",
+        label="Spectral",
+        wavelength_nm=tuple(np.linspace(450.0, 650.0, 120)),
+        flux=tuple(np.sin(np.linspace(0.0, np.pi, 120))),
+    )
+    time_series = OverlayTrace(
+        trace_id="time",
+        label="Photometry",
+        wavelength_nm=tuple(np.linspace(0.0, 20.0, 50)),
+        flux=tuple(np.linspace(0.0, 1.0, 50)),
+        axis_kind="time",
+    )
+
+    auto_range = _auto_viewport_range([spectral, time_series], axis_kind="wavelength")
+    assert auto_range is not None
+    low, high = auto_range
+    spectral_min = min(spectral.wavelength_nm)
+    spectral_max = max(spectral.wavelength_nm)
+    assert spectral_min <= low <= spectral_max
+    assert spectral_min <= high <= spectral_max
+
+
+def test_auto_viewport_for_time_axis():
+    time_trace = OverlayTrace(
+        trace_id="time",
+        label="Time series",
+        wavelength_nm=tuple(np.linspace(0.0, 10.0, 40)),
+        flux=tuple(np.cos(np.linspace(0.0, 2.0, 40))),
+        axis_kind="time",
+    )
+
+    auto_range = _auto_viewport_range([time_trace], axis_kind="time")
+    assert auto_range is not None
+    low, high = auto_range
+    assert 0.0 <= low < 1.0
+    assert 9.0 < high <= 10.0

--- a/tests/ui/test_overlay_full_resolution.py
+++ b/tests/ui/test_overlay_full_resolution.py
@@ -40,7 +40,7 @@ def test_full_resolution_preference_returns_all_points(session_state):
         display_units="nm",
         display_mode="Flux (raw)",
         normalization_mode="none",
-        viewport=(None, None),
+        viewport_by_kind={"wavelength": (None, None)},
         reference=None,
         differential_mode="Off",
         version_tag="vtest",

--- a/tests/ui/test_overlay_hover.py
+++ b/tests/ui/test_overlay_hover.py
@@ -14,7 +14,7 @@ def test_overlay_without_hover_uses_default_hover_fields():
         display_units="nm",
         display_mode="Flux (raw)",
         normalization_mode="none",
-        viewport=(None, None),
+        viewport_by_kind={"wavelength": (None, None)},
         reference=None,
         differential_mode="Off",
         version_tag="vtest",

--- a/tests/ui/test_overlay_mixed_axes.py
+++ b/tests/ui/test_overlay_mixed_axes.py
@@ -1,0 +1,40 @@
+import numpy as np
+
+from app.ui.main import OverlayTrace, _build_overlay_figure
+
+
+def test_mixed_axis_overlays_use_independent_viewports():
+    wavelength_trace = OverlayTrace(
+        trace_id="spec",
+        label="Spectral",
+        wavelength_nm=tuple(np.linspace(500.0, 600.0, 50)),
+        flux=tuple(np.linspace(0.0, 1.0, 50)),
+    )
+    time_trace = OverlayTrace(
+        trace_id="time",
+        label="Light curve",
+        wavelength_nm=tuple(np.linspace(0.0, 10.0, 25)),
+        flux=tuple(np.linspace(1.0, 0.5, 25)),
+        axis_kind="time",
+    )
+
+    fig, axis_title = _build_overlay_figure(
+        overlays=[wavelength_trace, time_trace],
+        display_units="nm",
+        display_mode="Flux (raw)",
+        normalization_mode="none",
+        viewport_by_kind={"wavelength": (510.0, 530.0), "time": (None, None)},
+        reference=None,
+        differential_mode="Off",
+        version_tag="vtest",
+        axis_viewport_by_kind={"wavelength": (510.0, 530.0)},
+    )
+
+    assert axis_title == "Mixed axes (time + wavelength)"
+    assert fig.layout.xaxis.range is None
+
+    spectral_trace, time_series_trace = fig.data
+    assert min(spectral_trace.x) >= 510.0
+    assert max(spectral_trace.x) <= 530.0
+    assert min(time_series_trace.x) == 0.0
+    assert max(time_series_trace.x) == 10.0


### PR DESCRIPTION
## Summary
- maintain per-axis viewport state and update overlay rendering plus warnings when time-series and spectral traces mix
- include axis metadata in overlay exports and refresh versioned docs for v1.2.0l
- expand UI tests to cover time-series auto-ranging and mixed-axis rendering

## Testing
- pytest tests/ui/test_auto_viewport.py tests/ui/test_overlay_full_resolution.py tests/ui/test_overlay_hover.py tests/ui/test_overlay_mixed_axes.py


------
https://chatgpt.com/codex/tasks/task_e_68dc9b5a15c48329b2c9bda15a80919e