### PR TITLE
Bootstrap Streamlit entrypoint imports for v1.2.1f

### DIFF
--- a/PATCHLOG.txt
+++ b/PATCHLOG.txt
@@ -29,3 +29,4 @@ Spectra App — Patch Log (append-only)
 - v1.2.0z: Remove FITS time-series epoch offsets from overlay payloads and surface reference epochs in the UI.
 - v1.2.1a: Accept legacy overlay ingest results after reruns and extend async queue regression coverage.
 - v1.2.1 (REF 1.2.1-A01): relocate overlay trace helpers onto OverlayTrace, add a direct `_build_overlay_figure` regression, and roll continuity collateral.
+- v1.2.1f: Bootstrap package imports for Streamlit file entry points so the UI loads without ModuleNotFound errors during cloud deployments.

--- a/app/ui/main.py
+++ b/app/ui/main.py
@@ -22,26 +22,32 @@ import streamlit as st
 from plotly.subplots import make_subplots
 from streamlit.delta_generator import DeltaGenerator
 
-from app.ui.targets import RegistryUnavailableError, render_targets_panel
+if __package__ in (None, ""):
+    import sys
 
-from app._version import get_version_info
-from app.ingest import OverlayIngestResult
-from app.export_manifest import build_manifest
-from app.server.differential import ratio, resample_to_common_grid, subtract
-from app.server.fetch_archives import FetchError, fetch_spectrum
-from app.similarity import (
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+    __package__ = "app.ui"
+
+from .targets import RegistryUnavailableError, render_targets_panel
+
+from .._version import get_version_info
+from ..ingest import OverlayIngestResult
+from ..export_manifest import build_manifest
+from ..server.differential import ratio, resample_to_common_grid, subtract
+from ..server.fetch_archives import FetchError, fetch_spectrum
+from ..similarity import (
     SimilarityCache,
     SimilarityOptions,
     TraceVectors,
     apply_normalization,
     viewport_alignment,
 )
-from app.similarity_panel import render_similarity_panel
-from app.utils.downsample import build_downsample_tiers, build_lttb_downsample
-from app.utils.duplicate_ledger import DuplicateLedger
-from app.utils.flux import flux_percentile_range
-from app.providers import ProviderQuery, search as provider_search
-from app.utils.local_ingest import (
+from ..similarity_panel import render_similarity_panel
+from ..utils.downsample import build_downsample_tiers, build_lttb_downsample
+from ..utils.duplicate_ledger import DuplicateLedger
+from ..utils.flux import flux_percentile_range
+from ..providers import ProviderQuery, search as provider_search
+from ..utils.local_ingest import (
     SUPPORTED_ASCII_EXTENSIONS,
     SUPPORTED_FITS_EXTENSIONS,
     LocalIngestError,

--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.1e",
-  "date_utc": "2025-10-02T00:00:00Z",
-  "summary": "Curate the CALSPEC library with astroquery-backed fetchers and provenance manifests."
+  "version": "v1.2.1f",
+  "date_utc": "2025-10-04T00:00:00Z",
+  "summary": "Allow Streamlit file entry points to load the packaged UI by bootstrapping module imports."
 }

--- a/docs/ai_log/2025-10-21.md
+++ b/docs/ai_log/2025-10-21.md
@@ -1,5 +1,18 @@
 # AI Log — 2025-10-21
 
+## Tasking — Streamlit import bootstrap
+- Ensure Streamlit Cloud can execute `app/ui/main.py` directly without `ModuleNotFoundError` by bootstrapping package imports and updating release collateral.
+
+## Actions & Decisions
+- Prepend the repository root to `sys.path` when `__package__` is unset and switch UI imports to relative form so the module works when imported or executed as a file. 【F:app/ui/main.py†L25-L80】
+- Rolled version metadata, patch notes, and brains documentation to capture the deployment-facing fix. 【F:app/version.json†L1-L5】【F:docs/patch_notes/v1.2.1f.md†L1-L20】【F:docs/atlas/brains.md†L1-L5】
+
+## Verification
+- `pytest tests/ui/test_docs_tab.py -q` 【7f26ef†L1-L2】
+
+## Docs Consulted
+- None.
+
 ## Tasking — Overlay ingest rerun stability
 - Ensure overlay ingest futures created before a Streamlit rerun still resolve successfully and update release collateral.
 

--- a/docs/atlas/brains.md
+++ b/docs/atlas/brains.md
@@ -1,3 +1,7 @@
+# Streamlit import bootstrap — 2025-10-21
+- Detect bare execution of `app.ui.main` in Streamlit Cloud, prepend the repository root to `sys.path`, and normalise imports so the UI loads whether invoked as a package or direct file. 【F:app/ui/main.py†L25-L80】
+- Recorded the continuity update in release metadata and patch notes for downstream automation. 【F:app/version.json†L1-L5】【F:docs/patch_notes/v1.2.1f.md†L1-L20】
+
 # Overlay ingest rerun continuity — 2025-10-21
 - Centralised `OverlayIngestResult` in a shared ingest module so executor futures resolve with a stable class across reruns and `_refresh_ingest_jobs` keeps adding payloads. 【F:app/ingest/results.py†L1-L18】【F:app/ui/main.py†L671-L798】
 - Added regression coverage that reloads the UI module before the future resolves and confirms `_add_overlay_payload` runs without surfacing the "Unexpected ingest result" fallback. 【F:tests/ui/test_overlay_ingest_queue_async.py†L186-L289】

--- a/docs/patch_notes/v1.2.1f.md
+++ b/docs/patch_notes/v1.2.1f.md
@@ -1,0 +1,15 @@
+# Patch Notes — v1.2.1f
+
+## Summary
+- Allow Streamlit Cloud to execute `app/ui/main.py` directly by seeding the repo root on `sys.path` and falling back to package-relative imports when `__package__` is unset. 【F:app/ui/main.py†L25-L51】
+- Refresh release metadata and patch log to capture the import bootstrap hotfix for deployment continuity. 【F:app/version.json†L1-L5】【F:PATCHLOG.txt†L34-L36】
+
+## Details
+1. **Streamlit entry-point bootstrap**
+   - Detect bare-module execution and prepend the repository root to `sys.path`, ensuring absolute package imports continue to resolve in Streamlit's file-runner mode. 【F:app/ui/main.py†L33-L51】
+   - Normalise UI imports to relative form so once the package context is established the module behaves identically when imported or executed directly. 【F:app/ui/main.py†L53-L80】
+2. **Continuity collateral**
+   - Bumped `version.json` to v1.2.1f and recorded the bootstrap change in the patch log for downstream tooling. 【F:app/version.json†L1-L5】【F:PATCHLOG.txt†L34-L36】
+
+## Verification
+- `pytest tests/ui/test_docs_tab.py -q` 【7f26ef†L1-L2】

--- a/tests/ui/test_docs_tab.py
+++ b/tests/ui/test_docs_tab.py
@@ -94,12 +94,12 @@ def test_resolve_patch_metadata_returns_current_patch_line():
     version_info = _version.get_version_info()
     patch_version, patch_summary, patch_line = main_module._resolve_patch_metadata(version_info)
 
-    assert patch_version == "v1.2.1"
+    assert patch_version == "v1.2.1f"
     assert (
         patch_summary
-        == "(REF 1.2.1-A01): relocate overlay trace helpers onto OverlayTrace, add a direct `_build_overlay_figure` regression, and roll continuity collateral."
+        == "Bootstrap package imports for Streamlit file entry points so the UI loads without ModuleNotFound errors during cloud deployments."
     )
     assert (
         patch_line
-        == "v1.2.1 (REF 1.2.1-A01): relocate overlay trace helpers onto OverlayTrace, add a direct `_build_overlay_figure` regression, and roll continuity collateral."
+        == "v1.2.1f: Bootstrap package imports for Streamlit file entry points so the UI loads without ModuleNotFound errors during cloud deployments."
     )


### PR DESCRIPTION
## Summary
- ensure `app/ui/main.py` seeds the repository root on `sys.path` when executed directly so package imports work under Streamlit Cloud
- normalize UI imports to relative form and update versioning collateral for the v1.2.1f hotfix
- refresh the docs tab regression to expect the new patch log summary

## Testing
- pytest tests/ui/test_docs_tab.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e142edf438832982a7122d63fc214f