### PR TITLE
Guard differential similarity from image overlays

### DIFF
--- a/app/ui/main.py
+++ b/app/ui/main.py
@@ -1891,7 +1891,7 @@ def _build_overlay_figure(
         else {}
     )
     reference_vectors: Optional[TraceVectors] = None
-    if reference:
+    if reference and _axis_kind_for_trace(reference) != "image":
         ref_kind = _axis_kind_for_trace(reference)
         reference_vectors = reference.to_vectors(
             max_points=max_points,
@@ -3171,9 +3171,17 @@ def _render_differential_tab() -> None:
     sample_default = int(st.session_state.get("differential_sample_points", 2000))
     normalization = st.session_state.get("normalization_mode", "unit")
     viewport_store = _get_viewport_store()
-    similarity_sources = [trace for trace in spectral_overlays if trace.visible]
+    similarity_sources = [
+        trace
+        for trace in spectral_overlays
+        if trace.visible and _axis_kind_for_trace(trace) != "image"
+    ]
     if len(similarity_sources) < 2:
-        similarity_sources = spectral_overlays
+        similarity_sources = [
+            trace
+            for trace in spectral_overlays
+            if _axis_kind_for_trace(trace) != "image"
+        ]
     wavelength_sources = [
         trace for trace in similarity_sources if _axis_kind_for_trace(trace) == "wavelength"
     ]

--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.1a",
-  "date_utc": "2025-10-1T11:00:00Z",
-  "summary": "Accept legacy overlay ingest results after reruns and extend async queue regression coverage."
+  "version": "v1.2.1b",
+  "date_utc": "2025-10-20T00:00:00Z",
+  "summary": "Guard differential similarity vectorisation from image overlays and add regression coverage."
 }

--- a/docs/ai_log/2025-10-20.md
+++ b/docs/ai_log/2025-10-20.md
@@ -1,0 +1,16 @@
+# AI Log — 2025-10-20
+
+## Tasking — Differential image guard hotfix
+- Prevent the differential similarity workflow from vectorising image overlays and add regression coverage, then roll continuity artefacts.
+
+## Actions & Decisions
+- Filtered differential similarity sources so only non-image overlays feed the vectorisation pipeline, preventing `to_vectors` from raising when images are visible. 【F:app/ui/main.py†L3174-L3184】
+- Bypassed reference vector construction for image overlays to keep similarity guards consistent across the workspace. 【F:app/ui/main.py†L1893-L1899】
+- Added an AppTest that mixes spectral and image overlays and confirmed the differential tab renders without exceptions, covering the previous regression. 【F:tests/ui/test_differential_form.py†L137-L151】
+- Published the v1.2.1b patch notes and version metadata to capture the guardrails and test coverage. 【F:docs/patch_notes/v1.2.1b.md†L1-L17】【F:app/version.json†L2-L5】
+
+## Verification
+- `pytest tests/ui/test_differential_form.py -q` 【6cbe60†L1-L2】
+
+## Docs Consulted
+- None — local search endpoint returned no results for the requested query.

--- a/docs/atlas/brains.md
+++ b/docs/atlas/brains.md
@@ -1,3 +1,8 @@
+# Differential similarity image guard — 2025-10-20
+- Filtered differential similarity sources to drop image overlays so vectorisation never calls `to_vectors` on image payloads. 【F:app/ui/main.py†L3174-L3184】
+- Skip building reference vectors when the active overlay is an image, preventing similarity helpers from raising ValueError. 【F:app/ui/main.py†L1893-L1899】
+- Added a differential tab regression that mixes spectral and image overlays to prove the UI renders without exceptions. 【F:tests/ui/test_differential_form.py†L137-L151】
+
 # Patch log v1.2.1 summary alignment — 2025-10-19
 - Added the v1.2.1 patch log entry so `_resolve_patch_metadata()` surfaces the overlay trace helper relocation summary across the Docs banner and app header. 【F:PATCHLOG.txt†L31-L31】【F:app/ui/main.py†L3308-L3392】
 - Updated the Docs tab regression to assert the v1.2.1 summary and header caption so UI surfaces the new copy. 【F:tests/ui/test_docs_tab.py†L16-L105】

--- a/docs/patch_notes/v1.2.1b.md
+++ b/docs/patch_notes/v1.2.1b.md
@@ -1,0 +1,19 @@
+# Patch Notes — v1.2.1b
+
+## Summary
+- Skip image overlays when building differential similarity vectors and guard reference vectorisation so image traces never trigger ValueError in similarity workflows. 【F:app/ui/main.py†L3174-L3184】【F:app/ui/main.py†L1893-L1899】
+- Add a differential tab regression that loads an image overlay to ensure the panel renders without raising exceptions. 【F:tests/ui/test_differential_form.py†L137-L151】
+
+## Details
+1. **Vectorisation guardrails**
+   - Filter similarity sources to exclude image overlays and keep the fallback set image-free so the similarity pipeline only vectorises spectral/time traces. 【F:app/ui/main.py†L3174-L3184】
+   - Skip building reference vectors when the selected reference overlay is an image, preventing accidental calls to `to_vectors` on image payloads. 【F:app/ui/main.py†L1893-L1899】
+2. **Regression coverage**
+   - Added an AppTest that mixes spectral and image overlays, runs the differential tab, and asserts no exception surfaces, covering the previous ValueError scenario. 【F:tests/ui/test_differential_form.py†L137-L151】
+
+## Verification
+- `pytest tests/ui/test_differential_form.py -q` 【6cbe60†L1-L2】
+
+## Continuity
+- Bumped `app/version.json` to v1.2.1b with the new summary. 【F:app/version.json†L2-L5】
+- Logged the change in `docs/atlas/brains.md` and recorded the AI activity entry for 2025-10-20. 【F:docs/atlas/brains.md†L1-L8】【F:docs/ai_log/2025-10-20.md†L1-L16】

--- a/tests/ui/test_differential_form.py
+++ b/tests/ui/test_differential_form.py
@@ -21,6 +21,18 @@ def _simple_overlay(trace_id: str) -> OverlayTrace:
     )
 
 
+def _image_overlay(trace_id: str) -> OverlayTrace:
+    return OverlayTrace(
+        trace_id=trace_id,
+        label=f"Image {trace_id}",
+        wavelength_nm=tuple(),
+        flux=tuple(),
+        kind="image",
+        axis_kind="image",
+        image={"data": [[1.0, 2.0], [3.0, 4.0]]},
+    )
+
+
 def test_differential_form_has_single_submit_button():
     app = AppTest.from_function(_render_differential_tab_entrypoint)
 
@@ -120,3 +132,20 @@ def test_similarity_panel_renders_with_differential_inputs():
 
     headings = [block.body for block in app.markdown]
     assert "### Similarity analysis" in headings
+
+
+def test_differential_tab_handles_image_overlays():
+    app = AppTest.from_function(_render_differential_tab_entrypoint)
+
+    app.session_state.overlay_traces = [
+        _simple_overlay("a"),
+        _simple_overlay("b"),
+        _image_overlay("img"),
+    ]
+    app.session_state.reference_trace_id = "a"
+    app.session_state.normalization_mode = "unit"
+    app.session_state.similarity_cache = SimilarityCache()
+
+    app.run()
+
+    assert not app.exception


### PR DESCRIPTION
## Summary
- filter differential similarity sources to skip image overlays and guard reference vectorization paths
- add a regression that loads an image overlay and confirms the differential tab renders cleanly
- update version metadata, brains, patch notes, and AI log for v1.2.1b

## Testing
- pytest tests/ui/test_differential_form.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dddab560d08329a69dce5179496bc9