### PR TITLE
Relocate overlay clear control to display settings

### DIFF
--- a/PATCHLOG.txt
+++ b/PATCHLOG.txt
@@ -21,3 +21,4 @@ Spectra App — Patch Log (append-only)
 - v1.2.0j (REF 1.2.0j-A01): move similarity analysis into the Differential workspace, extend regression coverage, keep overlay metadata/line tables intact, and refresh continuity docs.
 - v1.2.0k (REF 1.2.0k-A01): reorganize the target catalog with search filters, manifest metrics, grouped overlay actions, and new layout regression coverage.
 - v1.2.0l (REF 1.2.0l-A01): split overlay viewports by axis kind, surface mixed-axis warnings, update exports/tests, and refresh continuity docs.
+- v1.2.0m (REF 1.2.0m-A01): relocate the overlay clearing control into the display sidebar cluster, confirm the action in the overlay tab, extend UI coverage, and refresh release collateral.

--- a/app/ui/main.py
+++ b/app/ui/main.py
@@ -1033,6 +1033,17 @@ def _render_nist_form(container: DeltaGenerator) -> None:
 
 def _render_display_section(container: DeltaGenerator) -> None:
     container.markdown("#### Display & viewport")
+    overlays = _get_overlays()
+    cleared = container.button(
+        "Clear overlays",
+        key="clear_overlays_button",
+        help="Remove all overlays from the session.",
+        disabled=not overlays,
+    )
+    if cleared:
+        _clear_overlays()
+        st.session_state["overlay_clear_message"] = "Cleared all overlays."
+
     units = container.selectbox(
         "Wavelength units",
         ["nm", "Å", "µm", "cm^-1"],
@@ -1059,7 +1070,6 @@ def _render_display_section(container: DeltaGenerator) -> None:
     )
     st.session_state["display_full_resolution"] = bool(full_resolution)
 
-    overlays = _get_overlays()
     target_overlays = [trace for trace in overlays if trace.visible] or overlays
     if not target_overlays:
         st.session_state["auto_viewport"] = True
@@ -2376,8 +2386,7 @@ def _render_reference_controls(overlays: Sequence[OverlayTrace]) -> None:
     elif options:
         st.session_state["reference_trace_id"] = options[0]
 
-    col_select, col_action = st.columns([4, 1])
-    selection = col_select.selectbox(
+    selection = st.selectbox(
         "Reference trace",
         options,
         index=default_index,
@@ -2386,18 +2395,13 @@ def _render_reference_controls(overlays: Sequence[OverlayTrace]) -> None:
     )
     st.session_state["reference_trace_id"] = selection
 
-    cleared = False
-    if col_action.button("Clear overlays", key="clear_overlays_button"):
-        _clear_overlays()
-        cleared = True
-
-    if cleared:
-        st.warning("Cleared all overlays.")
-
 
 def _render_overlay_tab(version_info: Dict[str, str]) -> None:
     st.header("Overlay workspace")
     _render_local_upload()
+    cleared_message = st.session_state.pop("overlay_clear_message", None)
+    if cleared_message:
+        st.warning(str(cleared_message))
     overlays = _get_overlays()
     if not overlays:
         st.info("Upload a recorded spectrum or fetch from the archive tab to begin.")

--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.0l",
+  "version": "v1.2.0m",
   "date_utc": "2025-10-08T00:00:00Z",
-  "summary": "Segment overlay viewports by axis kind so time-series traces no longer clamp spectral plots."
+  "summary": "Move overlay clearing into display controls and confirm actions within the overlay workspace."
 }

--- a/docs/ai_log/2025-10-08.md
+++ b/docs/ai_log/2025-10-08.md
@@ -20,3 +20,17 @@
 
 ## Docs Consulted
 - Astropy time-series overview for axis handling expectations. 【F:docs/mirrored/astropy/timeseries.meta.json†L1-L7】
+
+## Tasking — v1.2.0m
+- Relocate the overlay clearing affordance into the Display & viewport controls and confirm the action inside the overlay workspace.
+
+## Actions & Decisions
+- Moved the "Clear overlays" button into the sidebar display section, disabled it when no overlays are loaded, and set a session flag so the action still calls `_clear_overlays()`. 【F:app/ui/main.py†L1034-L1045】
+- Added an overlay-tab warning banner that consumes the session flag to acknowledge the removal in context while leaving the differential reference chooser untouched. 【F:app/ui/main.py†L2399-L2408】【F:app/ui/main.py†L2375-L2396】
+- Extended UI tests to assert the control’s relocation and absence from the differential tab. 【F:tests/ui/test_differential_form.py†L66-L80】【F:tests/ui/test_sidebar_display_controls.py†L1-L35】
+
+## Verification
+- `pytest tests/ui/test_differential_form.py tests/ui/test_sidebar_display_controls.py` 【97f227†L1-L6】
+
+## Docs Consulted (v1.2.0m)
+- JWST portal overlay UX reference for contextual confirmation guidance. 【F:docs/mirrored/jwst_docs/accessing-jwst-data.meta.json†L1-L5】

--- a/docs/atlas/brains.md
+++ b/docs/atlas/brains.md
@@ -2,3 +2,8 @@
 - Maintain a `viewport_axes` session map keyed by axis kind so wavelength and time traces stop overwriting each other's zoom state.
 - Mixed-axis overlays reuse per-kind ranges during sampling/export while the chart surfaces a "Mixed axes" title and warning instead of forcing a shared x-range.
 - Export payloads now include `axis_kind` + unit metadata, keeping time-series rows intact when spectral viewports tighten.
+
+## Overlay clear control relocation — 2025-10-08
+- Move the destructive "Clear overlays" action into the Display & viewport cluster so overlay management lives beside viewport tools.
+- Raise a transient warning banner within the overlay tab after clearing so users receive immediate confirmation in the workspace context.
+- Differential tab keeps its reference selector without destructive controls, reducing the risk of accidental overlay loss while preparing comparisons.

--- a/docs/patch_notes/v1.2.0m.md
+++ b/docs/patch_notes/v1.2.0m.md
@@ -1,0 +1,20 @@
+# Patch Notes — v1.2.0m
+
+## Summary
+- Relocated the overlay clearing control into the Display & viewport sidebar block and surfaced confirmation directly in the overlay workspace.
+
+## Details
+1. **Sidebar placement**
+   - Render the "Clear overlays" button alongside viewport/display toggles so destructive actions live with overlay management tools.
+   - Disable the control when no overlays are loaded and persist the action through the existing `_clear_overlays()` helper.
+2. **Workspace feedback**
+   - Emit a warning banner within the overlay tab after clearing to confirm the removal in context, even when the overlay list becomes empty.
+   - Keep the Differential tab focused on trace selection by removing the destructive control from its reference sidebar.
+3. **Regression coverage**
+   - Updated the differential form test to ensure the button is absent there and added a sidebar test that asserts the control renders with overlays present.
+
+## Verification
+- `pytest tests/ui/test_differential_form.py tests/ui/test_sidebar_display_controls.py`
+
+## Continuity
+- Version bumped to v1.2.0m with corresponding brains entry and AI log update.

--- a/tests/ui/test_differential_form.py
+++ b/tests/ui/test_differential_form.py
@@ -73,7 +73,7 @@ def test_reference_controls_render_in_differential_tab():
     assert reference_select[0].value == "b"
 
     button_labels = [button.label for button in app.button]
-    assert "Clear overlays" in button_labels
+    assert "Clear overlays" not in button_labels
 
 
 def test_similarity_panel_renders_with_differential_inputs():

--- a/tests/ui/test_sidebar_display_controls.py
+++ b/tests/ui/test_sidebar_display_controls.py
@@ -1,0 +1,38 @@
+from streamlit.testing.v1 import AppTest
+
+
+def _render_sidebar_entrypoint() -> None:
+    import streamlit as st  # noqa: F401  # Re-exported for AppTest serialization
+
+    from app.ui.main import _ensure_session_state, _render_settings_group
+
+    _ensure_session_state()
+    container = st.sidebar.container()
+    _render_settings_group(container)
+
+
+def _simple_overlay(trace_id: str):
+    from app.ui.main import OverlayTrace
+
+    return OverlayTrace(
+        trace_id=trace_id,
+        label=f"Trace {trace_id}",
+        wavelength_nm=(500.0, 600.0, 700.0),
+        flux=(1.0, 1.1, 0.9),
+    )
+
+
+def test_clear_overlays_button_present_in_sidebar():
+    app = AppTest.from_function(_render_sidebar_entrypoint)
+
+    app.session_state.overlay_traces = [
+        _simple_overlay("a"),
+        _simple_overlay("b"),
+    ]
+
+    app.run()
+
+    sidebar_buttons = [button.label for button in app.sidebar.button]
+    assert "Clear overlays" in sidebar_buttons
+
+


### PR DESCRIPTION
## Summary
- move the Clear overlays control into the Display & viewport sidebar section and confirm the action in the overlay tab
- update differential and sidebar UI tests for the relocated button placement
- refresh brains, patch notes, version metadata, and AI log for v1.2.0m

## Testing
- pytest tests/ui/test_differential_form.py tests/ui/test_sidebar_display_controls.py

------
https://chatgpt.com/codex/tasks/task_e_68dc9f3802d88329aded01a1f982205e