### PR TITLE
Fix runtime.json structure and bump to v1.2.0w

### DIFF
--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.0v",
-  "date_utc": "2025-10-13T09:00:00Z",
-  "summary": "Retire the example browser and streamline the Examples sidebar around quick-add shortcuts."
+  "version": "v1.2.0w",
+  "date_utc": "2025-10-13T09:30:00Z",
+  "summary": "Repair runtime.json so python/platform metadata lives inside the top-level manifest."
 }

--- a/docs/ai_log/2025-10-01.md
+++ b/docs/ai_log/2025-10-01.md
@@ -1,12 +1,27 @@
 # AI Log — 2025-10-01
 
+## Tasking — v1.2.0w
+- Repair `docs/runtime.json` so the python, platform, and library metadata share the top-level object again.
+- Update versioning and continuity docs per the v1.2 protocol once the manifest validates.
+
+## Actions & Decisions
+- Folded the stray `python`, `platform`, and `libs` blocks back inside the runtime manifest so JSON tooling parses the file cleanly. 【F:docs/runtime.json†L1-L23】
+- Bumped release metadata to v1.2.0w and captured the fix in patch notes and the brains log for traceability. 【F:app/version.json†L1-L5】【F:docs/patch_notes/v1.2.0w.md†L1-L15】【F:docs/atlas/brains.md†L1-L4】
+
+## Verification
+- `python -m json.tool docs/runtime.json` 【c86be1†L1-L24】
+
+## Docs Consulted
+- None – runtime structure fix relied solely on local context.
+
+
 ## Tasking — v1.2.0v
 - Remove the example browser entry point and keep the Examples sidebar focused on the quick-add selector.
 - Clean up dormant session keys, update documentation/tests, and roll continuity collateral per the v1.2+ protocol.
 
 ## Actions & Decisions
 - Removed the browser launcher plus favourites/recents expanders so the quick-add form is the only curated entry point, and trimmed the corresponding session-state defaults. 【F:app/ui/main.py†L1230-L1245】【F:app/ui/main.py†L468-L483】
-- Updated the sidebar regression and library usage review to reflect the leaner Examples experience, and recorded the change in brains/patch notes. 【F:tests/ui/test_sidebar_examples.py†L1-L37】【F:docs/library_usage_review.md†L19-L47】【F:docs/atlas/brains.md†L1-L7】【F:docs/patch_notes/v1.2.0v.md†L1-L17】
+- Updated the sidebar regression and library usage review to reflect the leaner Examples experience, and recorded the change in brains/patch notes. 【F:tests/ui/test_sidebar_examples.py†L1-L37】【F:docs/library_usage_review.md†L19-L47】【F:docs/atlas/brains.md†L1-L4】【F:docs/patch_notes/v1.2.0v.md†L1-L17】
 
 ## Verification
 - `pytest tests/ui/test_sidebar_examples.py` 【520d93†L1-L4】

--- a/docs/atlas/brains.md
+++ b/docs/atlas/brains.md
@@ -1,3 +1,8 @@
+# Runtime manifest continuity — 2025-10-13
+- **REF 1.2.0w-A01**: Restored `docs/runtime.json` to a single JSON object so tooling can parse python, platform, and library metadata without errors. 【F:docs/runtime.json†L1-L23】
+- Recorded the fix in the v1.2.0w patch notes and AI log while bumping the version manifest to keep release metadata aligned. 【F:docs/patch_notes/v1.2.0w.md†L1-L15】【F:docs/ai_log/2025-10-01.md†L1-L15】【F:app/version.json†L1-L5】
+- Alternative considered: mirror the runtime manifest into YAML for readability, but JSON remains the contract consumed by automation so we kept the format and corrected structure instead.
+
 # Patch log continuity — 2025-10-13
 - **REF 1.2.0v-A01**: Added the `v1.2.0v` patch log entry so `_resolve_patch_metadata()` keeps the header and Docs banner in sync with version metadata. 【F:PATCHLOG.txt†L24-L26】【F:app/_version.py†L30-L64】
 - Locked the Docs tab and header regression against the quick-add summary so continuity helpers surface the expected copy without manual updates. 【F:tests/ui/test_docs_tab.py†L16-L78】

--- a/docs/patch_notes/v1.2.0w.md
+++ b/docs/patch_notes/v1.2.0w.md
@@ -1,0 +1,15 @@
+# Patch Notes — v1.2.0w
+
+## Summary
+- Fix the malformed runtime manifest so python, platform, and library metadata reside in the top-level JSON object again.
+
+## Details
+1. **Runtime manifest structure**
+   - Rewrote `docs/runtime.json` to keep `python`, `platform`, and `libs` alongside the existing package inventory so the file parses as a single JSON object. 【F:docs/runtime.json†L1-L23】
+   - Bumped the app version metadata to v1.2.0w and documented the repair across the brains log and AI activity log for continuity. 【F:app/version.json†L1-L5】【F:docs/atlas/brains.md†L1-L4】【F:docs/ai_log/2025-10-01.md†L1-L15】
+
+## Verification
+- `python -m json.tool docs/runtime.json` 【c86be1†L1-L24】
+
+## Continuity
+- Version bumped to v1.2.0w with brains and AI log updates recorded. 【F:app/version.json†L1-L5】【F:docs/atlas/brains.md†L1-L4】【F:docs/ai_log/2025-10-01.md†L1-L15】

--- a/docs/runtime.json
+++ b/docs/runtime.json
@@ -1,5 +1,4 @@
 {
-
   "generated_utc": "2025-09-30T00:00:00Z",
   "packages": {
     "astropy": "7.1.0",
@@ -12,9 +11,7 @@
     "requests": "2.32.5",
     "rich": "14.1.0",
     "streamlit": "1.50.0"
-  }
-}
-
+  },
   "python": "3.11.9",
   "platform": "Windows-10-10.0.26100-SP0",
   "libs": {
@@ -25,4 +22,3 @@
     "pandas": "2.3.2"
   }
 }
-


### PR DESCRIPTION
## Summary
- restore docs/runtime.json to a single JSON object containing the python, platform, and library metadata
- bump app/version.json to v1.2.0w and record the continuity update in patch notes and brains
- log the runtime manifest repair in docs/ai_log/2025-10-01.md for traceability

## Testing
- python -m json.tool docs/runtime.json

------
https://chatgpt.com/codex/tasks/task_e_68ddb7f94d48832980cf3feb573cfe8d