### PR TITLE
Stabilize overlay ingest result handling across reruns

### DIFF
--- a/app/ingest/__init__.py
+++ b/app/ingest/__init__.py
@@ -1,0 +1,5 @@
+"""Ingestion models and helpers."""
+
+from .results import OverlayIngestResult
+
+__all__ = ["OverlayIngestResult"]

--- a/app/ingest/results.py
+++ b/app/ingest/results.py
@@ -1,0 +1,18 @@
+"""Shared ingest result models for overlay workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class OverlayIngestResult:
+    """Outcome of an asynchronous overlay ingest job."""
+
+    status: str
+    detail: str
+    payload: Optional[Dict[str, Any]] = None
+
+
+__all__ = ["OverlayIngestResult"]

--- a/app/ui/main.py
+++ b/app/ui/main.py
@@ -25,6 +25,7 @@ from streamlit.delta_generator import DeltaGenerator
 from app.ui.targets import RegistryUnavailableError, render_targets_panel
 
 from app._version import get_version_info
+from app.ingest import OverlayIngestResult
 from app.export_manifest import build_manifest
 from app.server.differential import ratio, resample_to_common_grid, subtract
 from app.server.fetch_archives import FetchError, fetch_spectrum
@@ -206,13 +207,6 @@ class OverlayTrace:
                     return 0
             return 0
         return len(self.wavelength_nm)
-
-
-@dataclass
-class OverlayIngestResult:
-    status: str
-    detail: str
-    payload: Optional[Dict[str, Any]] = None
 
 
 @dataclass(frozen=True)

--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.1c",
-  "date_utc": "2025-10-20T00:00:00Z",
-  "summary": "Reject time-series overlays, normalise time offsets during FITS ingest, and document the policy."
+  "version": "v1.2.1d",
+  "date_utc": "2025-10-21T00:00:00Z",
+  "summary": "Stabilise overlay ingest results across reruns and document the regression coverage."
 }

--- a/docs/ai_log/2025-10-21.md
+++ b/docs/ai_log/2025-10-21.md
@@ -1,0 +1,15 @@
+# AI Log — 2025-10-21
+
+## Tasking — Overlay ingest rerun stability
+- Ensure overlay ingest futures created before a Streamlit rerun still resolve successfully and update release collateral.
+
+## Actions & Decisions
+- Moved `OverlayIngestResult` into `app.ingest` so worker futures keep returning the same class across reruns while `_refresh_ingest_jobs` continues to process payloads. 【F:app/ingest/results.py†L1-L18】【F:app/ui/main.py†L671-L798】
+- Added a regression test that reloads `app.ui.main` before fulfilling a future and confirms `_add_overlay_payload` executes without the "Unexpected ingest result" fallback. 【F:tests/ui/test_overlay_ingest_queue_async.py†L186-L289】
+- Updated version metadata and brains notes to document the hotfix. 【F:app/version.json†L1-L5】【F:docs/atlas/brains.md†L1-L24】
+
+## Verification
+- `pytest tests/ui/test_overlay_ingest_queue_async.py -q` 【795bdd†L1-L1】【7ae437†L1-L2】
+
+## Docs Consulted
+- None.

--- a/docs/atlas/brains.md
+++ b/docs/atlas/brains.md
@@ -1,3 +1,7 @@
+# Overlay ingest rerun continuity — 2025-10-21
+- Centralised `OverlayIngestResult` in a shared ingest module so executor futures resolve with a stable class across reruns and `_refresh_ingest_jobs` keeps adding payloads. 【F:app/ingest/results.py†L1-L18】【F:app/ui/main.py†L671-L798】
+- Added regression coverage that reloads the UI module before the future resolves and confirms `_add_overlay_payload` runs without surfacing the "Unexpected ingest result" fallback. 【F:tests/ui/test_overlay_ingest_queue_async.py†L186-L289】
+
 # Overlay time-series policy — 2025-10-20
 - Subtract FITS time-axis offsets inside `_extract_table_data`, flag provenance with `offset_subtracted`, and skip duplicate subtraction during payload assembly so canonical values remain relative to the advertised frame. 【F:app/server/ingest_fits.py†L519-L550】【F:app/server/ingest_fits.py†L1475-L1527】
 - Reject time-series overlays in `_add_overlay` and `ingest_local_file`, surface the policy in error messages, and treat time traces like images when grouping, reference selection, and plotting overlays. 【F:app/ui/main.py†L970-L1050】【F:app/ui/main.py†L373-L382】【F:app/ui/main.py†L1885-L1934】【F:app/utils/local_ingest.py†L461-L482】

--- a/docs/patch_notes/v1.2.1d.md
+++ b/docs/patch_notes/v1.2.1d.md
@@ -1,0 +1,18 @@
+# Patch Notes — v1.2.1d
+
+## Summary
+- Move `OverlayIngestResult` into a shared ingest module so background futures return a stable type across reruns and the UI keeps consuming payloads successfully. 【F:app/ingest/results.py†L1-L18】【F:app/ui/main.py†L671-L798】
+- Add regression coverage that simulates a rerun before the future resolves and confirms `_add_overlay_payload` handles the payload without triggering the "Unexpected ingest result" fallback. 【F:tests/ui/test_overlay_ingest_queue_async.py†L186-L289】
+- Refresh release collateral with the new version metadata, brains entry, and AI log for the hotfix. 【F:app/version.json†L1-L5】【F:docs/atlas/brains.md†L1-L24】【F:docs/ai_log/2025-10-21.md†L1-L15】
+
+## Details
+1. **Shared ingest results**
+   - Centralised `OverlayIngestResult` under `app.ingest` and updated the Streamlit worker helpers to import from the shared module, preventing stale class identities from breaking future callbacks after reruns. 【F:app/ingest/results.py†L1-L18】【F:app/ui/main.py†L671-L798】
+2. **Regression coverage**
+   - Added a unit test that reloads `app.ui.main` before fulfilling a queued future, asserts `_add_overlay_payload` runs, and ensures job details avoid the "Unexpected ingest result" fallback. 【F:tests/ui/test_overlay_ingest_queue_async.py†L186-L289】
+
+## Verification
+- `pytest tests/ui/test_overlay_ingest_queue_async.py -q` 【795bdd†L1-L1】【7ae437†L1-L2】
+
+## Continuity
+- Bumped `app/version.json` to v1.2.1d and captured the change in the brains log plus AI activity record. 【F:app/version.json†L1-L5】【F:docs/atlas/brains.md†L1-L24】【F:docs/ai_log/2025-10-21.md†L1-L15】


### PR DESCRIPTION
## Summary
- move `OverlayIngestResult` into `app.ingest` so background futures reuse the same class across Streamlit reruns
- add regression coverage that reloads the UI module before a future resolves and confirms `_add_overlay_payload` accepts the payload
- bump `app/version.json` to v1.2.1d and refresh the accompanying brains, patch notes, and AI log entries

## Testing
- `pytest tests/ui/test_overlay_ingest_queue_async.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68dde18a2e408329862ea82933823791