### PR TITLE
Move differential controls into tab workspace

### DIFF
--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.0q",
-  "date_utc": "2025-10-11T05:30:00Z",
-  "summary": "Stream background overlay downloads with a sidebar progress queue."
+  "version": "v1.2.0r",
+  "date_utc": "2025-10-11T18:00:00Z",
+  "summary": "Consolidate normalization and similarity controls into the differential workspace."
 }

--- a/docs/ai_log/2025-10-11.md
+++ b/docs/ai_log/2025-10-11.md
@@ -30,3 +30,18 @@
 
 ## Docs Consulted
 - `STATE_KEYS_REFERENCE` to confirm expectations around new `st.session_state` mutations. 【F:docs/atlas/STATE_KEYS_REFERENCE.md†L1-L15】
+
+## Tasking — v1.2.0r
+- Consolidate differential and similarity controls into the workspace tab and refresh collateral per the v1.2+ contract.
+
+## Actions & Decisions
+- Rebuilt the differential tab to own normalization, differential mode, and explanatory copy so comparisons stay contextually grouped with their compute form. 【F:app/ui/main.py†L3088-L3131】【F:app/ui/main.py†L3285-L3288】
+- Embedded the similarity metric, weighting, and normalization widgets inside a tab expander and pruned the sidebar group to keep session settings lean. 【F:app/ui/main.py†L3132-L3192】【F:app/ui/main.py†L1492-L1509】
+- Captured AppTest regressions confirming the controls moved from the sidebar into the tab and remain available for similarity runs. 【F:tests/ui/test_sidebar_display_controls.py†L1-L33】【F:tests/ui/test_differential_form.py†L1-L109】
+- Logged the change set across version metadata, patch notes, and brains for continuity. 【F:app/version.json†L1-L5】【F:docs/patch_notes/v1.2.0r.md†L1-L18】【F:docs/atlas/brains.md†L30-L33】
+
+## Verification
+- `pytest tests/ui/test_sidebar_display_controls.py tests/ui/test_differential_form.py` 【260840†L1-L5】
+
+## Docs Consulted
+- None (local RAG search for "differential controls" not required; existing UI contract already covered the constraints).

--- a/docs/atlas/brains.md
+++ b/docs/atlas/brains.md
@@ -26,3 +26,8 @@
 - Manage overlay downloads through a session-scoped executor that tracks queued, running, and completed jobs with shared progress snapshots for reruns to consume. 【F:app/ui/main.py†L526-L792】
 - Render an “Overlay downloads” sidebar cluster so users can watch job states resolve without leaving the workspace controls. 【F:app/ui/main.py†L795-L839】【F:app/ui/main.py†L3426-L3451】
 - Locked a regression that stalls network fetches to prove reruns stay responsive and jobs surface success once the worker completes. 【F:tests/ui/test_overlay_ingest_queue_async.py†L12-L112】
+
+## Differential controls relocate to workspace — 2025-10-11
+- Move normalization and differential-mode selectors into the differential tab so the compute form and explanatory caption live together, avoiding sidebar context switches during analysis. 【F:app/ui/main.py†L3097-L3130】【F:app/ui/main.py†L3285-L3288】
+- House similarity metric, weighting, and normalization widgets in a tab expander so users configure comparisons beside the plotted results instead of scrolling the sidebar. 【F:app/ui/main.py†L3132-L3190】
+- Verified the relocation with focused UI tests that assert the sidebar no longer exposes these controls while the differential tab does. 【F:tests/ui/test_sidebar_display_controls.py†L1-L33】【F:tests/ui/test_differential_form.py†L1-L109】

--- a/docs/patch_notes/v1.2.0r.md
+++ b/docs/patch_notes/v1.2.0r.md
@@ -1,0 +1,18 @@
+# Patch Notes — v1.2.0r
+
+## Summary
+- Move normalization, differential mode, and similarity configuration from the sidebar into the differential workspace.
+
+## Details
+1. **Differential tab owns comparison controls**
+   - Added normalization and differential mode selectors at the top of the tab so session math stays close to the compute form, keeping explanatory copy alongside the controls. 【F:app/ui/main.py†L3097-L3130】【F:app/ui/main.py†L3285-L3288】
+2. **Similarity configuration embedded with analysis**
+   - Relocated metric, weighting, and normalization widgets into a dedicated expander inside the tab so similarity runs follow the same context as differential results. 【F:app/ui/main.py†L3132-L3190】
+3. **Sidebar streamlined for general session tools**
+   - Removed the differential and similarity clusters from the settings group to leave archive, display, examples, and line catalog controls untouched. 【F:app/ui/main.py†L1492-L1509】
+
+## Verification
+- `pytest tests/ui/test_sidebar_display_controls.py tests/ui/test_differential_form.py`
+
+## Continuity
+- Version bumped to v1.2.0r with brains and AI log updates recorded.

--- a/tests/ui/test_differential_form.py
+++ b/tests/ui/test_differential_form.py
@@ -76,6 +76,29 @@ def test_reference_controls_render_in_differential_tab():
     assert "Clear overlays" not in button_labels
 
 
+def test_differential_controls_shifted_into_tab():
+    app = AppTest.from_function(_render_differential_tab_entrypoint)
+
+    app.session_state.overlay_traces = [
+        _simple_overlay("a"),
+        _simple_overlay("b"),
+    ]
+    app.session_state.reference_trace_id = "a"
+
+    app.run()
+
+    select_labels = [select.label for select in app.selectbox]
+    assert "Normalization" in select_labels
+    assert "Differential mode" in select_labels
+    assert "Similarity normalization" in select_labels
+
+    multiselect_labels = [multi.label for multi in getattr(app, "multiselect", [])]
+    assert "Metrics" in multiselect_labels
+
+    slider_labels = [slider.label for slider in app.slider]
+    assert "Line peak count" in slider_labels
+
+
 def test_similarity_panel_renders_with_differential_inputs():
     app = AppTest.from_function(_render_differential_tab_entrypoint)
 

--- a/tests/ui/test_sidebar_display_controls.py
+++ b/tests/ui/test_sidebar_display_controls.py
@@ -35,4 +35,8 @@ def test_clear_overlays_button_present_in_sidebar():
     sidebar_buttons = [button.label for button in app.sidebar.button]
     assert "Clear overlays" in sidebar_buttons
 
+    sidebar_selects = [select.label for select in getattr(app.sidebar, "selectbox", [])]
+    assert "Normalization" not in sidebar_selects
+    assert "Differential mode" not in sidebar_selects
+
 


### PR DESCRIPTION
## Summary
- consolidate normalization, differential mode, and similarity configuration within the differential analysis tab
- update UI regressions to expect relocated controls and confirm similarity inputs render
- bump version metadata and continuity docs for v1.2.0r

## Testing
- pytest tests/ui/test_sidebar_display_controls.py tests/ui/test_differential_form.py

------
https://chatgpt.com/codex/tasks/task_e_68dd92116d5883298e89a42d106af3dc