### PR TITLE
Document SpecViz code alignment audit

### DIFF
--- a/PATCHLOG.txt
+++ b/PATCHLOG.txt
@@ -30,3 +30,5 @@ Spectra App — Patch Log (append-only)
 - v1.2.1a: Accept legacy overlay ingest results after reruns and extend async queue regression coverage.
 - v1.2.1 (REF 1.2.1-A01): relocate overlay trace helpers onto OverlayTrace, add a direct `_build_overlay_figure` regression, and roll continuity collateral.
 - v1.2.1f: Bootstrap package imports for Streamlit file entry points so the UI loads without ModuleNotFound errors during cloud deployments.
+- v1.2.1g: Capture a SpecViz adoption blueprint and refresh release metadata for the research handoff.
+- v1.2.1h: Review Jdaviz GitHub design docs, audit current Spectra App architecture, and outline alignment tasks for the next phase.

--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.1f",
-  "date_utc": "2025-10-04T00:00:00Z",
-  "summary": "Allow Streamlit file entry points to load the packaged UI by bootstrapping module imports."
+  "version": "v1.2.1h",
+  "date_utc": "2025-10-05T00:00:00Z",
+  "summary": "Capture SpecViz GitHub insights, audit Spectra App code, and map alignment tasks."
 }

--- a/docs/ai_log/2025-10-05.md
+++ b/docs/ai_log/2025-10-05.md
@@ -23,3 +23,47 @@
 ## Docs Consulted
 - Spectra App v1.2+ – Handoff Protocol & Task Blueprint. 【F:docs/ai_handoff/Spectra App v1.2+ – Handoff Protocol & Task Blueprint.txt†L1-L35】
 - NIST Atomic Spectra Database help. 【F:docs/mirrored/nist_asd_help/help.meta.json†L1-L6】
+
+## Tasking — v1.2.1g
+- Compile a SpecViz/Jdaviz capability survey and translate it into an adoption blueprint for Spectra App.
+- Update v1.2+ continuity collateral (brains, patch notes, patch log, version) to document the research handoff.
+
+## Actions & Decisions
+- Reviewed Jdaviz quickstart, Specviz import/display/plugin/export guides, Cubeviz/Specviz2D docs, and developer API references to catalogue ingestion pathways, viewer ergonomics, plugin coverage, export flows, and provenance expectations. 【F:docs/research/specviz_adaptation.md†L5-L68】
+- Captured the findings in a gap matrix, phased roadmap, and research backlog to anchor Spectra App planning around SpecViz parity. 【F:docs/research/specviz_adaptation.md†L70-L144】
+- Logged the blueprint in `docs/atlas/brains.md`, published patch notes `v1.2.1g`, bumped `app/version.json`, and extended `PATCHLOG.txt` for traceability. 【F:docs/atlas/brains.md†L205-L210】【F:docs/patch_notes/v1.2.1g.md†L1-L20】【F:app/version.json†L1-L5】【F:PATCHLOG.txt†L34-L38】
+- Cross-referenced JWST archive guidance noting Jdaviz availability within the MAST portal to align our roadmap with community expectations. 【F:docs/mirrored/jwst_docs/accessing-jwst-data/mast-web-access.md†L60-L86】【F:docs/mirrored/jwst_docs/accessing-jwst-data/mast-web-access.meta.json†L1-L6】
+
+## Verification
+- Not applicable (documentation-only research update).
+
+## Outstanding Follow-ups
+- Size the engineering effort for adopting `specutils` data models within our ingest pipeline.
+- Prototype a pluggable panel/tray framework informed by the roadmap.
+- Evaluate Glue integration depth and session persistence strategies noted in the research backlog.
+
+## Docs Consulted
+- Jdaviz quickstart, Specviz, Cubeviz, Specviz2D, Mosviz, export, and API documentation. 【F:docs/research/specviz_adaptation.md†L5-L144】
+- JWST MAST portal guidance referencing Jdaviz tooling. 【F:docs/mirrored/jwst_docs/accessing-jwst-data/mast-web-access.md†L60-L86】【F:docs/mirrored/jwst_docs/accessing-jwst-data/mast-web-access.meta.json†L1-L6】
+
+## Tasking — v1.2.1h
+- Review newly published Jdaviz GitHub developer docs and reconcile them against Spectra App’s current architecture.
+- Produce a code-grounded alignment plan clarifying where to introduce registries, reusable components, helper APIs, and specutils-backed plugins.
+- Refresh continuity collateral (brains, patch notes, patch log, version) to capture the follow-up research milestone.
+
+## Actions & Decisions
+- Downloaded the Jdaviz developer infrastructure, plugin component, UI, and selection references from GitHub to extend the external research baseline. 【F:docs/research/specviz_code_alignment.md†L1-L42】
+- Audited Spectra App’s overlay model, ingest queue, analysis helpers, export manifest, and target gating to document the current implementation footprint. 【F:docs/research/specviz_code_alignment.md†L44-L89】
+- Captured alignment gaps and next steps bridging Specviz patterns with Spectra App’s Streamlit architecture, informing future engineering spikes. 【F:docs/research/specviz_code_alignment.md†L91-L128】
+- Logged the audit in brains, patch notes `v1.2.1h`, version metadata, and patch log to satisfy the v1.2+ continuity contract. 【F:docs/atlas/brains.md†L86-L94】【F:docs/patch_notes/v1.2.1h.md†L1-L11】【F:app/version.json†L1-L5】【F:PATCHLOG.txt†L34-L35】
+
+## Verification
+- Not applicable (documentation-only update).
+
+## Outstanding Follow-ups
+- Prototype the `panel_registry` abstraction and notebook helper API outlined in the alignment plan.
+- Investigate capturing Plotly ROI selections as `specutils.SpectralRegion` exports for provenance parity.
+- Evaluate specutils-backed fitting/smoothing plugins to replace bespoke NumPy pipelines.
+
+## Docs Consulted
+- Jdaviz developer documentation on infrastructure, plugin components, UI framework, and selections. 【F:docs/research/specviz_code_alignment.md†L1-L42】

--- a/docs/atlas/brains.md
+++ b/docs/atlas/brains.md
@@ -78,7 +78,17 @@
 ## Byte-string FITS unit coercion — 2025-10-10
 - Normalise FITS wavelength/time unit hints by decoding header bytes through `_coerce_header_value` before canonical checks so `TUNIT`/`CUNIT` byte strings match aliases. 【F:app/server/ingest_fits.py†L233-L305】【F:app/server/ingest_fits.py†L751-L799】
 - Preserve time-frame detection by case-folding decoded hints, keeping BJD offsets intact when headers arrive as byte strings. 【F:app/server/ingest_fits.py†L233-L305】
+
+# SpecViz adaptation blueprint — 2025-10-05
+- Captured a structured survey of Jdaviz delivery modes, ingestion patterns, viewer ergonomics, plugin coverage, export surfaces, and provenance expectations to guide parity planning. 【F:docs/research/specviz_adaptation.md†L5-L68】
+- Mapped the survey into a capability gap matrix plus phased roadmap that sequences infrastructure alignment, feature parity, and advanced JWST-aware integrations for Spectra App. 【F:docs/research/specviz_adaptation.md†L70-L133】
+- Logged follow-up research questions around Glue integration depth, specutils adoption, plugin sandboxing, and session persistence strategies. 【F:docs/research/specviz_adaptation.md†L135-L144】
 - Locked regression coverage on byte-string table headers to ensure wavelength and time ingestion keep reporting the right `axis_kind`. 【F:tests/server/test_ingest_fits.py†L375-L395】【F:tests/server/test_ingest_fits.py†L442-L466】
+
+## SpecViz code alignment audit — 2025-10-05
+- Reviewed the latest Jdaviz GitHub developer docs covering infrastructure, plugin components, UI design, and selection mechanics to ground follow-up planning. 【F:docs/research/specviz_code_alignment.md†L1-L42】
+- Documented the current Spectra App overlay model, ingest queue, analysis stacks, manifest export, and target gating to anchor parity work in concrete modules. 【F:docs/research/specviz_code_alignment.md†L44-L89】
+- Highlighted registry, component, helper API, selection persistence, and specutils integration tasks that align Spectra App with Specviz patterns. 【F:docs/research/specviz_code_alignment.md†L91-L128】
 
 ## Example browser provider persistence — 2025-10-11
 - Only seed the provider multiselect with defaults when the session key is unset so Streamlit relies on the stored selection thereafter, eliminating rerun warnings. 【F:app/ui/example_browser.py†L192-L210】

--- a/docs/patch_notes/v1.2.1g.md
+++ b/docs/patch_notes/v1.2.1g.md
@@ -1,0 +1,16 @@
+# Patch Notes — v1.2.1g
+
+## Summary
+- Compiled a SpecViz adaptation blueprint covering Jdaviz capabilities, Spectra App gaps, and a phased roadmap for adoption. 【F:docs/research/specviz_adaptation.md†L3-L133】
+- Recorded the research outcome in the brains log and refreshed release metadata to keep continuity collateral aligned. 【F:docs/atlas/brains.md†L205-L210】【F:app/version.json†L1-L5】【F:PATCHLOG.txt†L37-L38】
+
+## Details
+1. **SpecViz survey & plan**
+   - Summarised Jdaviz distribution modes, ingestion pathways, viewer ergonomics, plugin ecosystem, export surfaces, and provenance expectations as a reference for Spectra App. 【F:docs/research/specviz_adaptation.md†L5-L68】
+   - Translated findings into a capability gap matrix, phased roadmap, and research backlog to guide iterative adoption. 【F:docs/research/specviz_adaptation.md†L70-L144】
+2. **Continuity collateral**
+   - Logged the adaptation blueprint in `docs/atlas/brains.md` for institutional memory. 【F:docs/atlas/brains.md†L205-L210】
+   - Bumped `app/version.json` to v1.2.1g and appended the patch log entry for downstream automation. 【F:app/version.json†L1-L5】【F:PATCHLOG.txt†L37-L38】
+
+## Verification
+- Not applicable (documentation-only research update).

--- a/docs/patch_notes/v1.2.1h.md
+++ b/docs/patch_notes/v1.2.1h.md
@@ -1,0 +1,9 @@
+# Spectra App v1.2.1h — SpecViz code alignment audit
+
+## Summary
+- Reviewed the latest Jdaviz GitHub design docs and captured actionable takeaways for Spectra App. 【F:docs/research/specviz_code_alignment.md†L1-L42】
+- Catalogued current overlay, ingest, analysis, and provenance architecture across the codebase to ground SpecViz parity work. 【F:docs/research/specviz_code_alignment.md†L44-L89】
+- Defined alignment opportunities and immediate tasks bridging SpecViz patterns with our implementation. 【F:docs/research/specviz_code_alignment.md†L91-L128】
+
+## Verification
+- Documentation-only update (no automated tests executed).

--- a/docs/research/specviz_adaptation.md
+++ b/docs/research/specviz_adaptation.md
@@ -1,0 +1,98 @@
+# SpecViz Adaptation Blueprint
+
+## 1. External Capability Survey
+
+### 1.1 Platform scope and delivery
+- **Multi-surface distribution**: Jdaviz applications run inside notebooks, as standalone browser apps launched via the `jdaviz` CLI, and embed consistently across environments, enabling the same UI to cover desktop, lab, and web workflows.[^quickstart]
+- **Configuration presets**: Specviz (1D spectra), Cubeviz (data cubes + extracted spectra), Specviz2D (slit and IFU cutouts), Mosviz (multi-object sets), Imviz (2D images), and Rampviz provide tuned layouts over a shared engine so teams can mix viewers to match data shapes.[^specviz-index]
+
+### 1.2 Data ingestion expectations
+- **Spectrum-first contract**: Specviz only accepts inputs convertible to `specutils.Spectrum` objects, delegating parsing to `specutils` while keeping the viewer API coherent.[^specviz-import]
+- **Multiple entry points**: Data load flows include CLI arguments, a GUI import dialog, and helper APIs (`Specviz.load_data`) that accept file paths, in-memory spectra, NumPy arrays with units, and JWST `stdatamodels` products.[^specviz-import]
+- **Reusable products**: Documentation calls out “Jdaviz-readable products” guidelines so upstream pipelines can emit compliant artifacts that slot directly into viewers.[^user-guide-products]
+
+### 1.3 Visualization and interactivity
+- **Glue-powered viewers**: Display tooling leans on Glue’s data layer model, letting users toggle datasets per viewer, detach or reload layers, and coordinate UI state with plugin dropdowns.[^specviz-display]
+- **Cursor + tool affordances**: Built-in controls cover cursor readouts, zoom history, box/x-range zoom, pan variants, axis lock, and programmable `set_limits`/`reset_limits` helpers for automation.[^specviz-display]
+- **Region semantics**: Spectral subsets rely on Glue ROIs and propagate into plugins, exports, and API helpers for reproducible slice definitions.[^specviz-display]
+
+### 1.4 Plugin ecosystem
+- **Plugin tray architecture**: Analysis actions live in a tray surfaced by the plugin icon; outputs add new spectra/layers automatically while sharing a data menu for visibility control.[^specviz-plugins]
+- **Specviz toolchain**: Core plugins span metadata/plot options, subset tools, markers, Gaussian smoothing, Astropy-powered model fitting (with equation editor + fitter choice), unit conversion, line lists, and line analysis, each scriptable through helper APIs.[^specviz-plugins]
+- **Cubeviz & Specviz2D additions**: Cubeviz introduces collapse, spectral extraction, aperture photometry, moment maps, slicing, sonification, and region exports; Specviz2D focuses on slit extraction and 2D-specific plugin variants.[^cubeviz-plugins][^specviz2d-index]
+- **Extensibility registry**: The reference API exposes helper classes, viewer registries, parser hooks, and plugin modules per configuration, reinforcing a modular registration system for new tools.[^reference-api]
+
+### 1.5 Export and state management
+- **Data extraction**: `get_spectra`/`get_data` return `Spectrum` objects (with subset masks) for notebook reuse; plugin tables (e.g., model fits, spectral regions, marker catalogs) offer export helpers back to Python or disk (ECSV).[^specviz-export]
+- **Session persistence**: Users can save viewer state and plugin outputs, and documentation emphasizes round-tripping derived products into upstream workflows.[^user-guide-session]
+
+### 1.6 Scientific coverage and provenance
+- **JWST focus**: Mode tables enumerate supported NIRSpec, MIRI, NIRISS, and other JWST observing setups, illustrating how viewer presets adapt to instrument metadata.[^jwst-modes]
+- **Citation guidance**: The project publishes Zenodo DOIs and attribution text, embedding citation practices into user documentation and export flows.[^jdaviz-citation]
+
+## 2. Gap Analysis for Spectra App
+
+| Capability | Jdaviz Pattern | Spectra App Opportunity |
+| --- | --- | --- |
+| Data ingestion | Spectrum-centric contract with CLI/GUI/API loaders | Define canonical ingest API that wraps our FITS/table handlers and mirrors helper ergonomics for notebooks & automation. |
+| Viewer ergonomics | Glue-backed layer toggles, zoom history, ROI propagation | Audit our Plotly viewers for parity: add layer menus, zoom stacks, and ROI export hooks aligned with Glue semantics. |
+| Analysis plugins | Tray-based plugins covering smoothing, model fits, line tools | Refactor Streamlit sidebar into pluggable panels with shared data selectors, using Astropy/specutils for heavy lifting. |
+| Export surface | Consistent Python-returning helpers and ECSV dumps | Formalize `get_overlay_data`/`export_*` APIs that emit standardized tables & spectra, preserving subset masks and provenance. |
+| Configuration presets | Named layouts for spectrum, cube, MOS, 2D use cases | Introduce layout profiles (spectral, differential, cube) that toggle widgets and defaults without code forks. |
+| JWST instrument alignment | Documented mode support & metadata-driven defaults | Tie our registry to JWST mode metadata so available tools, unit defaults, and warnings track instrument context. |
+| Provenance & citation | Built-in citation copy + DOI references | Extend export manifest to include citation templates and remind users about data/tool attribution. |
+
+## 3. Adoption Roadmap
+
+### Phase 0 — Discovery (1–2 sprints)
+1. Catalogue our current ingest paths, viewer widgets, and analysis helpers against the matrix above; flag blockers for Spectrum-object parity.
+2. Prototype a minimal helper class mirroring `Specviz.load_data`/`get_data`, backed by our overlay store, to validate API ergonomics in notebooks.
+3. Inventory existing plugin-like panels (e.g., overlay math, line lists) and map them to a tray framework concept document.
+
+### Phase 1 — Infrastructure alignment (3–4 sprints)
+1. Ship a pluggable panel framework: registerable plugin objects with lifecycle hooks, shared data selectors, and policy for derived layer naming.
+2. Normalize ingestion around Spectrum-like dataclasses, including JWST datamodel adapters and specutils compatibility shims.
+3. Implement viewer layer menus, zoom history, and ROI serialization mirroring Glue behavior, ensuring UI contract coverage.
+
+### Phase 2 — Feature parity (4–6 sprints)
+1. Port high-value plugins (Gaussian smooth, model fitting, unit conversion, line lists/analysis) using Astropy components to match Specviz outputs.
+2. Wire export APIs for spectra, subsets, model tables, and markers with ECSV/ASDF outputs and provenance stamps.
+3. Introduce configuration presets that rearrange viewers/controls for spectral, cube, and MOS workflows, gated by metadata heuristics.
+
+### Phase 3 — Advanced integration (ongoing)
+1. Embed JWST mode awareness (unit defaults, warning banners, plugin enablement) derived from an instrument capability table.
+2. Offer helper APIs for saving/loading session state, aligning with Jdaviz’s session export guidance for reproducibility.
+3. Publish citation snippets and DOIs alongside exports, mirroring Jdaviz’s documentation cues.
+
+## 4. Research Backlog & Open Questions
+- **Glue integration depth**: Evaluate whether adopting Glue’s data structures directly would simplify ROI propagation or if a lighter compatibility layer suffices.
+- **Specutils adoption plan**: Determine scope for leveraging specutils (e.g., uncertainties, spectral regions) without overhauling existing pandas/NumPy pipelines.
+- **Plugin sandboxing**: Define security and performance expectations if we allow user-authored plugins, inspired by Jdaviz’s registry-based approach.
+- **Session persistence UX**: Decide between file-based session dumps or database-backed histories, referencing Jdaviz’s save-state mechanics.
+
+## 5. Source Links
+- Quickstart & CLI usage: <https://jdaviz.readthedocs.io/en/latest/quickstart.html>
+- Specviz data loading: <https://jdaviz.readthedocs.io/en/latest/specviz/import_data.html>
+- Specviz display tooling: <https://jdaviz.readthedocs.io/en/latest/specviz/displaying.html>
+- Specviz plugins: <https://jdaviz.readthedocs.io/en/latest/specviz/plugins.html>
+- Specviz exports: <https://jdaviz.readthedocs.io/en/latest/specviz/export_data.html>
+- Cubeviz plugins and exports: <https://jdaviz.readthedocs.io/en/latest/cubeviz/plugins.html>
+- Specviz2D overview: <https://jdaviz.readthedocs.io/en/latest/specviz2d/index.html>
+- Mosviz overview: <https://jdaviz.readthedocs.io/en/latest/mosviz/index.html>
+- Developer API registry: <https://jdaviz.readthedocs.io/en/latest/reference/api.html>
+- JWST mode support: <https://jdaviz.readthedocs.io/en/latest/index_jwst_modes.html>
+- Citation guidance: <https://jdaviz.readthedocs.io/en/latest/index_citation.html>
+
+[^quickstart]: “Quickstart,” *Jdaviz Documentation*. <https://jdaviz.readthedocs.io/en/latest/quickstart.html>
+[^specviz-index]: “Specviz,” *Jdaviz Documentation*. <https://jdaviz.readthedocs.io/en/latest/specviz/index.html>
+[^specviz-import]: “Importing Data Into Specviz,” *Jdaviz Documentation*. <https://jdaviz.readthedocs.io/en/latest/specviz/import_data.html>
+[^user-guide-products]: “Creating Jdaviz-readable Products,” *Jdaviz User Guide*. <https://jdaviz.readthedocs.io/en/latest/index_using_jdaviz.html#creating-jdaviz-readable-products>
+[^specviz-display]: “Displaying Spectra,” *Jdaviz Documentation*. <https://jdaviz.readthedocs.io/en/latest/specviz/displaying.html>
+[^specviz-plugins]: “Data Analysis Plugins,” *Jdaviz Documentation*. <https://jdaviz.readthedocs.io/en/latest/specviz/plugins.html>
+[^cubeviz-plugins]: “Data Analysis Plugins (Cubeviz),” *Jdaviz Documentation*. <https://jdaviz.readthedocs.io/en/latest/cubeviz/plugins.html>
+[^specviz2d-index]: “Specviz2D,” *Jdaviz Documentation*. <https://jdaviz.readthedocs.io/en/latest/specviz2d/index.html>
+[^reference-api]: “Reference/API,” *Jdaviz Documentation*. <https://jdaviz.readthedocs.io/en/latest/reference/api.html>
+[^specviz-export]: “Exporting Data From Specviz,” *Jdaviz Documentation*. <https://jdaviz.readthedocs.io/en/latest/specviz/export_data.html>
+[^user-guide-session]: “Saving the State of Your Jdaviz Session,” *Jdaviz User Guide*. <https://jdaviz.readthedocs.io/en/latest/index_using_jdaviz.html#saving-the-state-of-your-jdaviz-session>
+[^jwst-modes]: “JWST Instrument Modes in Jdaviz,” *Jdaviz Documentation*. <https://jdaviz.readthedocs.io/en/latest/index_jwst_modes.html>
+[^jdaviz-citation]: “Citing Jdaviz,” *Jdaviz Documentation*. <https://jdaviz.readthedocs.io/en/latest/index_citation.html>

--- a/docs/research/specviz_code_alignment.md
+++ b/docs/research/specviz_code_alignment.md
@@ -1,0 +1,61 @@
+# SpecViz Adaptation — Code Alignment Review
+
+## 1. GitHub documentation takeaways
+- **Layered application engine** — The `Jdaviz Design and Infrastructure` note shows how each viewer layout, plugin registry, and event hub lives in a shared application engine that orchestrates glue-jupyter widgets while pushing reusable logic upstream.[^jdaviz-infrastructure]
+- **Vue/traitlet component pattern** — Plugin components are split into Python mixins plus `.vue` templates registered at startup so reusable controls (subset selectors, model fit editors, etc.) stay reactive without duplicating traitlet wiring.[^jdaviz-plugin-components]
+- **Glupyter separation of state vs. view** — The UI design guide emphasises keeping widget state in Python traitlets while delegating rendering to Vuetify templates, enabling procedural control in notebooks alongside GUI interactions.[^jdaviz-ui-overview]
+- **Subset propagation as spectral regions** — The selection primer highlights that Specviz converts interactive selections into `specutils.SpectralRegion` masks returned through helper APIs, ensuring plugins and exports consume identical definitions.[^jdaviz-selections]
+
+## 2. Spectra App baseline (2025-10)
+### 2.1 Overlay data model and rendering
+- `OverlayTrace` keeps every loaded series (label, units, provenance, cached down-samples) in session state so tables, charts, and exports share a canonical payload.[^spectra-overlay-trace]
+- Sampling honours viewport bounds, tiered down-samples, and LTTB fallbacks before streaming vectors to similarity metrics or Plotly figures, echoing Specviz’s need for responsive rendering with dense spectra.[^spectra-overlay-sample]
+
+### 2.2 Async ingestion and duplicate control
+- The ingest queue lazily seeds a session-scoped `ThreadPoolExecutor`, normalises queued items, and records progress snapshots for the sidebar “Overlay downloads” panel.[^spectra-ingest-runtime]
+- Each job resolves archives, annotates provenance (`ingest.method`, URLs, cache hits), then hands payloads to `_add_overlay_payload`, which also walks any companion traces and records ledger fingerprints to block duplicates.[^spectra-ingest-prep]
+- Local uploads detect ASCII/FITS/ZIP payloads, auto-decompress when required, and fall back to dense parsers for million-row tables while synthesising user-facing labels and summaries.[^spectra-local-ingest]
+
+### 2.3 Analysis pipelines
+- The similarity stack memoises pairwise metrics behind `SimilarityCache`, normalises traces per user choice, and renders ribbon + matrix summaries via `render_similarity_panel` tabs.[^spectra-similarity]
+- Differential maths resamples pairs onto a shared grid and exposes subtraction/ratio helpers that downstream panels already call.[^spectra-differential]
+
+### 2.4 Export and provenance
+- `build_manifest` gathers export timestamps, version metadata, continuity links, and per-series counts so CSV/PNG dumps stay auditable.[^spectra-manifest]
+- The duplicate ledger hashes payloads to disk, tracks session IDs, and offers purge hooks so reruns reset state, mirroring Specviz’s emphasis on reproducible ingestion.[^spectra-duplicate-ledger]
+
+### 2.5 Target registry governance
+- The targets panel scans manifest axis hints, filters to 1-D-compatible products, and surfaces user-facing rejection reasons (e.g., JWST CALINTS cubes) before enabling overlay actions.[^spectra-targets]
+
+## 3. Alignment opportunities
+| Specviz insight | Spectra baseline | Adoption tasks |
+| --- | --- | --- |
+| Application engine manages layouts + plugin registry.[^jdaviz-infrastructure] | Streamlit entrypoint imports `app.ui.main` and renders everything inside a monolithic module.[^spectra-main-entry] | Extract a registry-driven panel manager so sidebar/workspace panels register like Jdaviz plugins, enabling mode-specific layouts. |
+| Vue/traitlet components encapsulate reusable controls.[^jdaviz-plugin-components] | Controls are repeated across sidebar forms and tabs (normalisation widgets, overlay toggles).[^spectra-main-controls] | Introduce reusable component classes (e.g., overlay visibility, normalization) to reduce duplication and prepare for notebook embedding. |
+| Traitlet-backed state enables notebook automation.[^jdaviz-ui-overview] | Session state and helper functions exist but lack a thin API for notebook users (`SpectraApp.load_data`, `SpectraApp.get_overlays`).[^spectra-overlay-trace][^spectra-ingest-prep] | Wrap ingest/add/export flows in helper classes returning dataclasses so notebooks can control the app without Streamlit. |
+| Spectral selections become `specutils.SpectralRegion` masks fed into helpers.[^jdaviz-selections] | ROI selection does not yet persist beyond Plotly interactions; exports/manifests lack subset masks.[^spectra-overlay-sample] | Store Plotly selection bounds in session state, convert to `specutils` regions, and extend manifest/export payloads to include them. |
+| Plugins share specutils/astropy pipelines for smoothing, fitting, etc.[^jdaviz-infrastructure] | Similarity/differential math live in bespoke modules without specutils integration.[^spectra-similarity][^spectra-differential] | Evaluate migrating normalization/fitting to `specutils` routines, exposing plugin-style hooks for advanced analysis. |
+
+## 4. Immediate next steps
+1. Draft a `panel_registry` module that mirrors Specviz’s plugin registration (ID, label, render callable) and refactor overlay/similarity/differential panels to register themselves before render.[^spectra-main-entry]
+2. Prototype a `SpectraWorkspace` helper exposing `load_overlay`, `list_overlays`, and `export_view` methods backed by `_add_overlay_payload` and `build_manifest`, enabling notebook parity with Specviz helpers.[^spectra-ingest-prep][^spectra-manifest]
+3. Capture viewport-derived selections inside `OverlayTrace` and serialise them into export manifests while experimenting with `specutils.SpectralRegion` for ROI persistence.[^spectra-overlay-trace][^spectra-overlay-sample]
+4. Spike a specutils-based fitting plugin by wrapping similarity normalization options around `specutils.manipulation` utilities and comparing outputs against existing NumPy routines.[^spectra-similarity]
+5. Update docs/UI contract once the registry abstraction lands, ensuring layout and provenance promises stay aligned with the v1.2+ continuity checklist.
+
+[^jdaviz-infrastructure]: “Jdaviz Design and Infrastructure,” *Jdaviz Docs* (GitHub). <https://raw.githubusercontent.com/spacetelescope/jdaviz/main/docs/dev/infrastructure.rst>
+[^jdaviz-plugin-components]: “Plugin Components,” *Jdaviz Docs* (GitHub). <https://raw.githubusercontent.com/spacetelescope/jdaviz/main/docs/dev/ui_plugin_components.rst>
+[^jdaviz-ui-overview]: “Glupyter Framework Overview,” *Jdaviz Docs* (GitHub). <https://raw.githubusercontent.com/spacetelescope/jdaviz/main/docs/dev/ui_description.rst>
+[^jdaviz-selections]: “Specviz Selections,” *Jdaviz Docs* (GitHub). <https://raw.githubusercontent.com/spacetelescope/jdaviz/main/docs/dev/specviz_selection.rst>
+[^spectra-overlay-trace]: `OverlayTrace` data model defining shared metadata for loaded spectra. 【F:app/ui/main.py†L63-L135】
+[^spectra-overlay-sample]: `OverlayTrace.sample` handles viewport filtering, tiered down-samples, and LTTB fallbacks. 【F:app/ui/main.py†L102-L171】
+[^spectra-ingest-runtime]: Ingest runtime initialisation and job tracking for the overlay queue. 【F:app/ui/main.py†L550-L833】
+[^spectra-ingest-prep]: Ingest payload preparation adds provenance and duplicate protection before registering overlays. 【F:app/ui/main.py†L587-L1228】
+[^spectra-local-ingest]: Local ingestion detects formats, decompresses archives, and synthesises overlay metadata. 【F:app/utils/local_ingest.py†L17-L200】
+[^spectra-similarity]: Similarity metrics, caching, and Streamlit rendering pipeline. 【F:app/similarity.py†L1-L200】【F:app/similarity_panel.py†L1-L118】
+[^spectra-differential]: Differential helpers resample traces and compute subtraction/ratio. 【F:app/server/differential.py†L1-L33】
+[^spectra-manifest]: Export manifest builder captures version metadata and per-series counts. 【F:app/export_manifest.py†L1-L55】
+[^spectra-duplicate-ledger]: Duplicate ledger hashes payloads and scopes entries per session. 【F:app/utils/duplicate_ledger.py†L1-L38】
+[^spectra-targets]: Target panel analyses manifest axis hints to gate overlay enablement. 【F:app/ui/targets.py†L1-L200】
+[^spectra-main-entry]: Streamlit entry point imports `app.ui.main` and defers to `render()`. 【F:app/app_merged.py†L1-L74】【F:app/ui/entry.py†L1-L19】
+[^spectra-main-controls]: Overlay, normalization, and analysis controls share duplicated widget wiring inside `app/ui/main.py`. 【F:app/ui/main.py†L883-L1276】【F:app/ui/main.py†L3097-L3190】


### PR DESCRIPTION
## Summary
- add a SpecViz code-alignment research note that maps new Jdaviz GitHub developer docs onto the current Spectra App architecture
- update patch notes, brains, version metadata, and patch log for v1.2.1h and log the research activity in the AI log

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68e2fe18c6608329b36db450112a57c1