### PR TITLE
Handle FITS byte-string unit hints

### DIFF
--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.0n",
-  "date_utc": "2025-10-10T00:00:00Z",
-  "summary": "Add FITS image overlay ingestion with a dedicated viewer and metadata pipeline."
+  "version": "v1.2.0o",
+  "date_utc": "2025-10-10T00:15:00Z",
+  "summary": "Handle FITS byte-string axis units during spectral and time-series ingestion."
 }

--- a/docs/ai_log/2025-10-10.md
+++ b/docs/ai_log/2025-10-10.md
@@ -1,0 +1,16 @@
+# AI Log — 2025-10-10
+
+## Tasking — v1.2.0o
+- Ensure FITS ingestion normalises wavelength/time axis units when headers provide byte strings and extend regression coverage.
+- Roll continuity collateral (version, patch notes, brains, AI log) per the v1.2 protocol.
+
+## Actions & Decisions
+- Routed `_parse_time_unit_hint`, `_normalise_wavelength_unit`, and `_unit_is_wavelength` through `_coerce_header_value`, decoding bytes and case-folding hints before normalisation so byte-string headers align with canonical units. 【F:app/server/ingest_fits.py†L233-L305】【F:app/server/ingest_fits.py†L751-L799】【F:app/server/ingest_fits.py†L338-L353】
+- Added ingestion tests that inject byte-string `TUNIT1`/`CUNIT1` hints for wavelength and time tables, asserting successful parsing and axis classification. 【F:tests/server/test_ingest_fits.py†L375-L395】【F:tests/server/test_ingest_fits.py†L442-L466】
+- Published patch notes, brains entry, and version bump documenting the hotfix. 【F:docs/patch_notes/v1.2.0o.md†L1-L18】【F:docs/atlas/brains.md†L16-L19】【F:app/version.json†L1-L5】
+
+## Verification
+- `pytest tests/server/test_ingest_fits.py` 【d84ce6†L1-L26】
+
+## Docs Consulted
+- Astropy units equivalencies reference for byte-handling expectations. 【F:docs/mirrored/astropy/units.meta.json†L1-L7】

--- a/docs/atlas/brains.md
+++ b/docs/atlas/brains.md
@@ -12,3 +12,8 @@
 - Treat FITS HDUs lacking spectral axes but carrying WCS metadata as `axis_kind="image"`, preserving masks, shape, and WCS serialisation for downstream viewers. 【F:app/server/ingest_fits.py†L1120-L1350】
 - Skip spectral sample requirements in local ingest, summarising images via pixel dimensions while leaving existing spectral flows untouched. 【F:app/utils/local_ingest.py†L433-L517】
 - Overlay UI renders Plotly heatmaps with intensity sliders and excludes image traces from spectral viewport math to keep axis warnings accurate. 【F:app/ui/main.py†L1910-L2079】【F:app/ui/main.py†L1608-L1756】
+
+## Byte-string FITS unit coercion — 2025-10-10
+- Normalise FITS wavelength/time unit hints by decoding header bytes through `_coerce_header_value` before canonical checks so `TUNIT`/`CUNIT` byte strings match aliases. 【F:app/server/ingest_fits.py†L233-L305】【F:app/server/ingest_fits.py†L751-L799】
+- Preserve time-frame detection by case-folding decoded hints, keeping BJD offsets intact when headers arrive as byte strings. 【F:app/server/ingest_fits.py†L233-L305】
+- Locked regression coverage on byte-string table headers to ensure wavelength and time ingestion keep reporting the right `axis_kind`. 【F:tests/server/test_ingest_fits.py†L375-L395】【F:tests/server/test_ingest_fits.py†L442-L466】

--- a/docs/patch_notes/v1.2.0o.md
+++ b/docs/patch_notes/v1.2.0o.md
@@ -1,0 +1,16 @@
+# Patch Notes — v1.2.0o
+
+## Summary
+- Harden FITS ingestion against byte-string axis unit keywords so wavelength and time tables normalise correctly.
+
+## Details
+1. **FITS unit coercion**
+   - `_parse_time_unit_hint`, `_normalise_wavelength_unit`, and `_unit_is_wavelength` now coerce header values before normalising, decoding bytes, and case-folding candidates so byte-string `TUNIT`/`CUNIT` entries resolve to canonical units. 【F:app/server/ingest_fits.py†L233-L305】【F:app/server/ingest_fits.py†L751-L799】【F:app/server/ingest_fits.py†L338-L353】
+2. **Regression coverage**
+   - Added ingestion tests that inject byte-string `TUNIT1`/`CUNIT1` values for both wavelength and time tables, asserting successful parsing and axis kind detection. 【F:tests/server/test_ingest_fits.py†L375-L395】【F:tests/server/test_ingest_fits.py†L442-L466】
+
+## Verification
+- `pytest tests/server/test_ingest_fits.py` 【d84ce6†L1-L26】
+
+## Continuity
+- Version bumped to v1.2.0o with brains and AI log updates recorded.


### PR DESCRIPTION
## Summary
- decode time and wavelength unit hints through `_coerce_header_value` before normalisation so byte-string headers resolve consistently
- add regression coverage for tables whose TUNIT/CUNIT keywords are byte strings for Angstrom and BJD offsets
- roll version/notes/brains/AI log per the v1.2 protocol

## Testing
- pytest tests/server/test_ingest_fits.py

------
https://chatgpt.com/codex/tasks/task_e_68dd603d3e608329ad0db63bf397265b