### PR TITLE
Fix example browser provider filter state

### DIFF
--- a/app/ui/example_browser.py
+++ b/app/ui/example_browser.py
@@ -189,17 +189,12 @@ def render_example_browser_sheet(
             provider_options, stored_selection
         )
 
-        multiselect_kwargs = {
-            "label": "Providers",
-            "options": provider_options,
-            "key": providers_key,
-        }
-
-        if providers_key in st.session_state:
-            if provider_defaults != list(st.session_state[providers_key]):
-                st.session_state[providers_key] = provider_defaults
-        else:
-            multiselect_kwargs["default"] = provider_defaults
+        state_selection = st.session_state.setdefault(
+            providers_key, list(provider_defaults)
+        )
+        if list(state_selection) != provider_defaults:
+            state_selection.clear()
+            state_selection.extend(provider_defaults)
 
         search_key = "example_browser_search"
         favourites_key = "example_browser_favourites_only"
@@ -210,7 +205,9 @@ def render_example_browser_sheet(
             key=search_key,
             help="Filter by label, description, provider, or query metadata.",
         )
-        selected_providers = st.multiselect(**multiselect_kwargs)
+        selected_providers = st.multiselect(
+            "Providers", provider_options, key=providers_key
+        )
         favourites_only = st.checkbox(
             "Show favourites only",
             value=st.session_state.get(favourites_key, False),

--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.0r",
-  "date_utc": "2025-10-11T18:00:00Z",
-  "summary": "Consolidate normalization and similarity controls into the differential workspace."
+  "version": "v1.2.0s",
+  "date_utc": "2025-10-12T18:00:00Z",
+  "summary": "Stabilise the example browser provider filter so reruns keep selections without Streamlit warnings."
 }

--- a/docs/ai_log/2025-10-11.md
+++ b/docs/ai_log/2025-10-11.md
@@ -45,3 +45,19 @@
 
 ## Docs Consulted
 - None (local RAG search for "differential controls" not required; existing UI contract already covered the constraints).
+
+## Tasking — v1.2.0s
+- Eliminate the Streamlit rerun warning on the example browser provider filter while keeping user selections intact.
+- Refresh continuity collateral per the v1.2+ blueprint.
+
+## Actions & Decisions
+- Seeded the provider filter session key with `setdefault` and mutated the cached list in place so normalised selections persist without triggering Streamlit's reassignment warning. 【F:app/ui/example_browser.py†L189-L207】
+- Exercised the existing AppTest across reruns with narrowed and stale providers to ensure the warning stays absent and selections persist. 【F:tests/ui/test_example_browser.py†L63-L97】
+- Bumped version metadata and recorded the change in brains and patch notes for v1.2.0s. 【F:app/version.json†L1-L5】【F:docs/atlas/brains.md†L24-L29】【F:docs/patch_notes/v1.2.0s.md†L1-L17】
+
+## Verification
+- `pytest tests/ui/test_example_browser.py` 【005833†L1-L3】
+
+## Docs Consulted
+- Confirmed provider naming expectations against the MAST API reference while reviewing filter normalisation. 【F:docs/mirrored/mast_api.meta.json†L1-L6】
+- Revisited the session state reference to ensure the mutation pattern adheres to existing guidelines. 【F:docs/atlas/STATE_KEYS_REFERENCE.md†L1-L15】

--- a/docs/atlas/brains.md
+++ b/docs/atlas/brains.md
@@ -19,8 +19,12 @@
 - Locked regression coverage on byte-string table headers to ensure wavelength and time ingestion keep reporting the right `axis_kind`. 【F:tests/server/test_ingest_fits.py†L375-L395】【F:tests/server/test_ingest_fits.py†L442-L466】
 
 ## Example browser provider persistence — 2025-10-11
-- Only seed the provider multiselect with defaults when the session key is unset so Streamlit relies on the stored selection thereafter, eliminating rerun warnings. 【F:app/ui/example_browser.py†L199-L218】
-- Normalise any cached provider list before rendering and sync it back to session state so stale providers disappear without losing user intent. 【F:app/ui/example_browser.py†L185-L198】
+- Only seed the provider multiselect with defaults when the session key is unset so Streamlit relies on the stored selection thereafter, eliminating rerun warnings. 【F:app/ui/example_browser.py†L192-L210】
+- Normalise any cached provider list before rendering and sync it back to session state so stale providers disappear without losing user intent. 【F:app/ui/example_browser.py†L185-L197】
+
+## Example browser provider filter normalisation — 2025-10-12
+- Populate the provider filter session key via `setdefault` and mutate the cached list in place so reruns keep user selections without triggering Streamlit's state reassignment warning. 【F:app/ui/example_browser.py†L189-L207】
+- Keep the UI regression that drives reruns with narrowed and stale providers to ensure the warning stays silent while selections persist. 【F:tests/ui/test_example_browser.py†L63-L97】
 
 ## Asynchronous overlay ingest queue — 2025-10-11
 - Manage overlay downloads through a session-scoped executor that tracks queued, running, and completed jobs with shared progress snapshots for reruns to consume. 【F:app/ui/main.py†L526-L792】

--- a/docs/patch_notes/v1.2.0s.md
+++ b/docs/patch_notes/v1.2.0s.md
@@ -1,0 +1,16 @@
+# Patch Notes — v1.2.0s
+
+## Summary
+- Keep the example browser provider filter in sync without Streamlit state warnings.
+
+## Details
+1. **Session state seeded once**
+   - Normalise provider selections before seeding session state and mutate the cached list in place so reruns avoid Streamlit warnings while retaining user choices. 【F:app/ui/example_browser.py†L189-L207】
+2. **Regression coverage**
+   - Exercised the AppTest through reruns with narrowed and stale providers to confirm selections persist and warning banners stay absent. 【F:tests/ui/test_example_browser.py†L63-L97】
+
+## Verification
+- `pytest tests/ui/test_example_browser.py` 【005833†L1-L3】
+
+## Continuity
+- Version bumped to v1.2.0s with brains and AI log updates recorded. 【F:app/version.json†L1-L5】【F:docs/atlas/brains.md†L24-L29】【F:docs/ai_log/2025-10-11.md†L49-L63】


### PR DESCRIPTION
## Summary
- normalise the example browser provider filter session state in place to avoid Streamlit rerun warnings
- confirm the provider filter AppTest keeps selections persistent without warnings
- update brains, patch notes, version metadata, and AI log for v1.2.0s

## Testing
- pytest tests/ui/test_example_browser.py

------
https://chatgpt.com/codex/tasks/task_e_68dd94505dc08329acef2597b1a1fcf8