### PR TITLE
Add image overlay ingestion and viewer support

### DIFF
--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.0m",
-  "date_utc": "2025-10-08T00:00:00Z",
-  "summary": "Move overlay clearing into display controls and confirm actions within the overlay workspace."
+  "version": "v1.2.0n",
+  "date_utc": "2025-10-10T00:00:00Z",
+  "summary": "Add FITS image overlay ingestion with a dedicated viewer and metadata pipeline."
 }

--- a/docs/ai_log/2025-10-08.md
+++ b/docs/ai_log/2025-10-08.md
@@ -34,3 +34,19 @@
 
 ## Docs Consulted (v1.2.0m)
 - JWST portal overlay UX reference for contextual confirmation guidance. 【F:docs/mirrored/jwst_docs/accessing-jwst-data.meta.json†L1-L5】
+
+## Tasking — v1.2.0n
+- Accept 2-D FITS images as overlays, preserve spatial WCS metadata, surface a viewer with contrast control, and roll continuity updates.
+
+## Actions & Decisions
+- Extended `_ingest_image_hdu` with WCS-based axis detection, serialised image payloads/masks, and `axis_kind="image"` metadata while keeping spectral collapse for genuine wavelength axes. 【F:app/server/ingest_fits.py†L1120-L1350】
+- Updated `ingest_local_file` summaries and safeguards so spatial images bypass spectral sample checks yet propagate pixel counts and `image` payloads. 【F:app/utils/local_ingest.py†L433-L517】
+- Added image-aware overlay handling—new heatmap panels with intensity sliders, metadata formatting, and mixed-axis filtering across the UI. 【F:app/ui/main.py†L60-L206】【F:app/ui/main.py†L1910-L2079】
+- Augmented regression coverage for spatial ingestion, local upload, and UI rendering; refreshed contract, version, brains, and patch notes accordingly. 【F:tests/server/test_ingest_fits.py†L214-L260】【F:docs/patch_notes/v1.2.0n.md†L1-L25】
+
+## Verification
+- `pytest tests/server/test_ingest_fits.py tests/server/test_local_ingest.py` 【f66e47†L1-L33】
+- `pytest tests/ui/test_metadata_summary.py tests/ui/test_overlay_mixed_axes.py tests/ui/test_overlay_additional_traces.py` 【bd7771†L1-L18】
+
+## Docs Consulted (v1.2.0n)
+- Astropy WCS overview for axis typing guidance. 【F:docs/mirrored/astropy/wcs.meta.json†L1-L6】

--- a/docs/atlas/brains.md
+++ b/docs/atlas/brains.md
@@ -7,3 +7,8 @@
 - Move the destructive "Clear overlays" action into the Display & viewport cluster so overlay management lives beside viewport tools.
 - Raise a transient warning banner within the overlay tab after clearing so users receive immediate confirmation in the workspace context.
 - Differential tab keeps its reference selector without destructive controls, reducing the risk of accidental overlay loss while preparing comparisons.
+
+## Image overlay ingestion — 2025-10-10
+- Treat FITS HDUs lacking spectral axes but carrying WCS metadata as `axis_kind="image"`, preserving masks, shape, and WCS serialisation for downstream viewers. 【F:app/server/ingest_fits.py†L1120-L1350】
+- Skip spectral sample requirements in local ingest, summarising images via pixel dimensions while leaving existing spectral flows untouched. 【F:app/utils/local_ingest.py†L433-L517】
+- Overlay UI renders Plotly heatmaps with intensity sliders and excludes image traces from spectral viewport math to keep axis warnings accurate. 【F:app/ui/main.py†L1910-L2079】【F:app/ui/main.py†L1608-L1756】

--- a/docs/patch_notes/v1.2.0n.md
+++ b/docs/patch_notes/v1.2.0n.md
@@ -1,0 +1,24 @@
+# Patch Notes — v1.2.0n
+
+## Summary
+- Add first-class ingestion for FITS spatial images, propagate WCS metadata, and surface overlays through a dedicated image viewer with contrast controls.
+
+## Details
+1. **FITS ingestion updates**
+   - `_ingest_image_hdu` now distinguishes spectral vs. spatial HDUs via WCS axis typing, preserving 2-D image payloads, masks, and WCS headers under `axis_kind="image"`. 【F:app/server/ingest_fits.py†L1120-L1350】
+   - Table ingestion recognises wavenumbers regardless of canonical label variants and continues to drop non-positive bins before wavelength conversion. 【F:app/server/ingest_fits.py†L470-L620】
+2. **Local ingest & metadata**
+   - `ingest_local_file` bypasses spectral sample checks for image payloads, forwards the `image` structure, and builds summaries from pixel shape. 【F:app/utils/local_ingest.py†L433-L517】
+3. **UI image viewer**
+   - Overlay traces carry optional `image` payloads; image axes skip plotting, while `_render_image_overlay_panels` renders Plotly heatmaps with per-trace intensity clipping sliders and WCS captions. 【F:app/ui/main.py†L60-L206】【F:app/ui/main.py†L1910-L2079】
+   - Mixed-axis helpers, metadata summaries, and reference logic treat `axis_kind="image"` as non-plottable while maintaining overlay visibility toggles. 【F:app/ui/main.py†L336-L366】【F:app/ui/main.py†L2482-L2527】
+4. **Tests**
+   - Added server regression coverage for spatial images and wavenumber filtering plus local ingest acceptance. 【F:tests/server/test_ingest_fits.py†L214-L260】【F:tests/server/test_local_ingest.py†L655-L688】
+   - UI tests assert metadata formatting, mixed-axis plotting, and image slider session keys. 【F:tests/ui/test_metadata_summary.py†L201-L253】【F:tests/ui/test_overlay_mixed_axes.py†L1-L52】
+
+## Verification
+- `pytest tests/server/test_ingest_fits.py tests/server/test_local_ingest.py` 【f66e47†L1-L33】
+- `pytest tests/ui/test_metadata_summary.py tests/ui/test_overlay_mixed_axes.py tests/ui/test_overlay_additional_traces.py` 【bd7771†L1-L18】
+
+## Continuity
+- Version bumped to v1.2.0n with atlas brain entry, UI contract update, patch notes, and AI log append recorded.

--- a/docs/ui_contract.json
+++ b/docs/ui_contract.json
@@ -22,7 +22,7 @@
   "plot": [
     "legend_non_empty"
   ],
-  "v": "v1.2.0j",
+  "v": "v1.2.0n",
   "must_have": [
     "Overlay tab present",
     "Differential tab present",
@@ -35,6 +35,7 @@
     "Export manifest contains fetch_provenance when traces are fetched",
     "Differential A/B selections persist; epsilon guard toggle exists",
     "Similarity analysis panel lives in Differential tab when two spectra loaded",
-    "NIST line catalog fetch available from sidebar when online"
+    "NIST line catalog fetch available from sidebar when online",
+    "Image overlays render a zoomable panel with intensity clip control"
   ]
 }

--- a/tests/ui/test_overlay_mixed_axes.py
+++ b/tests/ui/test_overlay_mixed_axes.py
@@ -38,3 +38,35 @@ def test_mixed_axis_overlays_use_independent_viewports():
     assert max(spectral_trace.x) <= 530.0
     assert min(time_series_trace.x) == 0.0
     assert max(time_series_trace.x) == 10.0
+
+
+def test_build_overlay_figure_ignores_image_axes():
+    spectral_trace = OverlayTrace(
+        trace_id="spec",
+        label="Spectrum",
+        wavelength_nm=(500.0, 510.0, 520.0),
+        flux=(1.0, 0.9, 1.1),
+    )
+    image_trace = OverlayTrace(
+        trace_id="img",
+        label="Image",
+        wavelength_nm=tuple(),
+        flux=tuple(),
+        axis="image",
+        axis_kind="image",
+        image={"data": [[0.0, 1.0], [2.0, 3.0]], "shape": [2, 2]},
+    )
+
+    fig, axis_title = _build_overlay_figure(
+        overlays=[spectral_trace, image_trace],
+        display_units="nm",
+        display_mode="Flux (raw)",
+        normalization_mode="none",
+        viewport_by_kind={"wavelength": (None, None)},
+        reference=None,
+        differential_mode="Off",
+        version_tag="vtest",
+    )
+
+    assert axis_title == "Wavelength (nm)"
+    assert len(fig.data) == 1


### PR DESCRIPTION
## Summary
- extend FITS ingestion to emit `axis_kind="image"` payloads with serialized image data, masks, and WCS provenance
- allow local ingest and overlay management to accept non-spectral image traces while surfacing a Plotly-based image viewer in the UI
- update documentation, patch notes, and regression coverage for spatial overlays and metadata summaries

## Testing
- `pytest tests/server/test_ingest_fits.py tests/server/test_local_ingest.py`
- `pytest tests/ui/test_metadata_summary.py tests/ui/test_overlay_mixed_axes.py tests/ui/test_overlay_additional_traces.py`


------
https://chatgpt.com/codex/tasks/task_e_68dca7aee88483298414dfc08d50c10e