### PR TITLE
Canonicalize FITS wavelength aliases

### DIFF
--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.0x",
-  "date_utc": "2025-10-14T09:30:00Z",
-  "summary": "Finalize overlay ingestion on the main thread to avoid ScriptRunContext warnings."
+  "version": "v1.2.0y",
+  "date_utc": "2025-10-15T11:00:00Z",
+  "summary": "Canonicalize FITS wavelength unit aliases before validation and extend byte-string regression coverage."
 }

--- a/docs/ai_log/2025-10-15.md
+++ b/docs/ai_log/2025-10-15.md
@@ -1,0 +1,17 @@
+# AI Log — 2025-10-15
+
+## Tasking — v1.2.0y
+- Ensure FITS wavelength unit hints normalise to canonical aliases before validation and extend regression coverage for plural byte headers.
+- Update release collateral (version manifest, brains, patch notes, AI log) per the v1.2+ protocol.
+
+## Actions & Decisions
+- Routed `_normalise_wavelength_unit` candidates through a canonicaliser before fallback heuristics so plural byte aliases land on FITS strings the validator accepts. 【F:app/server/ingest_fits.py†L751-L810】
+- Simplified `_unit_is_wavelength` to treat canonical strings as authoritative while defensively decoding byte inputs, preventing redundant coercion from rejecting already-normalised units. 【F:app/server/ingest_fits.py†L338-L353】
+- Added regression tests for plural byte `TUNIT` and `CUNIT` headers to confirm ingestion reports canonical units and preserves the header metadata for provenance. 【F:tests/server/test_ingest_fits.py†L375-L420】
+- Bumped the release metadata and documented the change across patch notes and the brains atlas to keep continuity artefacts in sync. 【F:app/version.json†L1-L5】【F:docs/patch_notes/v1.2.0y.md†L1-L18】【F:docs/atlas/brains.md†L1-L8】
+
+## Verification
+- `pytest tests/server/test_ingest_fits.py` 【829103†L1-L33】
+
+## Docs Consulted
+- Reviewed the MAST Data Format Guidelines for wavelength unit conventions. https://archive.stsci.edu/data_format.html 【F:docs/mirrored/stsci_archive/data_format.html.meta.json†L1-L6】

--- a/docs/atlas/brains.md
+++ b/docs/atlas/brains.md
@@ -1,3 +1,8 @@
+# FITS wavelength alias canonicalisation — 2025-10-15
+- Funnel `_normalise_wavelength_unit` candidates through a canonicaliser so byte-decoded aliases (e.g., `Angstroms`) resolve to the singular FITS label before `_unit_is_wavelength` validates them. 【F:app/server/ingest_fits.py†L758-L805】
+- Let `_unit_is_wavelength` trust canonical strings while still decoding defensive byte inputs, ensuring previously-normalised units skip redundant coercion. 【F:app/server/ingest_fits.py†L343-L356】
+- Locked regressions for plural byte `TUNIT`/`CUNIT` headers to prove ingestion surfaces canonical units and preserved metadata. 【F:tests/server/test_ingest_fits.py†L371-L426】
+
 # Overlay ingest thread-safety — 2025-10-14
 - **REF 1.2.0x-A01**: Route overlay payload additions through the main thread by returning ingest results from worker futures and finalising state updates in `_refresh_ingest_jobs`, eliminating cross-thread Streamlit mutations. 【F:app/ui/main.py†L621-L678】【F:app/ui/main.py†L680-L713】
 - Hardened the ingest queue regression to assert queued overlays complete without `ScriptRunContext` warnings while preserving async progress. 【F:tests/ui/test_overlay_ingest_queue_async.py†L9-L128】

--- a/docs/patch_notes/v1.2.0y.md
+++ b/docs/patch_notes/v1.2.0y.md
@@ -1,0 +1,17 @@
+# Patch Notes — v1.2.0y
+
+## Summary
+- Canonicalised FITS wavelength hints so plural byte aliases resolve before validation and added regression coverage for plural `TUNIT`/`CUNIT` headers. 【F:app/server/ingest_fits.py†L338-L353】【F:app/server/ingest_fits.py†L751-L810】【F:tests/server/test_ingest_fits.py†L375-L420】
+
+## Details
+1. **Canonical wavelength aliasing**
+   - Route `_normalise_wavelength_unit` candidates through a shared canonicaliser so plural strings (including decoded byte aliases) resolve to FITS labels before conversion or validation. 【F:app/server/ingest_fits.py†L751-L810】
+   - Simplified `_unit_is_wavelength` to trust canonical strings while defensively decoding bytes, ensuring already-normalised hints skip redundant coercion. 【F:app/server/ingest_fits.py†L338-L353】
+2. **Regression coverage**
+   - Extended ingestion tests with plural byte `TUNIT` and `CUNIT` fixtures to confirm canonical units are reported while metadata preserves the original header values. 【F:tests/server/test_ingest_fits.py†L375-L420】
+
+## Verification
+- `pytest tests/server/test_ingest_fits.py` 【829103†L1-L33】
+
+## Continuity
+- Version bumped to v1.2.0y with brains and AI log updates recorded per the release protocol. 【F:app/version.json†L1-L5】【F:docs/atlas/brains.md†L1-L8】【F:docs/ai_log/2025-10-15.md†L1-L20】


### PR DESCRIPTION
## Summary
- canonicalise FITS wavelength hints before validation so plural aliases resolve to FITS strings
- add regression coverage for byte-string TUNIT/CUNIT headers and document the behaviour change
- bump v1.2.0y collateral (version manifest, patch notes, brains, AI log) per the release protocol

## Testing
- `pytest tests/server/test_ingest_fits.py`


------
https://chatgpt.com/codex/tasks/task_e_68ddbe43c6508329a216885ada0e79b0