### PR TITLE
Guard overlay ingest queue thread-safety

### DIFF
--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.0w",
-  "date_utc": "2025-10-13T09:30:00Z",
-  "summary": "Repair runtime.json so python/platform metadata lives inside the top-level manifest."
+  "version": "v1.2.0x",
+  "date_utc": "2025-10-14T09:30:00Z",
+  "summary": "Finalize overlay ingestion on the main thread to avoid ScriptRunContext warnings."
 }

--- a/docs/ai_log/2025-10-13.md
+++ b/docs/ai_log/2025-10-13.md
@@ -15,3 +15,19 @@
 
 ## Docs Consulted
 - Spectra App v1.2+ – Handoff Protocol & Task Blueprint. 【F:docs/ai_handoff/Spectra App v1.2+ – Handoff Protocol & Task Blueprint.txt†L1-L120】
+
+## Tasking — v1.2.0x
+- Hotfix the overlay ingest queue so background workers avoid touching Streamlit state and queued payloads complete without ScriptRunContext warnings.
+- Refresh the continuity artefacts (brains, patch notes, version manifest, AI log) for the new hotfix entry.
+
+## Actions & Decisions
+- Reworked `_ingest_overlay_job` to return `OverlayIngestResult` payloads and moved `_add_overlay_payload` execution into `_refresh_ingest_jobs`, keeping Streamlit state mutations on the main thread. 【F:app/ui/main.py†L621-L678】【F:app/ui/main.py†L680-L713】
+- Extended the ingest queue AppTest to assert overlays complete without ScriptRunContext warnings while continuing to verify async progress messaging. 【F:tests/ui/test_overlay_ingest_queue_async.py†L9-L128】
+- Logged the hotfix across the v1.2.0x patch notes, version manifest, and brains overview for continuity. 【F:docs/patch_notes/v1.2.0x.md†L1-L17】【F:app/version.json†L1-L5】【F:docs/atlas/brains.md†L1-L7】
+- Attempted to query the docs index, but `faiss` remains unavailable in this environment; no new mirrored docs consulted. 【40a747†L1-L5】
+
+## Verification
+- `pytest tests/ui/test_overlay_ingest_queue_async.py` 【5b7b2a†L1-L3】
+
+## Docs Consulted
+- UI Contract overview to confirm overlay sidebar controls remain in place. 【F:docs/ui_contract.json†L1-L28】

--- a/docs/atlas/brains.md
+++ b/docs/atlas/brains.md
@@ -1,3 +1,8 @@
+# Overlay ingest thread-safety — 2025-10-14
+- **REF 1.2.0x-A01**: Route overlay payload additions through the main thread by returning ingest results from worker futures and finalising state updates in `_refresh_ingest_jobs`, eliminating cross-thread Streamlit mutations. 【F:app/ui/main.py†L621-L678】【F:app/ui/main.py†L680-L713】
+- Hardened the ingest queue regression to assert queued overlays complete without `ScriptRunContext` warnings while preserving async progress. 【F:tests/ui/test_overlay_ingest_queue_async.py†L9-L128】
+- Recorded the thread-safety fix in the v1.2.0x patch notes and AI activity log alongside the version bump. 【F:docs/patch_notes/v1.2.0x.md†L1-L17】【F:app/version.json†L1-L5】【F:docs/ai_log/2025-10-13.md†L19-L33】
+
 # Runtime manifest continuity — 2025-10-13
 - **REF 1.2.0w-A01**: Restored `docs/runtime.json` to a single JSON object so tooling can parse python, platform, and library metadata without errors. 【F:docs/runtime.json†L1-L23】
 - Recorded the fix in the v1.2.0w patch notes and AI log while bumping the version manifest to keep release metadata aligned. 【F:docs/patch_notes/v1.2.0w.md†L1-L15】【F:docs/ai_log/2025-10-01.md†L1-L15】【F:app/version.json†L1-L5】

--- a/docs/patch_notes/v1.2.0x.md
+++ b/docs/patch_notes/v1.2.0x.md
@@ -1,0 +1,17 @@
+# Patch Notes — v1.2.0x
+
+## Summary
+- Finalize overlay ingestion on the main thread to eliminate Streamlit ScriptRunContext warnings while preserving async progress updates. 【F:app/ui/main.py†L621-L678】【F:app/ui/main.py†L680-L713】
+
+## Details
+1. **Thread-safe overlay completion**
+   - Return overlay payloads from worker futures and finalize additions on the main thread so Streamlit state mutations stay in the UI thread. 【F:app/ui/main.py†L621-L678】
+   - Guard ingest job updates behind thread-safe records and reuse `_add_overlay_payload` only after the background job resolves. 【F:app/ui/main.py†L680-L713】
+2. **Regression coverage**
+   - Extend the ingest queue AppTest suite with a warning assertion to prove queued overlays complete without ScriptRunContext noise. 【F:tests/ui/test_overlay_ingest_queue_async.py†L9-L128】
+
+## Verification
+- `pytest tests/ui/test_overlay_ingest_queue_async.py` 【5b7b2a†L1-L3】
+
+## Continuity
+- Version bumped to v1.2.0x with brains and AI log updates recorded. 【F:app/version.json†L1-L5】【F:docs/atlas/brains.md†L1-L7】【F:docs/ai_log/2025-10-13.md†L19-L33】


### PR DESCRIPTION
## Summary
- return overlay ingest futures with payloads and finalize overlay additions on the main thread to keep Streamlit state thread-safe
- extend the ingest queue regression to assert ScriptRunContext warnings are absent
- roll the v1.2.0x documentation updates (version, brains, patch notes, AI log)

## Testing
- pytest tests/ui/test_overlay_ingest_queue_async.py

------
https://chatgpt.com/codex/tasks/task_e_68ddb946c90883299816dad620d04062