### PR TITLE
Add asynchronous overlay ingest queue and sidebar status panel

### DIFF
--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.0p",
-  "date_utc": "2025-10-11T02:45:00Z",
-  "summary": "Stabilise example browser provider persistence to prevent warning banners."
+  "version": "v1.2.0q",
+  "date_utc": "2025-10-11T05:30:00Z",
+  "summary": "Stream background overlay downloads with a sidebar progress queue."
 }

--- a/docs/ai_log/2025-10-11.md
+++ b/docs/ai_log/2025-10-11.md
@@ -14,3 +14,19 @@
 
 ## Docs Consulted
 - None (RAG query returned no relevant hits for "example browser" or provider persistence).
+
+## Tasking — v1.2.0q
+- Decouple overlay ingestion from the render loop so queued downloads run in the background while exposing live status in the sidebar.
+- Prove the async worker keeps the queue responsive across reruns even when downloads stall.
+
+## Actions & Decisions
+- Replaced the synchronous queue walker with a session-scoped executor, progress callbacks, and job snapshots so reruns simply schedule work and reconcile finished futures. 【F:app/ui/main.py†L526-L792】
+- Added an “Overlay downloads” sidebar section that renders status captions and success/error callouts for each job using the new snapshot helper. 【F:app/ui/main.py†L795-L839】【F:app/ui/main.py†L3426-L3451】
+- Captured a slow-download regression AppTest to assert the queue stays interactive and surfaces completion banners once the worker finishes. 【F:tests/ui/test_overlay_ingest_queue_async.py†L12-L112】
+- Logged the architecture shift in patch notes and brains while bumping version metadata to v1.2.0q. 【F:docs/patch_notes/v1.2.0q.md†L1-L18】【F:docs/atlas/brains.md†L31-L36】【F:app/version.json†L1-L5】
+
+## Verification
+- `pytest tests/ui/test_overlay_ingest_queue_async.py::test_ingest_queue_remains_interactive_during_long_download` 【437e22†L1-L3】
+
+## Docs Consulted
+- `STATE_KEYS_REFERENCE` to confirm expectations around new `st.session_state` mutations. 【F:docs/atlas/STATE_KEYS_REFERENCE.md†L1-L15】

--- a/docs/atlas/brains.md
+++ b/docs/atlas/brains.md
@@ -21,3 +21,8 @@
 ## Example browser provider persistence — 2025-10-11
 - Only seed the provider multiselect with defaults when the session key is unset so Streamlit relies on the stored selection thereafter, eliminating rerun warnings. 【F:app/ui/example_browser.py†L199-L218】
 - Normalise any cached provider list before rendering and sync it back to session state so stale providers disappear without losing user intent. 【F:app/ui/example_browser.py†L185-L198】
+
+## Asynchronous overlay ingest queue — 2025-10-11
+- Manage overlay downloads through a session-scoped executor that tracks queued, running, and completed jobs with shared progress snapshots for reruns to consume. 【F:app/ui/main.py†L526-L792】
+- Render an “Overlay downloads” sidebar cluster so users can watch job states resolve without leaving the workspace controls. 【F:app/ui/main.py†L795-L839】【F:app/ui/main.py†L3426-L3451】
+- Locked a regression that stalls network fetches to prove reruns stay responsive and jobs surface success once the worker completes. 【F:tests/ui/test_overlay_ingest_queue_async.py†L12-L112】

--- a/docs/patch_notes/v1.2.0q.md
+++ b/docs/patch_notes/v1.2.0q.md
@@ -1,0 +1,18 @@
+# Patch Notes — v1.2.0q
+
+## Summary
+- Move overlay ingestion to a session-scoped background worker with sidebar progress tracking.
+
+## Details
+1. **Threaded ingest queue runtime**
+   - Added a session-managed `ThreadPoolExecutor`, per-job state tracking, and progress callbacks so overlay downloads run asynchronously without blocking rerenders. 【F:app/ui/main.py†L526-L792】
+2. **Sidebar progress and completion messaging**
+   - Surfaced an “Overlay downloads” panel that lists queued, running, and completed items with live status captions and success/error callouts tied to the new runtime snapshot. 【F:app/ui/main.py†L795-L839】【F:app/ui/main.py†L3426-L3451】
+3. **Regression coverage for long downloads**
+   - Exercised a simulated slow network fetch to confirm queued overlays stay interactive across reruns and finish with completion banners once released. 【F:tests/ui/test_overlay_ingest_queue_async.py†L12-L112】
+
+## Verification
+- `pytest tests/ui/test_overlay_ingest_queue_async.py::test_ingest_queue_remains_interactive_during_long_download`
+
+## Continuity
+- Version bumped to v1.2.0q with brains and AI log updates recorded.

--- a/docs/ui_contract.json
+++ b/docs/ui_contract.json
@@ -5,7 +5,8 @@
     "Examples library",
     "Differential & normalization",
     "Similarity settings",
-    "Line catalogs"
+    "Line catalogs",
+    "Overlay downloads"
   ],
   "tabs": [
     "Overlay",
@@ -22,7 +23,7 @@
   "plot": [
     "legend_non_empty"
   ],
-  "v": "v1.2.0n",
+  "v": "v1.2.0q",
   "must_have": [
     "Overlay tab present",
     "Differential tab present",

--- a/tests/ui/test_overlay_ingest_queue_async.py
+++ b/tests/ui/test_overlay_ingest_queue_async.py
@@ -1,0 +1,118 @@
+"""Regression coverage for the asynchronous overlay ingest queue."""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, Dict, List
+
+from streamlit.testing.v1 import AppTest
+
+
+def _render_ingest_sidebar_entrypoint() -> None:
+    import streamlit as st  # noqa: F401 - re-exported for AppTest serialisation
+
+    from app.ui.main import (
+        _ensure_session_state,
+        _process_ingest_queue,
+        _render_ingest_queue_panel,
+    )
+
+    _ensure_session_state()
+    _process_ingest_queue()
+    _render_ingest_queue_panel(st.sidebar.container())
+
+
+def test_ingest_queue_remains_interactive_during_long_download(monkeypatch):
+    """Simulate a slow download and ensure reruns stay responsive."""
+
+    from app.ui import main as main_module
+
+    release_download = threading.Event()
+    first_request_started = threading.Event()
+    request_lock = threading.Lock()
+    requested_urls: List[str] = []
+
+    class _FakeResponse:
+        def __init__(self) -> None:
+            self.content = b"binary-overlay"
+
+        def raise_for_status(self) -> None:
+            return None
+
+    def _fake_requests_get(url: str, timeout: int = 60) -> _FakeResponse:
+        with request_lock:
+            requested_urls.append(url)
+        first_request_started.set()
+        release_download.wait()
+        return _FakeResponse()
+
+    monkeypatch.setattr(main_module.requests, "get", _fake_requests_get)
+
+    def _fake_ingest_local_file(filename: str, content: bytes) -> Dict[str, Any]:
+        return {
+            "label": filename,
+            "wavelength_nm": [500.0, 600.0, 700.0],
+            "flux": [1.0, 0.9, 1.1],
+        }
+
+    monkeypatch.setattr(main_module, "ingest_local_file", _fake_ingest_local_file)
+
+    added_payloads: List[Dict[str, Any]] = []
+
+    def _fake_add_overlay_payload(payload: Dict[str, Any]) -> tuple[bool, str]:
+        added_payloads.append(payload)
+        label = payload.get("label") or "overlay"
+        return True, f"Added {label}"
+
+    monkeypatch.setattr(main_module, "_add_overlay_payload", _fake_add_overlay_payload)
+
+    app = AppTest.from_function(_render_ingest_sidebar_entrypoint)
+
+    try:
+        app.session_state.ingest_queue = [
+            {"url": "http://example.com/one.fits", "label": "One"}
+        ]
+        app.run()
+
+        assert first_request_started.wait(1.0), "Background download did not start"
+
+        captions = [caption.value for caption in app.sidebar.caption]
+        assert any(
+            "Downloading overlay data" in value for value in captions
+        ), "Expected running download status in sidebar"
+
+        app.session_state.ingest_queue = [
+            {"url": "http://example.com/two.fits", "label": "Two"}
+        ]
+        app.run()
+
+        captions = [caption.value for caption in app.sidebar.caption]
+        assert any(
+            "Downloading overlay data" in value for value in captions
+        ), "First download status should persist across reruns"
+        assert len(requested_urls) >= 2, "Second overlay should schedule while first runs"
+
+        release_download.set()
+        for _ in range(50):
+            if len(added_payloads) >= 2:
+                break
+            time.sleep(0.05)
+
+        app.run()
+
+        success_messages = [message.value for message in app.sidebar.success]
+        lowered_messages = [value.lower() for value in success_messages]
+        assert any("added" in value for value in lowered_messages)
+        assert any("one" in value for value in lowered_messages)
+        assert any("two" in value for value in lowered_messages)
+    finally:
+        release_download.set()
+        runtime = (
+            app.session_state["ingest_runtime"]
+            if "ingest_runtime" in app.session_state
+            else {}
+        )
+        executor = runtime.get("executor") if isinstance(runtime, dict) else None
+        if executor:
+            executor.shutdown(wait=True)


### PR DESCRIPTION
## Summary
- move overlay ingestion onto a session-scoped executor that tracks job progress and reconciles completed futures on rerun
- surface an "Overlay downloads" sidebar section with per-item progress and completion messaging
- add a slow-download regression AppTest and update patch notes, brains, UI contract, and version metadata

## Testing
- pytest tests/ui/test_overlay_ingest_queue_async.py::test_ingest_queue_remains_interactive_during_long_download

------
https://chatgpt.com/codex/tasks/task_e_68dd66a909188329a25bbd4e24ebdd5d