### PR TITLE
Document SpecViz-inspired improvement backlog

### DIFF
--- a/PATCHLOG.txt
+++ b/PATCHLOG.txt
@@ -31,3 +31,4 @@ Spectra App — Patch Log (append-only)
 - v1.2.1 (REF 1.2.1-A01): relocate overlay trace helpers onto OverlayTrace, add a direct `_build_overlay_figure` regression, and roll continuity collateral.
 - v1.2.1f: Bootstrap package imports for Streamlit file entry points so the UI loads without ModuleNotFound errors during cloud deployments.
 - v1.2.1g: Document the SpecViz adaptation blueprint and roadmap so the team can plan ingestion, viewer, and plugin parity work.
+- v1.2.1h: Outline SpecViz-inspired ingestion, viewer, and plugin improvements so planning collateral guides upcoming parity work.

--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.1g",
-  "date_utc": "2025-10-22T00:00:00Z",
-  "summary": "Document the SpecViz adaptation blueprint to guide ingestion, viewer, and plugin parity work."
+  "version": "v1.2.1h",
+  "date_utc": "2025-10-23T00:00:00Z",
+  "summary": "Outline SpecViz-inspired ingestion, viewer, and plugin improvements for the Spectra App roadmap."
 }

--- a/docs/ai_log/2025-10-23.md
+++ b/docs/ai_log/2025-10-23.md
@@ -1,0 +1,16 @@
+# AI Log — 2025-10-23
+
+## Tasking — SpecViz parity backlog
+- Outline SpecViz-inspired improvements that guide Spectra App's ingestion, viewer, analysis, and automation roadmap.
+
+## Actions & Decisions
+- Authored a SpecViz-inspired backlog capturing ingestion, viewer, plugin, and automation enhancements so planning artifacts steer upcoming parity work. 【F:docs/research/specviz_improvement_backlog.md†L1-L74】
+- Rolled release metadata, patch notes, and patch log entries so the platform advertises the new planning deliverable. 【F:app/version.json†L1-L5】【F:docs/patch_notes/v1.2.1h.md†L1-L17】【F:PATCHLOG.txt†L33-L34】
+- Reviewed MAST API product metadata fields to ensure remote ingestion considerations remain aligned with backlog provenance requirements. 【F:docs/mirrored/mast_api/MastApiTutorial.html.md†L1-L22】【F:docs/mirrored/mast_api/MastApiTutorial.html.meta.json†L1-L7】
+
+## Verification
+- Not applicable (documentation-only change).
+
+## Docs Consulted
+- `docs/mirrored/mast_api/MastApiTutorial.html.md` (MAST product metadata columns). 【F:docs/mirrored/mast_api/MastApiTutorial.html.md†L1-L22】【F:docs/mirrored/mast_api/MastApiTutorial.html.meta.json†L1-L7】
+- SpecViz documentation on GitHub (see references embedded in the backlog).

--- a/docs/atlas/brains.md
+++ b/docs/atlas/brains.md
@@ -1,3 +1,7 @@
+# SpecViz improvement backlog planning — 2025-10-23
+- Logged SpecViz-inspired ingestion, viewer, plugin, and automation backlog items so the roadmap targets parity work with clear provenance ties. 【F:docs/research/specviz_improvement_backlog.md†L1-L74】
+- Updated release metadata, patch notes, and patch log to advertise the planning deliverable across the app surfaces. 【F:app/version.json†L1-L5】【F:docs/patch_notes/v1.2.1h.md†L1-L17】【F:PATCHLOG.txt†L33-L34】
+
 # Streamlit import bootstrap — 2025-10-21
 - Detect bare execution of `app.ui.main` in Streamlit Cloud, prepend the repository root to `sys.path`, and normalise imports so the UI loads whether invoked as a package or direct file. 【F:app/ui/main.py†L25-L80】
 - Recorded the continuity update in release metadata and patch notes for downstream automation. 【F:app/version.json†L1-L5】【F:docs/patch_notes/v1.2.1f.md†L1-L20】

--- a/docs/patch_notes/v1.2.1h.md
+++ b/docs/patch_notes/v1.2.1h.md
@@ -1,0 +1,15 @@
+# Patch Notes — v1.2.1h
+
+## Summary
+- Outlined SpecViz-inspired backlog items covering ingestion, viewer interactions, and analysis plugins to steer Spectra App improvements. 【F:docs/research/specviz_improvement_backlog.md†L1-L74】
+- Updated release metadata so platform surfaces the new planning deliverable. 【F:app/version.json†L1-L5】
+
+## Details
+1. **SpecViz improvement backlog**
+   - Captured ingestion enhancements that align our loaders, provenance, and JWST mode handling with SpecViz expectations. 【F:docs/research/specviz_improvement_backlog.md†L7-L33】
+   - Documented viewer, interaction, and plugin priorities plus collaboration hooks modeled after SpecViz's helper ecosystem. 【F:docs/research/specviz_improvement_backlog.md†L35-L74】
+2. **Release collateral**
+   - Bumped `app/version.json` to v1.2.1h with a summary highlighting the SpecViz-inspired backlog. 【F:app/version.json†L1-L5】
+
+## Verification
+- Not applicable (documentation-only change).

--- a/docs/research/specviz_improvement_backlog.md
+++ b/docs/research/specviz_improvement_backlog.md
@@ -1,0 +1,59 @@
+# SpecViz-Inspired Improvement Backlog
+
+## Purpose
+- Translate SpecViz's mature 1D spectroscopy workflows into actionable upgrades for Spectra App so our roadmap targets proven interaction models and helper APIs. [1][2]
+- Highlight near-term improvements that de-risk ingestion, visualization, and analysis parity while respecting Spectra App's Streamlit-first architecture. [1][3]
+
+## Ingestion Enhancements
+1. **Adopt SpecViz loader affordances**
+   - Offer separate UI affordances for single-file, directory, and helper-driven loads mirroring SpecViz's CLI/UI/API entry points so observers can stage whole programs quickly. [1]
+   - Provide load options (`concat_by_file`, `stash_in_catalog`, remote URI fetch) exposed both in the sidebar and helper API, keeping ingestion reproducible. [1][3]
+2. **Specutils-native payload contracts**
+   - Normalize all internal ingestion outputs to `Spectrum1D`/`SpectrumList` containers and surface coercion errors clearly, leveraging SpecViz's helper validations as guidance. [1][3]
+   - When ingestion fails, capture the offending header/column diagnostics in provenance (similar to SpecViz's toast + helper exceptions) so analysts can remediate upstream files. [1]
+3. **Mode-aware routing**
+   - Detect JWST mode/product mismatches during ingest (e.g., MIRI MRS cubes) and steer users toward alternative workspaces before rendering errors propagate, following SpecViz's mode matrix. [4]
+   - Persist accepted/rejected mode decisions in provenance to reinforce reproducibility when sharing sessions. [4]
+
+## Viewer & Interaction Upgrades
+1. **Layer-aware viewer controls**
+   - Mirror SpecViz's layer list with per-trace visibility, styling, and unlink actions to reduce reliance on sidebar toggles. [2]
+   - Introduce hover/cursor readouts and ROI subset tools that sync with exported metadata, honoring SpecViz's glue-backed interactions. [2]
+2. **Toolbar modernization**
+   - Expand the toolbar with reset, autoscale, zoom box, and pan controls plus keyboard shortcuts, matching SpecViz's Matplotlib/Glue toolset to quicken exploratory analysis. [2]
+   - Provide helper endpoints (`set_limits`, `link_limits`) so notebooks and regression fixtures can assert viewer state deterministically. [3]
+3. **Unit conversion & scaling**
+   - Embed a unit conversion widget that propagates axis and flux unit changes across visible traces without mutating source data, borrowing SpecViz's plugin UX. [5]
+   - Cache user-selected unit preferences per session and expose them through our helper API so automation runs can align outputs. [3][5]
+
+## Analysis & Plugin Parity
+1. **Core plugin tranche**
+   - Prioritize Gaussian smoothing, line list management, and redshift slider plugins that deliver immediate science value and mirror SpecViz's defaults. [5]
+   - Ensure each plugin registers derived layers/data tables with provenance hooks so export manifests stay audit-ready. [5]
+2. **Model fitting workflow**
+   - Provide a component builder similar to SpecViz's model fitting plugin: selectable Astropy models, editable initial guesses, and fit diagnostics exported alongside plots. [5]
+   - Integrate helper calls to rerun fits programmatically, enabling regression tests to replay scenarios without UI driving. [3]
+3. **Export surfaces**
+   - Replicate SpecViz's export plugin paths (spectrum subsets, region definitions, viewer captures) and tie them to Spectra App's existing manifest schema. [1][5]
+   - Document the export behaviors with parity tables so operations knows which artefacts match SpecViz outputs and where divergences remain. [5]
+
+## Collaboration & Automation
+1. **Helper API coverage**
+   - Publish a `spectra.helpers.SpecvizCompat` module that wraps ingestion, viewer state, plugin triggers, and export retrieval mirroring SpecViz helper signatures for low-friction migration. [3]
+   - Log helper calls into provenance (similar to SpecViz's hub events) so shared sessions reveal the scripted steps behind derived products. [3]
+2. **Test & contract extensions**
+   - Expand regression suites to capture viewer state (limits, subsets) and plugin outputs, using SpecViz tutorial scenarios as fixtures to ensure parity. [2][5]
+   - Update the UI contract to enumerate toolbar expectations, layer list controls, and plugin affordances before implementing UI changes, minimizing regressions. [2]
+3. **Documentation alignment**
+   - Mirror SpecViz's documentation structure—importing data, displaying spectra, plugin guides, API usage—and link Spectra App equivalents so users recognize familiar workflows. [1][2][3][5]
+   - Add citation guidance referencing Spectra App's Zenodo/DOI once available, following SpecViz's approach to crediting software releases. [6]
+
+---
+
+**References**
+1. SpecViz data ingestion documentation — https://github.com/spacetelescope/jdaviz/blob/main/docs/specviz/import_data.rst
+2. SpecViz display interactions — https://github.com/spacetelescope/jdaviz/blob/main/docs/specviz/displaying.rst
+3. SpecViz helper implementation — https://github.com/spacetelescope/jdaviz/blob/main/jdaviz/configs/specviz/helper.py
+4. JWST mode support matrix — https://github.com/spacetelescope/jdaviz/blob/main/docs/index_jwst_modes.rst
+5. SpecViz plugin catalog — https://github.com/spacetelescope/jdaviz/blob/main/docs/specviz/plugins.rst
+6. SpecViz citation guidance — https://github.com/spacetelescope/jdaviz/blob/main/docs/index_citation.rst


### PR DESCRIPTION
## Summary
- add a SpecViz-inspired improvement backlog that prioritizes ingestion, viewer, plugin, and automation upgrades for Spectra App
- refresh release collateral (version manifest, patch notes, patch log, brains) to surface the new planning deliverable
- log the documentation work in the daily AI activity record

## Testing
- not run (documentation-only)


------
https://chatgpt.com/codex/tasks/task_e_68e319673dc88329a474872b43cffadf