### PR TITLE
Normalize time ingest offsets and reject time-series overlays

### DIFF
--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.1b",
+  "version": "v1.2.1c",
   "date_utc": "2025-10-20T00:00:00Z",
-  "summary": "Guard differential similarity vectorisation from image overlays and add regression coverage."
+  "summary": "Reject time-series overlays, normalise time offsets during FITS ingest, and document the policy."
 }

--- a/docs/ai_log/2025-10-20.md
+++ b/docs/ai_log/2025-10-20.md
@@ -14,3 +14,17 @@
 
 ## Docs Consulted
 - None — local search endpoint returned no results for the requested query.
+
+## Tasking — Overlay time-series policy update
+- Normalise FITS time offsets before emitting time samples and block time-series payloads from overlay ingestion while updating documentation.
+
+## Actions & Decisions
+- Subtracted detected FITS time offsets inside `_extract_table_data`, recorded an `offset_subtracted` flag, and prevented duplicate subtraction when building payload metadata. 【F:app/server/ingest_fits.py†L519-L550】【F:app/server/ingest_fits.py†L1475-L1527】
+- Rejected time-series overlays in both `_add_overlay` and local ingest, filtered time traces from overlay grouping/rendering, and surfaced the policy through user-facing error messages. 【F:app/ui/main.py†L970-L1050】【F:app/ui/main.py†L373-L382】【F:app/ui/main.py†L1885-L1934】【F:app/utils/local_ingest.py†L461-L482】
+- Added regression coverage with TESS-like light curves to assert FITS ingest normalises offsets, local ingest emits the policy error, and overlay rendering ignores time traces. 【F:tests/server/test_ingest_fits.py†L491-L513】【F:tests/server/test_local_ingest.py†L517-L691】【F:tests/ui/test_overlay_time_policy.py†L15-L65】
+
+## Verification
+- `pytest tests/server/test_ingest_fits.py tests/server/test_local_ingest.py tests/ui/test_overlay_time_policy.py -q` 【3af223†L1-L37】
+
+## Docs Consulted
+- None — local doc search returned an empty payload for overlay policy queries. 【dbafaa†L1-L1】

--- a/docs/atlas/brains.md
+++ b/docs/atlas/brains.md
@@ -1,3 +1,8 @@
+# Overlay time-series policy — 2025-10-20
+- Subtract FITS time-axis offsets inside `_extract_table_data`, flag provenance with `offset_subtracted`, and skip duplicate subtraction during payload assembly so canonical values remain relative to the advertised frame. 【F:app/server/ingest_fits.py†L519-L550】【F:app/server/ingest_fits.py†L1475-L1527】
+- Reject time-series overlays in `_add_overlay` and `ingest_local_file`, surface the policy in error messages, and treat time traces like images when grouping, reference selection, and plotting overlays. 【F:app/ui/main.py†L970-L1050】【F:app/ui/main.py†L373-L382】【F:app/ui/main.py†L1885-L1934】【F:app/utils/local_ingest.py†L461-L482】
+- Added TESS-inspired regression coverage confirming FITS ingest normalises offsets, local ingest surfaces the new error, and overlay rendering drops time traces from figures. 【F:tests/server/test_ingest_fits.py†L491-L513】【F:tests/server/test_local_ingest.py†L517-L691】【F:tests/ui/test_overlay_time_policy.py†L15-L65】
+
 # Differential similarity image guard — 2025-10-20
 - Filtered differential similarity sources to drop image overlays so vectorisation never calls `to_vectors` on image payloads. 【F:app/ui/main.py†L3174-L3184】
 - Skip building reference vectors when the active overlay is an image, preventing similarity helpers from raising ValueError. 【F:app/ui/main.py†L1893-L1899】

--- a/docs/patch_notes/v1.2.1c.md
+++ b/docs/patch_notes/v1.2.1c.md
@@ -1,0 +1,24 @@
+# Patch Notes — v1.2.1c
+
+## Summary
+- Normalise FITS time-axis offsets during ingestion so time samples are emitted in the canonical frame before provenance capture. 【F:app/server/ingest_fits.py†L519-L550】【F:app/server/ingest_fits.py†L1475-L1527】
+- Block time-series payloads from overlay ingestion with clear user messaging and filter any residual time traces out of overlay rendering. 【F:app/ui/main.py†L970-L1050】【F:app/ui/main.py†L373-L382】【F:app/ui/main.py†L1885-L1934】【F:app/utils/local_ingest.py†L461-L482】
+- Add regression coverage with TESS-like headers for FITS ingestion, overlay rejection, and rendering safeguards to document the new policy. 【F:tests/server/test_ingest_fits.py†L435-L513】【F:tests/server/test_local_ingest.py†L517-L691】【F:tests/ui/test_overlay_time_policy.py†L15-L65】
+
+## Details
+1. **Time-axis normalisation**
+   - Subtract detected FITS time offsets inside `_extract_table_data` and mark the provenance so downstream code works with offset-free quantities. 【F:app/server/ingest_fits.py†L519-L550】
+   - Guard the parse layer against double subtraction by honouring the new `offset_subtracted` flag when building metadata. 【F:app/server/ingest_fits.py†L1475-L1527】
+2. **Overlay policy enforcement**
+   - Reject time-series overlays in both `_add_overlay` and local ingest, surface the policy in error messages, and exclude time traces from overlay figures, grouping, and reference selection. 【F:app/ui/main.py†L970-L1050】【F:app/ui/main.py†L1885-L1934】【F:app/utils/local_ingest.py†L461-L482】
+   - Extend session utilities to treat time traces like images when deduplicating references and similarity sources. 【F:app/ui/main.py†L2726-L3200】
+3. **Regression coverage**
+   - Add targeted server and UI tests that construct TESS-like light-curve HDUs to assert FITS offsets are normalised, local ingest blocks time-series payloads, and overlay rendering ignores stray time traces. 【F:tests/server/test_ingest_fits.py†L435-L513】【F:tests/server/test_local_ingest.py†L517-L691】【F:tests/ui/test_overlay_time_policy.py†L15-L65】
+   - Update existing FITS ingestion tests to confirm the new provenance metadata. 【F:tests/server/test_ingest_fits.py†L491-L513】
+
+## Verification
+- `pytest tests/server/test_ingest_fits.py tests/server/test_local_ingest.py tests/ui/test_overlay_time_policy.py -q` 【3af223†L1-L37】
+
+## Continuity
+- Bumped `app/version.json` to v1.2.1c with the updated summary. 【F:app/version.json†L1-L4】
+- Logged the change in `docs/atlas/brains.md` and recorded the AI activity entry for 2025-10-20. 【F:docs/atlas/brains.md†L1-L6】【F:docs/ai_log/2025-10-20.md†L1-L33】

--- a/tests/ui/test_overlay_time_policy.py
+++ b/tests/ui/test_overlay_time_policy.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+
+import pytest
+
+from app.ui import main
+
+
+@pytest.fixture(autouse=True)
+def reset_session_state(monkeypatch):
+    state = {"overlay_traces": [], "display_full_resolution": False}
+    monkeypatch.setattr(main, "st", SimpleNamespace(session_state=state))
+    yield state
+
+
+def test_add_overlay_payload_rejects_time_series(reset_session_state):
+    payload = {
+        "label": "TESS Light Curve",
+        "wavelength_nm": [0.0, 0.5, 1.0],
+        "flux": [1200.0, 1195.0, 1187.0],
+        "axis_kind": "time",
+        "metadata": {"axis_kind": "time", "time_unit": "day"},
+    }
+
+    added, message = main._add_overlay_payload(payload)
+
+    assert added is False
+    assert "Time-series overlays are not supported" in message
+    assert main._get_overlays() == []
+
+
+def test_grouping_and_rendering_ignore_time_traces(reset_session_state):
+    spectral_trace = main.OverlayTrace(
+        trace_id="spec",
+        label="Spectral",
+        wavelength_nm=(500.0, 505.0, 510.0),
+        flux=(1.0, 0.9, 1.1),
+        axis_kind="wavelength",
+    )
+    time_trace = main.OverlayTrace(
+        trace_id="time",
+        label="Time",
+        wavelength_nm=(0.0, 1.0, 2.0),
+        flux=(1200.0, 1180.0, 1170.0),
+        axis_kind="time",
+    )
+
+    groups = main._group_overlays_by_axis_kind([spectral_trace, time_trace])
+    assert "time" not in groups
+    assert groups["wavelength"] == [spectral_trace]
+
+    viewport = {"wavelength": (None, None)}
+    fig, axis_title = main._build_overlay_figure(
+        [spectral_trace, time_trace],
+        "nm",
+        "Flux (raw)",
+        "unit",
+        viewport,
+        reference=spectral_trace,
+        differential_mode="Off",
+        version_tag="vtest",
+    )
+
+    assert len(fig.data) == 1
+    assert fig.data[0].name == "Spectral"
+    assert axis_title.startswith("Wavelength")


### PR DESCRIPTION
## Summary
- subtract detected FITS time-axis offsets before emitting samples and mark the provenance to avoid double subtraction downstream
- block time-series payloads from overlay ingestion, filter residual time traces from overlay rendering, and surface the policy in error messaging
- add regression coverage for TESS-like FITS inputs, overlay rejection, and rendering safeguards, and record the policy change in docs

## Testing
- pytest tests/server/test_ingest_fits.py tests/server/test_local_ingest.py tests/ui/test_overlay_time_policy.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dddd6b28e883299ec30947c6accc34