### PR TITLE
Document SpecViz parity matrix and jdaviz attribution

### DIFF
--- a/PATCHLOG.txt
+++ b/PATCHLOG.txt
@@ -34,3 +34,4 @@ Spectra App — Patch Log (append-only)
 - v1.2.1h: Outline SpecViz-inspired ingestion, viewer, and plugin improvements so planning collateral guides upcoming parity work.
 - v1.2.1i: Normalise local uploads to Spectrum1D objects, validate flux/wavelength units with specutils, and extend ingestion regression coverage.
 - v1.2.1j: Capture image overlay statistics during local ingest and surface the richer metadata in the viewer summary.
+- v1.2.1k: Publish the SpecViz parity matrix, wire user docs to the new overview, and credit the jdaviz authors across ingest and viewer guides.

--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.1i",
-  "date_utc": "2025-10-23T00:00:00Z",
-  "summary": "Normalise local ingestion payloads to Spectrum1D objects and surface unit coercion errors."
+  "version": "v1.2.1k",
+  "date_utc": "2025-10-24T00:00:00Z",
+  "summary": "Publish the SpecViz parity matrix and credit upstream jdaviz documentation across user guides."
 }

--- a/docs/ai_log/2025-10-24.md
+++ b/docs/ai_log/2025-10-24.md
@@ -1,0 +1,15 @@
+# AI Log — 2025-10-24
+
+## Tasking — SpecViz parity matrix publishing
+- Publish a SpecViz-to-Spectra feature matrix and ensure user guides credit the jdaviz authors for upstream documentation.
+
+## Actions & Decisions
+- Added a SpecViz parity matrix with ingestion, viewer, and plugin deltas plus explicit attribution for the jdaviz maintainers. 【F:docs/research/specviz_improvement_backlog.md†L5-L20】
+- Linked the user guide and workspace docs to the new matrix while surfacing jdaviz attribution notes across ingestion, viewer, and differential workflows. 【F:docs/app/user_guide.md†L1-L15】【F:docs/app/archive_and_provenance.md†L1-L13】【F:docs/app/overlay_workspace.md†L1-L13】【F:docs/app/differential_workspace.md†L1-L13】
+- Updated version metadata, patch notes, and the patch log so release collateral records the documentation credit work. 【F:app/version.json†L1-L5】【F:docs/patch_notes/v1.2.1k.md†L1-L18】【F:PATCHLOG.txt†L33-L35】
+
+## Verification
+- Not applicable (documentation-only change).
+
+## Docs Consulted
+- `docs/mirrored/stsci_archive/data_format.md` — reviewed FITS documentation formatting to keep external references consistent. 【F:docs/mirrored/stsci_archive/data_format.md†L1-L18】【F:docs/mirrored/stsci_archive/data_format.meta.json†L1-L7】

--- a/docs/app/archive_and_provenance.md
+++ b/docs/app/archive_and_provenance.md
@@ -1,7 +1,11 @@
 # Archive lookups and provenance
 
 Spectra App connects to several provider stubs so you can experiment with
-lookups without leaving the UI.
+lookups without leaving the UI. Broader ingest roadmap context lives in the
+[Spectra ↔ SpecViz parity matrix](../research/specviz_improvement_backlog.md#spectra--specviz-parity-matrix).
+
+> **Attribution.** Ingestion comparisons acknowledge the SpecViz documentation
+> authored by the [jdaviz team](https://github.com/spacetelescope/jdaviz).
 
 ## Archive lookups
 

--- a/docs/app/differential_workspace.md
+++ b/docs/app/differential_workspace.md
@@ -1,7 +1,12 @@
 # Differential workspace reference
 
 Use the differential tab to quantify how two spectra differ once they are
-aligned to the same wavelength sampling.
+aligned to the same wavelength sampling. Planned SpecViz-inspired upgrades for
+these comparisons are captured in the
+[Spectra ↔ SpecViz parity matrix](../research/specviz_improvement_backlog.md#spectra--specviz-parity-matrix).
+
+> **Attribution.** Differential workflow comparisons cite the SpecViz
+> documentation maintained by the [jdaviz authors](https://github.com/spacetelescope/jdaviz).
 
 ## Workflow
 

--- a/docs/app/overlay_workspace.md
+++ b/docs/app/overlay_workspace.md
@@ -2,7 +2,11 @@
 
 The overlay tab is the heart of Spectra App. It renders every trace that is
 currently loaded and keeps controls close to the chart so you can stay in the
-analysis flow.
+analysis flow. Feature roadmaps that align with SpecViz are summarised in the
+[Spectra ↔ SpecViz parity matrix](../research/specviz_improvement_backlog.md#spectra--specviz-parity-matrix).
+
+> **Attribution.** Viewer comparisons draw on the SpecViz guides curated by the
+> [jdaviz authors](https://github.com/spacetelescope/jdaviz).
 
 ## Plot controls
 

--- a/docs/app/user_guide.md
+++ b/docs/app/user_guide.md
@@ -1,7 +1,13 @@
 # Spectra App quick start
 
 Use this guide to get familiar with the refreshed Spectra App workspace and the
-core flows for loading, inspecting, and comparing spectra.
+core flows for loading, inspecting, and comparing spectra. For a parity
+overview, consult the [Spectra ↔ SpecViz parity matrix](../research/specviz_improvement_backlog.md#spectra--specviz-parity-matrix),
+which outlines how ingestion, viewer, and plugin features relate to the
+upstream SpecViz tooling.
+
+> **Attribution.** The parity comparisons reference the SpecViz documentation
+> maintained by the [jdaviz authors](https://github.com/spacetelescope/jdaviz).
 
 ## 1. Load reference material
 

--- a/docs/atlas/brains.md
+++ b/docs/atlas/brains.md
@@ -1,3 +1,8 @@
+# SpecViz parity matrix publication — 2025-10-24
+- Documented the SpecViz parity matrix so roadmap owners can trace ingestion, viewer, and plugin deltas alongside credited upstream docs. 【F:docs/research/specviz_improvement_backlog.md†L5-L20】
+- Linked the user guide and workspace docs to the matrix with jdaviz attribution notes for ingestion, viewer, and differential workflows. 【F:docs/app/user_guide.md†L1-L15】【F:docs/app/archive_and_provenance.md†L1-L13】【F:docs/app/overlay_workspace.md†L1-L13】【F:docs/app/differential_workspace.md†L1-L13】
+- Bumped version metadata, patch notes, and patch log so release collateral records the documentation credit update. 【F:app/version.json†L1-L5】【F:docs/patch_notes/v1.2.1k.md†L1-L18】【F:PATCHLOG.txt†L33-L35】
+
 # Spectrum1D ingestion normalisation — 2025-10-5
 - Convert local ingest payloads into `Spectrum1D` objects with Astropy quantity checks so unit coercion errors surface before overlays are added, while skipping conversion for image products. 【F:app/utils/local_ingest.py†L300-L386】【F:app/utils/local_ingest.py†L597-L772】
 - Added specutils as a dependency and broadened ingestion tests to assert Spectrum1D availability and unit validation for base and additional traces. 【F:requirements.txt†L1-L11】【F:tests/server/test_local_ingest.py†L1-L186】【F:tests/server/test_local_ingest.py†L230-L321】

--- a/docs/patch_notes/v1.2.1k.md
+++ b/docs/patch_notes/v1.2.1k.md
@@ -1,0 +1,14 @@
+# Patch Notes — v1.2.1k
+
+## Summary
+- Published the SpecViz parity matrix to connect Spectra App features to upstream documentation and deltas. 【F:docs/research/specviz_improvement_backlog.md†L5-L20】
+- Linked user-facing guides to the new matrix and credited the jdaviz authors for the underlying SpecViz material. 【F:docs/app/user_guide.md†L1-L10】【F:docs/app/archive_and_provenance.md†L1-L8】【F:docs/app/overlay_workspace.md†L1-L9】【F:docs/app/differential_workspace.md†L1-L9】
+
+## Details
+1. **SpecViz parity matrix**
+   - Added a feature-to-doc mapping table in the SpecViz improvement backlog that highlights ingestion, viewer, and plugin differences and credits the jdaviz authors. 【F:docs/research/specviz_improvement_backlog.md†L7-L16】
+2. **User guide attribution**
+   - Referenced the parity matrix from the user guide and workspace docs while calling out the jdaviz authors whose work informs Spectra App's roadmap. 【F:docs/app/user_guide.md†L1-L10】【F:docs/app/archive_and_provenance.md†L1-L8】【F:docs/app/overlay_workspace.md†L1-L9】【F:docs/app/differential_workspace.md†L1-L9】
+
+## Verification
+- Documentation-only change; no automated tests were run.

--- a/docs/research/specviz_improvement_backlog.md
+++ b/docs/research/specviz_improvement_backlog.md
@@ -4,6 +4,22 @@
 - Translate SpecViz's mature 1D spectroscopy workflows into actionable upgrades for Spectra App so our roadmap targets proven interaction models and helper APIs. [1][2]
 - Highlight near-term improvements that de-risk ingestion, visualization, and analysis parity while respecting Spectra App's Streamlit-first architecture. [1][3]
 
+## Spectra ↔ SpecViz parity matrix
+
+| Spectra feature area | SpecViz reference docs | Summary of current delta |
+| --- | --- | --- |
+| Ingestion workflows | [Importing data][import], [JWST mode matrix][jwst] | Spectra App lacks SpecViz's multi-entry loaders, auto-mode routing, and ingest helper diagnostics; roadmap items aim to align affordances and provenance handling. |
+| Viewer interactions | [Displaying spectra][display] | The viewer currently provides Plotly-driven basics without SpecViz's layer list, toolbar breadth, or ROI/readout tooling, motivating the queued viewer upgrades. |
+| Plugin & analysis suite | [Plugin catalog][plugins], [Helper APIs][helper] | Plugin coverage is limited to core Spectra features; SpecViz's modeling, smoothing, and export surfaces drive the plugin parity tranche and helper API expansion. |
+
+> **Attribution.** SpecViz documentation excerpts and comparisons credit the [jdaviz authors](https://github.com/spacetelescope/jdaviz) who maintain the upstream guides and helper APIs that informed this matrix.
+
+[import]: https://github.com/spacetelescope/jdaviz/blob/main/docs/specviz/import_data.rst
+[jwst]: https://github.com/spacetelescope/jdaviz/blob/main/docs/index_jwst_modes.rst
+[display]: https://github.com/spacetelescope/jdaviz/blob/main/docs/specviz/displaying.rst
+[plugins]: https://github.com/spacetelescope/jdaviz/blob/main/docs/specviz/plugins.rst
+[helper]: https://github.com/spacetelescope/jdaviz/blob/main/jdaviz/configs/specviz/helper.py
+
 ## Ingestion Enhancements
 1. **Adopt SpecViz loader affordances**
    - Offer separate UI affordances for single-file, directory, and helper-driven loads mirroring SpecViz's CLI/UI/API entry points so observers can stage whole programs quickly. [1]


### PR DESCRIPTION
## Summary
- add a Spectra ↔ SpecViz parity matrix to the research backlog with upstream doc links and attribution
- link user-facing workspace guides to the new matrix and acknowledge the jdaviz authors
- roll version metadata, patch notes, brains, and AI log entries to record the documentation update

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e33ccdb34483299c006ee26a27d566