### PR TITLE
Add v1.2.1 patch log entry and refresh continuity

### DIFF
--- a/PATCHLOG.txt
+++ b/PATCHLOG.txt
@@ -28,3 +28,4 @@ Spectra App — Patch Log (append-only)
 - v1.2.0y: Canonicalise FITS wavelength unit aliases before validation and extend byte-string regression coverage.
 - v1.2.0z: Remove FITS time-series epoch offsets from overlay payloads and surface reference epochs in the UI.
 - v1.2.1a: Accept legacy overlay ingest results after reruns and extend async queue regression coverage.
+- v1.2.1 (REF 1.2.1-A01): relocate overlay trace helpers onto OverlayTrace, add a direct `_build_overlay_figure` regression, and roll continuity collateral.

--- a/docs/ai_log/2025-10-19.md
+++ b/docs/ai_log/2025-10-19.md
@@ -1,0 +1,16 @@
+# AI Log — 2025-10-19
+
+## Tasking — v1.2.1 continuity
+- Append the missing v1.2.1 release entry, refresh continuity collateral, and lock UI regressions to the new summary.
+
+## Actions & Decisions
+- Added the v1.2.1 (REF 1.2.1-A01) patch log entry so `_resolve_patch_metadata()` surfaces the helper relocation summary in the Docs banner and header. 【F:PATCHLOG.txt†L31-L31】【F:app/ui/main.py†L3306-L3393】
+- Updated the Docs tab regression to snapshot the v1.2.1 summary and header caption, confirming the UI presents the refreshed copy. 【F:tests/ui/test_docs_tab.py†L16-L105】
+- Published v1.2.1 patch notes and recorded the change in the brains log to maintain release continuity. 【F:docs/patch_notes/v1.2.1.md†L1-L23】【F:docs/atlas/brains.md†L1-L4】
+
+## Verification
+- `pytest tests/ui/test_docs_tab.py` 【e87a6c†L1-L5】
+- `pytest tests/ui/test_overlay_mixed_axes.py -q` 【dff6dc†L1-L2】
+
+## Docs Consulted
+- None

--- a/docs/atlas/brains.md
+++ b/docs/atlas/brains.md
@@ -1,3 +1,8 @@
+# Patch log v1.2.1 summary alignment — 2025-10-19
+- Added the v1.2.1 patch log entry so `_resolve_patch_metadata()` surfaces the overlay trace helper relocation summary across the Docs banner and app header. 【F:PATCHLOG.txt†L31-L31】【F:app/ui/main.py†L3308-L3392】
+- Updated the Docs tab regression to assert the v1.2.1 summary and header caption so UI surfaces the new copy. 【F:tests/ui/test_docs_tab.py†L16-L105】
+- Published the v1.2.1 patch notes to capture the helper relocation and regression coverage. 【F:docs/patch_notes/v1.2.1.md†L1-L23】
+
 # Overlay ingest result continuity — 2025-10-18
 - Duck-type overlay ingest futures on their `status`, `detail`, and `payload` attributes so cached dataclass instances from previous reruns continue to resolve successfully on the UI thread. 【F:app/ui/main.py†L761-L777】
 - Added regression coverage that submits a completed future with a legacy-style ingest result and verifies `_add_overlay_payload` executes without "Unexpected ingest result" failures. 【F:tests/ui/test_overlay_ingest_queue_async.py†L186-L236】

--- a/docs/patch_notes/v1.2.1.md
+++ b/docs/patch_notes/v1.2.1.md
@@ -1,0 +1,19 @@
+# Patch Notes — v1.2.1
+
+## Summary
+- Relocated overlay trace helpers onto `OverlayTrace`, added a direct `_build_overlay_figure` regression, and refreshed release collateral for the v1.2.1 cut. 【F:app/ui/main.py†L56-L209】【F:tests/ui/test_overlay_mixed_axes.py†L1-L35】【F:PATCHLOG.txt†L27-L31】
+
+## Details
+1. **OverlayTrace owns helper utilities**
+   - Moved dataframe conversion, sampling, vectorisation, and point-count helpers from ingest results to `OverlayTrace` so downstream UI components operate on the canonical trace model. 【F:app/ui/main.py†L56-L209】
+   - Ensured helper-backed vector generation powers similarity tooling by relying on `OverlayTrace.to_vectors`. 【F:app/ui/main.py†L166-L196】
+2. **Regression coverage**
+   - Added a direct `_build_overlay_figure` regression to confirm overlay traces expose helper methods required for figure construction. 【F:tests/ui/test_overlay_mixed_axes.py†L1-L35】
+   - Exercised mixed-axis and offset scenarios to verify helper-backed traces respect viewport segregation and time-offset provenance. 【F:tests/ui/test_overlay_mixed_axes.py†L68-L155】
+
+## Verification
+- `pytest tests/ui/test_overlay_mixed_axes.py -q` 【dff6dc†L1-L2】
+
+## Continuity
+- Added the v1.2.1 entry to `PATCHLOG.txt` so `_resolve_patch_metadata()` surfaces the updated summary across the UI header and Docs tab. 【F:PATCHLOG.txt†L27-L31】【F:app/ui/main.py†L3385-L3392】【F:tests/ui/test_docs_tab.py†L16-L105】
+- Recorded the change in `docs/atlas/brains.md` and `docs/ai_log/2025-10-19.md` per the v1.2 protocol. 【F:docs/atlas/brains.md†L1-L4】【F:docs/ai_log/2025-10-19.md†L1-L15】

--- a/tests/ui/test_docs_tab.py
+++ b/tests/ui/test_docs_tab.py
@@ -51,10 +51,10 @@ def test_docs_tab_banner_uses_patch_metadata(monkeypatch, tmp_path):
     monkeypatch.setattr(main_module, "_get_overlays", lambda: [])
 
     version_info = {
-        "version": "v1.2.0x",
-        "patch_version": "v1.2.0x",
-        "patch_summary": "Finalize overlay ingestion on the main thread to avoid ScriptRunContext warnings.",
-        "patch_raw": "v1.2.0x: Finalize overlay ingestion on the main thread to avoid ScriptRunContext warnings.",
+        "version": "v1.2.1",
+        "patch_version": "v1.2.1",
+        "patch_summary": "(REF 1.2.1-A01): relocate overlay trace helpers onto OverlayTrace, add a direct `_build_overlay_figure` regression, and roll continuity collateral.",
+        "patch_raw": "v1.2.1 (REF 1.2.1-A01): relocate overlay trace helpers onto OverlayTrace, add a direct `_build_overlay_figure` regression, and roll continuity collateral.",
     }
 
     main_module._render_docs_tab(version_info)
@@ -62,7 +62,7 @@ def test_docs_tab_banner_uses_patch_metadata(monkeypatch, tmp_path):
     assert captured_info
     assert (
         captured_info[0]
-        == "v1.2.0x: Finalize overlay ingestion on the main thread to avoid ScriptRunContext warnings."
+        == "v1.2.1 (REF 1.2.1-A01): relocate overlay trace helpers onto OverlayTrace, add a direct `_build_overlay_figure` regression, and roll continuity collateral."
     )
 
 
@@ -75,17 +75,17 @@ def test_header_prefers_patch_version(monkeypatch):
 
     version_info = {
         "version": "v0.0.0-dev",
-        "patch_version": "v1.2.0x",
-        "patch_summary": "Finalize overlay ingestion on the main thread to avoid ScriptRunContext warnings.",
-        "patch_raw": "v1.2.0x: Finalize overlay ingestion on the main thread to avoid ScriptRunContext warnings.",
-        "date_utc": "2025-10-14T09:30:00Z",
+        "patch_version": "v1.2.1",
+        "patch_summary": "(REF 1.2.1-A01): relocate overlay trace helpers onto OverlayTrace, add a direct `_build_overlay_figure` regression, and roll continuity collateral.",
+        "patch_raw": "v1.2.1 (REF 1.2.1-A01): relocate overlay trace helpers onto OverlayTrace, add a direct `_build_overlay_figure` regression, and roll continuity collateral.",
+        "date_utc": "2025-10-17T09:30:00Z",
     }
 
     main_module._render_app_header(version_info)
 
     assert captured_caption
-    assert captured_caption[0].startswith("v1.2.0x • Updated 2025-10-14 09:30 UTC")
-    assert "Finalize overlay ingestion" in captured_caption[0]
+    assert captured_caption[0].startswith("v1.2.1 • Updated 2025-10-17 09:30 UTC")
+    assert "relocate overlay trace helpers" in captured_caption[0]
 
 
 def test_resolve_patch_metadata_returns_current_patch_line():
@@ -94,9 +94,12 @@ def test_resolve_patch_metadata_returns_current_patch_line():
     version_info = _version.get_version_info()
     patch_version, patch_summary, patch_line = main_module._resolve_patch_metadata(version_info)
 
-    assert patch_version == "v1.2.0x"
-    assert patch_summary == "Finalize overlay ingestion on the main thread to avoid ScriptRunContext warnings."
+    assert patch_version == "v1.2.1"
+    assert (
+        patch_summary
+        == "(REF 1.2.1-A01): relocate overlay trace helpers onto OverlayTrace, add a direct `_build_overlay_figure` regression, and roll continuity collateral."
+    )
     assert (
         patch_line
-        == "v1.2.0x: Finalize overlay ingestion on the main thread to avoid ScriptRunContext warnings."
+        == "v1.2.1 (REF 1.2.1-A01): relocate overlay trace helpers onto OverlayTrace, add a direct `_build_overlay_figure` regression, and roll continuity collateral."
     )


### PR DESCRIPTION
## Summary
- append the v1.2.1 release entry with REF metadata to `PATCHLOG.txt`
- roll continuity collateral for the release, including new patch notes, brains entry, and AI activity log
- update the Docs tab regression to assert the v1.2.1 summary and header caption

## Testing
- pytest tests/ui/test_docs_tab.py
- pytest tests/ui/test_overlay_mixed_axes.py -q

------
https://chatgpt.com/codex/tasks/task_e_68ddd8650c008329b37d2b97ba1cfab0