### PR TITLE
Align v1.2.0x patch metadata

### DIFF
--- a/PATCHLOG.txt
+++ b/PATCHLOG.txt
@@ -24,3 +24,4 @@ Spectra App — Patch Log (append-only)
 - v1.2.0m (REF 1.2.0m-A01): relocate the overlay clearing control into the display sidebar cluster, confirm the action in the overlay tab, extend UI coverage, and refresh release collateral.
 - v1.2.0t (REF 1.2.0t-A01): tighten target library overlay gating with manifest axis checks, block JWST CALINTS cubes, surface clearer disabled-button guidance, and extend regression coverage.
 - v1.2.0v: Retire the example browser and streamline the Examples sidebar around quick-add shortcuts.
+- v1.2.0x: Finalize overlay ingestion on the main thread to avoid ScriptRunContext warnings.

--- a/docs/ai_log/2025-10-14.md
+++ b/docs/ai_log/2025-10-14.md
@@ -1,0 +1,16 @@
+# AI Log — 2025-10-14
+
+## Tasking — v1.2.0x
+- Append the v1.2.0x summary to `PATCHLOG.txt` so release metadata in `app/version.json` flows through `_resolve_patch_metadata()`.
+- Refresh the continuity collateral (tests, brains, patch notes, AI log) so the Docs tab banner reflects the current hotfix release.
+
+## Actions & Decisions
+- Added the v1.2.0x bullet to `PATCHLOG.txt`, ensuring `get_version_info()` exposes the same summary consumed by `_resolve_patch_metadata()`. 【F:PATCHLOG.txt†L27-L27】【F:app/_version.py†L32-L67】
+- Updated the Docs tab/header regression to expect the v1.2.0x copy and asserted `_resolve_patch_metadata()` now returns the new patch line verbatim. 【F:tests/ui/test_docs_tab.py†L16-L102】
+- Rolled the continuity docs (atlas overview, brains index, dedicated brains log, patch notes) to document the metadata alignment. 【F:docs/atlas/brains.md†L1-L8】【F:docs/brains/brains_INDEX.md†L1-L18】【F:docs/brains/brains_v1.2.0x.md†L1-L13】【F:docs/patch_notes/v1.2.0x.md†L1-L21】
+
+## Verification
+- `pytest tests/ui/test_docs_tab.py` 【0a2fd9†L1-L6】
+
+## Docs Consulted
+- None (mirrored documentation was not required for this metadata alignment).

--- a/docs/atlas/brains.md
+++ b/docs/atlas/brains.md
@@ -1,7 +1,8 @@
 # Overlay ingest thread-safety — 2025-10-14
 - **REF 1.2.0x-A01**: Route overlay payload additions through the main thread by returning ingest results from worker futures and finalising state updates in `_refresh_ingest_jobs`, eliminating cross-thread Streamlit mutations. 【F:app/ui/main.py†L621-L678】【F:app/ui/main.py†L680-L713】
 - Hardened the ingest queue regression to assert queued overlays complete without `ScriptRunContext` warnings while preserving async progress. 【F:tests/ui/test_overlay_ingest_queue_async.py†L9-L128】
-- Recorded the thread-safety fix in the v1.2.0x patch notes and AI activity log alongside the version bump. 【F:docs/patch_notes/v1.2.0x.md†L1-L17】【F:app/version.json†L1-L5】【F:docs/ai_log/2025-10-13.md†L19-L33】
+- Added the v1.2.0x patch log entry so `_resolve_patch_metadata()` propagates the main-thread ingestion summary to the header and Docs banner. 【F:PATCHLOG.txt†L27-L27】【F:tests/ui/test_docs_tab.py†L16-L102】
+- Recorded the thread-safety fix in the v1.2.0x patch notes and AI activity log alongside the version bump. 【F:docs/patch_notes/v1.2.0x.md†L1-L21】【F:app/version.json†L1-L5】【F:docs/ai_log/2025-10-14.md†L1-L16】
 
 # Runtime manifest continuity — 2025-10-13
 - **REF 1.2.0w-A01**: Restored `docs/runtime.json` to a single JSON object so tooling can parse python, platform, and library metadata without errors. 【F:docs/runtime.json†L1-L23】

--- a/docs/brains/brains_INDEX.md
+++ b/docs/brains/brains_INDEX.md
@@ -1,6 +1,6 @@
 # MAKE NEW BRAINS EACH TIME YOU MAKE A CHANGE. DO NOT OVER WRITE PREVIOUS BRAINS * unless needed
 # Spectra App — Brains Index
-_Last updated: 2025-10-13T09:00:00Z_
+_Last updated: 2025-10-14T09:30:00Z_
 
 This index is the mandated entry point before touching the codebase.
 It tracks the latest continuity documents and the required cross-links between them.
@@ -14,6 +14,7 @@ It tracks the latest continuity documents and the required cross-links between t
 ## Continuity Table
 | Version | Brains Log | Patch Notes | AI Handoff |
 | --- | --- | --- | --- |
+| v1.2.0x | [docs/brains/brains_v1.2.0x.md](brains_v1.2.0x.md) | [docs/patch_notes/v1.2.0x.md](../patch_notes/v1.2.0x.md) | — |
 | v1.2.0v | [docs/brains/brains_v1.2.0v.md](brains_v1.2.0v.md) | [docs/patch_notes/v1.2.0v.md](../patch_notes/v1.2.0v.md) | — |
 | v1.2.0l | [docs/brains/brains_v1.2.0l.md](brains_v1.2.0l.md) | [docs/patch_notes/v1.2.0l.md](../patch_notes/v1.2.0l.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0k.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0k.md) |
 | v1.2.0k | [docs/brains/brains_v1.2.0k.md](brains_v1.2.0k.md) | [docs/patch_notes/v1.2.0k.md](../patch_notes/v1.2.0k.md) | [docs/ai_handoff/AI_HANDOFF_PROMPT_v1.2.0k.md](../ai_handoff/AI_HANDOFF_PROMPT_v1.2.0k.md) |

--- a/docs/brains/brains_v1.2.0x.md
+++ b/docs/brains/brains_v1.2.0x.md
@@ -1,0 +1,14 @@
+# Brains — v1.2.0x
+
+## Release focus
+- **REF 1.2.0x-A02**: Keep the docs banner and app header synchronized with the hotfix summary by extending `_resolve_patch_metadata()` coverage. 【F:PATCHLOG.txt†L27-L27】【F:tests/ui/test_docs_tab.py†L16-L102】
+
+## Implementation notes
+- Appended the v1.2.0x entry to `PATCHLOG.txt` so `get_version_info()` delivers the main-thread ingestion summary everywhere `_resolve_patch_metadata()` is consumed. 【F:PATCHLOG.txt†L27-L27】【F:app/_version.py†L32-L67】
+- Added a regression asserting `_resolve_patch_metadata()` now returns the v1.2.0x patch line derived from the log, ensuring the Docs tab banner renders the release copy verbatim. 【F:tests/ui/test_docs_tab.py†L16-L102】
+
+## Testing
+- `pytest tests/ui/test_docs_tab.py` 【0a2fd9†L1-L6】
+
+## Continuity updates
+- Logged the patch log alignment in the brains atlas, refreshed patch notes continuity, and recorded this AI log entry for the release. 【F:docs/atlas/brains.md†L1-L8】【F:docs/patch_notes/v1.2.0x.md†L1-L21】【F:docs/ai_log/2025-10-14.md†L1-L16】

--- a/docs/patch_notes/v1.2.0x.md
+++ b/docs/patch_notes/v1.2.0x.md
@@ -14,4 +14,5 @@
 - `pytest tests/ui/test_overlay_ingest_queue_async.py` 【5b7b2a†L1-L3】
 
 ## Continuity
-- Version bumped to v1.2.0x with brains and AI log updates recorded. 【F:app/version.json†L1-L5】【F:docs/atlas/brains.md†L1-L7】【F:docs/ai_log/2025-10-13.md†L19-L33】
+- Added the v1.2.0x entry to `PATCHLOG.txt` so `_resolve_patch_metadata()` surfaces the main-thread ingest summary across the app header and Docs tab. 【F:PATCHLOG.txt†L27-L27】【F:tests/ui/test_docs_tab.py†L16-L102】【F:app/_version.py†L32-L67】
+- Version bumped to v1.2.0x with brains and AI log updates recorded. 【F:app/version.json†L1-L5】【F:docs/atlas/brains.md†L1-L8】【F:docs/ai_log/2025-10-14.md†L1-L16】

--- a/tests/ui/test_docs_tab.py
+++ b/tests/ui/test_docs_tab.py
@@ -51,10 +51,10 @@ def test_docs_tab_banner_uses_patch_metadata(monkeypatch, tmp_path):
     monkeypatch.setattr(main_module, "_get_overlays", lambda: [])
 
     version_info = {
-        "version": "v1.2.0v",
-        "patch_version": "v1.2.0v",
-        "patch_summary": "Retire the example browser and streamline the Examples sidebar around quick-add shortcuts.",
-        "patch_raw": "v1.2.0v: Retire the example browser and streamline the Examples sidebar around quick-add shortcuts.",
+        "version": "v1.2.0x",
+        "patch_version": "v1.2.0x",
+        "patch_summary": "Finalize overlay ingestion on the main thread to avoid ScriptRunContext warnings.",
+        "patch_raw": "v1.2.0x: Finalize overlay ingestion on the main thread to avoid ScriptRunContext warnings.",
     }
 
     main_module._render_docs_tab(version_info)
@@ -62,7 +62,7 @@ def test_docs_tab_banner_uses_patch_metadata(monkeypatch, tmp_path):
     assert captured_info
     assert (
         captured_info[0]
-        == "v1.2.0v: Retire the example browser and streamline the Examples sidebar around quick-add shortcuts."
+        == "v1.2.0x: Finalize overlay ingestion on the main thread to avoid ScriptRunContext warnings."
     )
 
 
@@ -75,14 +75,28 @@ def test_header_prefers_patch_version(monkeypatch):
 
     version_info = {
         "version": "v0.0.0-dev",
-        "patch_version": "v1.2.0v",
-        "patch_summary": "Retire the example browser and streamline the Examples sidebar around quick-add shortcuts.",
-        "patch_raw": "v1.2.0v: Retire the example browser and streamline the Examples sidebar around quick-add shortcuts.",
-        "date_utc": "2025-10-13T09:00:00Z",
+        "patch_version": "v1.2.0x",
+        "patch_summary": "Finalize overlay ingestion on the main thread to avoid ScriptRunContext warnings.",
+        "patch_raw": "v1.2.0x: Finalize overlay ingestion on the main thread to avoid ScriptRunContext warnings.",
+        "date_utc": "2025-10-14T09:30:00Z",
     }
 
     main_module._render_app_header(version_info)
 
     assert captured_caption
-    assert captured_caption[0].startswith("v1.2.0v • Updated 2025-10-13 09:00 UTC")
-    assert "Retire the example browser" in captured_caption[0]
+    assert captured_caption[0].startswith("v1.2.0x • Updated 2025-10-14 09:30 UTC")
+    assert "Finalize overlay ingestion" in captured_caption[0]
+
+
+def test_resolve_patch_metadata_returns_current_patch_line():
+    from app import _version
+
+    version_info = _version.get_version_info()
+    patch_version, patch_summary, patch_line = main_module._resolve_patch_metadata(version_info)
+
+    assert patch_version == "v1.2.0x"
+    assert patch_summary == "Finalize overlay ingestion on the main thread to avoid ScriptRunContext warnings."
+    assert (
+        patch_line
+        == "v1.2.0x: Finalize overlay ingestion on the main thread to avoid ScriptRunContext warnings."
+    )


### PR DESCRIPTION
## Summary
- append the v1.2.0x summary to `PATCHLOG.txt` so `_resolve_patch_metadata()` surfaces the current release copy
- update the Docs tab regression to expect the new banner text and add a guard that `get_version_info()` returns it verbatim
- refresh the continuity collateral (patch notes, brains index/log, AI log) to record the patch log alignment

## Testing
- pytest tests/ui/test_docs_tab.py

------
https://chatgpt.com/codex/tasks/task_e_68ddbcb3c394832991a1c8259a0376c7