### PR TITLE
Align v1.2.0v patch metadata surfaces

### DIFF
--- a/PATCHLOG.txt
+++ b/PATCHLOG.txt
@@ -23,3 +23,4 @@ Spectra App — Patch Log (append-only)
 - v1.2.0l (REF 1.2.0l-A01): split overlay viewports by axis kind, surface mixed-axis warnings, update exports/tests, and refresh continuity docs.
 - v1.2.0m (REF 1.2.0m-A01): relocate the overlay clearing control into the display sidebar cluster, confirm the action in the overlay tab, extend UI coverage, and refresh release collateral.
 - v1.2.0t (REF 1.2.0t-A01): tighten target library overlay gating with manifest axis checks, block JWST CALINTS cubes, surface clearer disabled-button guidance, and extend regression coverage.
+- v1.2.0v: Retire the example browser and streamline the Examples sidebar around quick-add shortcuts.

--- a/docs/ai_log/2025-10-13.md
+++ b/docs/ai_log/2025-10-13.md
@@ -1,0 +1,17 @@
+# AI Log — 2025-10-13
+
+## Tasking — v1.2.0v
+- Align the v1.2.0v patch metadata so the patch log, header caption, and Docs banner all surface the quick-add summary recorded in `app/version.json`. 【F:app/version.json†L1-L5】【F:docs/patch_notes/v1.2.0v.md†L1-L22】
+- Refresh the continuity artefacts called out in the v1.2+ blueprint (brains, patch notes, AI log) after verifying regression coverage. 【F:docs/ai_handoff/Spectra App v1.2+ – Handoff Protocol & Task Blueprint.txt†L1-L120】
+
+## Actions & Decisions
+- Appended the `v1.2.0v` line to `PATCHLOG.txt` so `_resolve_patch_metadata()` exposes the same summary as `app/version.json`, keeping header and Docs banner logic in sync. 【F:PATCHLOG.txt†L24-L26】【F:app/_version.py†L30-L64】
+- Updated the Docs tab and header regression to assert the quick-add summary renders verbatim from the patch metadata. 【F:tests/ui/test_docs_tab.py†L16-L78】
+- Rolled the continuity collateral (brains overview, versioned brains entry, patch notes, brains index) to document the alignment work. 【F:docs/atlas/brains.md†L1-L18】【F:docs/brains/brains_v1.2.0v.md†L1-L17】【F:docs/brains/brains_INDEX.md†L1-L24】【F:docs/patch_notes/v1.2.0v.md†L1-L22】
+- Attempted to query the local docs index but the FAISS dependency is unavailable in this environment; recorded the limitation for follow-up. 【c31ea1†L1-L17】
+
+## Verification
+- `pytest tests/ui/test_docs_tab.py` 【245a80†L1-L5】
+
+## Docs Consulted
+- Spectra App v1.2+ – Handoff Protocol & Task Blueprint. 【F:docs/ai_handoff/Spectra App v1.2+ – Handoff Protocol & Task Blueprint.txt†L1-L120】

--- a/docs/atlas/brains.md
+++ b/docs/atlas/brains.md
@@ -1,3 +1,8 @@
+# Patch log continuity — 2025-10-13
+- **REF 1.2.0v-A01**: Added the `v1.2.0v` patch log entry so `_resolve_patch_metadata()` keeps the header and Docs banner in sync with version metadata. 【F:PATCHLOG.txt†L24-L26】【F:app/_version.py†L30-L64】
+- Locked the Docs tab and header regression against the quick-add summary so continuity helpers surface the expected copy without manual updates. 【F:tests/ui/test_docs_tab.py†L16-L78】
+- Rolled the release docs (brains, patch notes, AI log) to capture the alignment work. 【F:docs/patch_notes/v1.2.0v.md†L1-L22】【F:docs/brains/brains_v1.2.0v.md†L1-L17】【F:docs/ai_log/2025-10-13.md†L1-L22】
+
 # Examples quick-add focus — 2025-10-13
 - Remove the example browser launcher and associated favourites/recents panels so the Examples sidebar leans on the quick-add selector only. 【F:app/ui/main.py†L1230-L1245】
 - Drop the dormant browser state initialisers to prevent future Streamlit warnings now that the sheet is gone. 【F:app/ui/main.py†L468-L483】

--- a/docs/brains/brains_INDEX.md
+++ b/docs/brains/brains_INDEX.md
@@ -1,6 +1,6 @@
 # MAKE NEW BRAINS EACH TIME YOU MAKE A CHANGE. DO NOT OVER WRITE PREVIOUS BRAINS * unless needed
 # Spectra App — Brains Index
-_Last updated: 2025-10-08T00:00:00Z_
+_Last updated: 2025-10-13T09:00:00Z_
 
 This index is the mandated entry point before touching the codebase.
 It tracks the latest continuity documents and the required cross-links between them.
@@ -14,6 +14,7 @@ It tracks the latest continuity documents and the required cross-links between t
 ## Continuity Table
 | Version | Brains Log | Patch Notes | AI Handoff |
 | --- | --- | --- | --- |
+| v1.2.0v | [docs/brains/brains_v1.2.0v.md](brains_v1.2.0v.md) | [docs/patch_notes/v1.2.0v.md](../patch_notes/v1.2.0v.md) | — |
 | v1.2.0l | [docs/brains/brains_v1.2.0l.md](brains_v1.2.0l.md) | [docs/patch_notes/v1.2.0l.md](../patch_notes/v1.2.0l.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0k.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0k.md) |
 | v1.2.0k | [docs/brains/brains_v1.2.0k.md](brains_v1.2.0k.md) | [docs/patch_notes/v1.2.0k.md](../patch_notes/v1.2.0k.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0k.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0k.md) |
 | v1.2.0j | [docs/brains/brains_v1.2.0j.md](brains_v1.2.0j.md) | [docs/patch_notes/v1.2.0j.md](../patch_notes/v1.2.0j.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0e.md) |

--- a/docs/brains/brains_v1.2.0v.md
+++ b/docs/brains/brains_v1.2.0v.md
@@ -1,0 +1,14 @@
+# Brains — v1.2.0v
+
+## Release focus
+- **REF 1.2.0v-A01**: Align the patch log and surfaced metadata so the header and Docs banner quote the quick-add summary verbatim. 【F:PATCHLOG.txt†L24-L26】【F:tests/ui/test_docs_tab.py†L16-L78】
+
+## Implementation notes
+- Appended the `v1.2.0v` entry to `PATCHLOG.txt` so `_resolve_patch_metadata()` reads the same summary that lives in `app/version.json`, keeping continuity helpers in sync. 【F:PATCHLOG.txt†L24-L26】【F:app/_version.py†L30-L64】
+- Refreshed the Docs tab and header regression to pin against the quick-add summary so future releases surface the right text without manual string swaps. 【F:tests/ui/test_docs_tab.py†L16-L78】
+
+## Testing
+- `pytest tests/ui/test_docs_tab.py` 【245a80†L1-L5】
+
+## Continuity updates
+- Logged the alignment in the atlas brains overview, refreshed patch notes, and wrote the AI log entry for the release. 【F:docs/atlas/brains.md†L1-L18】【F:docs/patch_notes/v1.2.0v.md†L1-L22】【F:docs/ai_log/2025-10-13.md†L1-L22】

--- a/docs/patch_notes/v1.2.0v.md
+++ b/docs/patch_notes/v1.2.0v.md
@@ -9,9 +9,13 @@
    - Dropped the dormant browser session keys now that the sheet is gone to avoid future Streamlit warnings. 【F:app/ui/main.py†L468-L483】
 2. **Regression coverage & docs**
    - Updated the sidebar AppTest to assert only the quick-add form remains, and refreshed the library usage review to describe the leaner Examples section. 【F:tests/ui/test_sidebar_examples.py†L1-L37】【F:docs/library_usage_review.md†L19-L47】
+3. **Patch log + UI metadata alignment**
+   - Added the v1.2.0v patch log entry so the release summary stays in lockstep with `app/version.json`. 【F:PATCHLOG.txt†L24-L26】
+   - Updated the Docs tab and header regression to assert the quick-add summary renders from patch metadata. 【F:tests/ui/test_docs_tab.py†L16-L78】
 
 ## Verification
 - `pytest tests/ui/test_sidebar_examples.py` 【520d93†L1-L4】
+- `pytest tests/ui/test_docs_tab.py` 【245a80†L1-L5】
 
 ## Continuity
-- Version bumped to v1.2.0v with brains and AI log updates recorded. 【F:app/version.json†L1-L5】【F:docs/atlas/brains.md†L1-L7】【F:docs/ai_log/2025-10-01.md†L1-L20】
+- Version bumped to v1.2.0v with brains, patch log, and AI log updates recorded. 【F:app/version.json†L1-L5】【F:PATCHLOG.txt†L24-L26】【F:docs/atlas/brains.md†L1-L18】【F:docs/ai_log/2025-10-13.md†L1-L22】

--- a/tests/ui/test_docs_tab.py
+++ b/tests/ui/test_docs_tab.py
@@ -51,16 +51,19 @@ def test_docs_tab_banner_uses_patch_metadata(monkeypatch, tmp_path):
     monkeypatch.setattr(main_module, "_get_overlays", lambda: [])
 
     version_info = {
-        "version": "v1.2.0d",
-        "patch_version": "v1.2.0d",
-        "patch_summary": "Docs tab banner pulls from patch log",
-        "patch_raw": "v1.2.0d: Docs tab banner pulls from patch log",
+        "version": "v1.2.0v",
+        "patch_version": "v1.2.0v",
+        "patch_summary": "Retire the example browser and streamline the Examples sidebar around quick-add shortcuts.",
+        "patch_raw": "v1.2.0v: Retire the example browser and streamline the Examples sidebar around quick-add shortcuts.",
     }
 
     main_module._render_docs_tab(version_info)
 
     assert captured_info
-    assert captured_info[0] == "v1.2.0d: Docs tab banner pulls from patch log"
+    assert (
+        captured_info[0]
+        == "v1.2.0v: Retire the example browser and streamline the Examples sidebar around quick-add shortcuts."
+    )
 
 
 def test_header_prefers_patch_version(monkeypatch):
@@ -72,14 +75,14 @@ def test_header_prefers_patch_version(monkeypatch):
 
     version_info = {
         "version": "v0.0.0-dev",
-        "patch_version": "v1.2.0e",
-        "patch_summary": "(REF 1.2.0e-A01): Header pulls from patch metadata",
-        "patch_raw": "v1.2.0e (REF 1.2.0e-A01): Header pulls from patch metadata",
-        "date_utc": "2025-10-02T18:30:00Z",
+        "patch_version": "v1.2.0v",
+        "patch_summary": "Retire the example browser and streamline the Examples sidebar around quick-add shortcuts.",
+        "patch_raw": "v1.2.0v: Retire the example browser and streamline the Examples sidebar around quick-add shortcuts.",
+        "date_utc": "2025-10-13T09:00:00Z",
     }
 
     main_module._render_app_header(version_info)
 
     assert captured_caption
-    assert captured_caption[0].startswith("v1.2.0e • Updated 2025-10-02 18:30 UTC")
-    assert "Header pulls from patch metadata" in captured_caption[0]
+    assert captured_caption[0].startswith("v1.2.0v • Updated 2025-10-13 09:00 UTC")
+    assert "Retire the example browser" in captured_caption[0]


### PR DESCRIPTION
## Summary
- append the v1.2.0v patch log entry so the release summary matches `app/version.json` and update regression coverage for the header/docs banner
- refresh the v1.2.0v continuity collateral (brains overview + entry, patch notes, brains index, AI log)

## Testing
- pytest tests/ui/test_docs_tab.py

------
https://chatgpt.com/codex/tasks/task_e_68ddb601737083298201e7a8c3efbf9d