### PR TITLE
Fix FITS byte-string unit decoding

### DIFF
--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.0q",
-  "date_utc": "2025-10-11T05:30:00Z",
-  "summary": "Stream background overlay downloads with a sidebar progress queue."
+  "version": "v1.2.0r",
+  "date_utc": "2025-10-01T20:41:26Z",
+  "summary": "Coerce FITS byte-string axis units before wavelength/time classification."
 }

--- a/docs/ai_log/2025-10-11.md
+++ b/docs/ai_log/2025-10-11.md
@@ -30,3 +30,18 @@
 
 ## Docs Consulted
 - `STATE_KEYS_REFERENCE` to confirm expectations around new `st.session_state` mutations. 【F:docs/atlas/STATE_KEYS_REFERENCE.md†L1-L15】
+
+## Tasking — v1.2.0r
+- Harden FITS ingestion so byte-string axis unit hints decode before wavelength/time classification.
+- Extend regression coverage and roll the v1.2 continuity collateral.
+
+## Actions & Decisions — v1.2.0r
+- Added `_decode_header_text` and routed `_parse_time_unit_hint`, `_normalise_wavelength_unit`, and `_unit_is_wavelength` through it so decoded header bytes are case-folded before alias resolution. 【F:app/server/ingest_fits.py†L233-L305】【F:app/server/ingest_fits.py†L338-L353】【F:app/server/ingest_fits.py†L751-L815】
+- Captured regression fixtures that inject byte-string `Angstroms` and `BJD - 2457000, days` table headers, asserting ingestion preserves the correct `axis_kind`. 【F:tests/server/test_ingest_fits.py†L86-L135】【F:tests/server/test_ingest_fits.py†L396-L426】
+- Published the continuity updates (version bump, patch notes, brains) documenting the hotfix. 【F:app/version.json†L1-L5】【F:docs/patch_notes/v1.2.0r.md†L1-L18】【F:docs/atlas/brains.md†L24-L29】
+
+## Verification — v1.2.0r
+- `pytest tests/server/test_ingest_fits.py` 【dacbb4†L1-L28】
+
+## Docs Consulted — v1.2.0r
+- Astropy units reference for header byte handling expectations. 【F:docs/mirrored/astropy/units.meta.json†L1-L6】

--- a/docs/atlas/brains.md
+++ b/docs/atlas/brains.md
@@ -26,3 +26,8 @@
 - Manage overlay downloads through a session-scoped executor that tracks queued, running, and completed jobs with shared progress snapshots for reruns to consume. 【F:app/ui/main.py†L526-L792】
 - Render an “Overlay downloads” sidebar cluster so users can watch job states resolve without leaving the workspace controls. 【F:app/ui/main.py†L795-L839】【F:app/ui/main.py†L3426-L3451】
 - Locked a regression that stalls network fetches to prove reruns stay responsive and jobs surface success once the worker completes. 【F:tests/ui/test_overlay_ingest_queue_async.py†L12-L112】
+
+## FITS byte-string axis units — 2025-10-01
+- Added `_decode_header_text` so spectral/time unit parsing normalises decoded header bytes before alias checks, keeping byte-coded `TUNIT`/`CUNIT` hints intact. 【F:app/server/ingest_fits.py†L233-L305】【F:app/server/ingest_fits.py†L751-L815】
+- Routed `_unit_is_wavelength` through the normaliser to reuse alias handling before equivalency checks. 【F:app/server/ingest_fits.py†L338-L353】
+- Introduced pytest fixtures that feed byte-string `Angstroms` and `BJD - 2457000, days` headers, asserting the parser preserves wavelength/time `axis_kind`. 【F:tests/server/test_ingest_fits.py†L86-L135】【F:tests/server/test_ingest_fits.py†L396-L426】

--- a/docs/patch_notes/v1.2.0r.md
+++ b/docs/patch_notes/v1.2.0r.md
@@ -1,0 +1,16 @@
+# Patch Notes — v1.2.0r
+
+## Summary
+- Decode byte-string FITS axis unit hints before wavelength/time classification and lock in regression coverage.
+
+## Details
+1. **Header unit decoding helper**
+   - Added `_decode_header_text` so `_parse_time_unit_hint`, `_normalise_wavelength_unit`, and `_unit_is_wavelength` case-fold decoded header bytes prior to normalisation, ensuring aliases like `Angstroms` survive ingestion. 【F:app/server/ingest_fits.py†L233-L305】【F:app/server/ingest_fits.py†L751-L815】
+2. **Regression fixtures for byte units**
+   - Introduced pytest fixtures that feed byte-string `TUNIT`/`CUNIT` combinations for `Angstroms` and `BJD - 2457000, days`, asserting the parser reports `axis_kind="wavelength"` and `axis_kind="time"`. 【F:tests/server/test_ingest_fits.py†L86-L135】【F:tests/server/test_ingest_fits.py†L396-L426】
+
+## Verification
+- `pytest tests/server/test_ingest_fits.py`
+
+## Continuity
+- Version bumped to v1.2.0r with brains and AI log updates recorded.


### PR DESCRIPTION
## Summary
- decode FITS header byte strings with a shared helper before time/wavelength normalisation
- reuse the wavelength normaliser in `_unit_is_wavelength` and add fixtures covering byte-string TUNIT/CUNIT hints
- roll v1.2 continuity collateral (version, patch notes, brains, AI log) for the hotfix

## Testing
- `pytest tests/server/test_ingest_fits.py`


------
https://chatgpt.com/codex/tasks/task_e_68dd909e60bc8329905e569d3bb36c6a