### PR TITLE
Add SpecViz-compatible batch ingest helpers and provider diagnostics

### DIFF
--- a/PATCHLOG.txt
+++ b/PATCHLOG.txt
@@ -34,3 +34,4 @@ Spectra App — Patch Log (append-only)
 - v1.2.1h: Outline SpecViz-inspired ingestion, viewer, and plugin improvements so planning collateral guides upcoming parity work.
 - v1.2.1i: Normalise local uploads to Spectrum1D objects, validate flux/wavelength units with specutils, and extend ingestion regression coverage.
 - v1.2.1j: Capture image overlay statistics during local ingest and surface the richer metadata in the viewer summary.
+- v1.2.1k: Introduce SpecViz-compatible batch ingestion helpers plus richer provider diagnostics for concatenated program pulls.

--- a/app/helpers/__init__.py
+++ b/app/helpers/__init__.py
@@ -1,0 +1,5 @@
+"""Helper modules exposing SpecViz-compatible APIs."""
+
+from .specviz_compat import SpecvizCompatHelper, load_data
+
+__all__ = ["SpecvizCompatHelper", "load_data"]

--- a/app/helpers/specviz_compat.py
+++ b/app/helpers/specviz_compat.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+"""SpecViz-compatible helper that wraps local ingest pathways."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Mapping, MutableMapping, Sequence, Tuple, Union
+
+from app.utils.local_ingest import BatchIngestReport, ingest_local_paths
+
+
+class SpecvizCompatError(RuntimeError):
+    """Raised when scripted SpecViz-style ingestion fails."""
+
+
+@dataclass
+class HelperResult:
+    """Container returned when diagnostics are requested."""
+
+    payloads: List[Mapping[str, object]]
+    report: BatchIngestReport
+
+
+def _normalise_sequence(value: Union[str, Path, Iterable[Union[str, Path]]]) -> List[Path]:
+    if isinstance(value, (str, Path)):
+        return [Path(value)]
+    if not isinstance(value, Iterable):
+        raise TypeError("SpecvizCompatHelper.load_data expects a path or iterable of paths.")
+    paths: List[Path] = []
+    for item in value:
+        paths.append(Path(item))
+    return paths
+
+
+def _apply_helper_provenance(
+    payloads: Iterable[MutableMapping[str, object]],
+    helper_options: Mapping[str, object],
+) -> None:
+    for payload in payloads:
+        provenance = dict(payload.get("provenance") or {})
+        helper_chain = list(provenance.get("helpers") or [])
+        helper_chain.append({"helper": "SpecvizCompatHelper", **helper_options})
+        provenance["helpers"] = helper_chain
+        provenance.setdefault("helper", helper_options)
+        payload["provenance"] = provenance
+
+
+class SpecvizCompatHelper:
+    """Mirror jdaviz SpecViz helper signatures for scripted ingest workflows."""
+
+    def __init__(self, *, follow_symlinks: bool = False) -> None:
+        self._follow_symlinks = follow_symlinks
+
+    def load_data(
+        self,
+        data: Union[str, Path, Iterable[Union[str, Path]]],
+        data_label: str | None = None,
+        spectral_axis_unit: str | None = None,
+        flux_unit: str | None = None,
+        *,
+        directory: str | Path | None = None,
+        glob: Union[str, Sequence[str], None] = None,
+        recursive: bool = True,
+        allow_empty: bool = False,
+        return_report: bool = False,
+        diagnostics: bool = False,
+        **kwargs,
+    ) -> Union[Mapping[str, object], List[Mapping[str, object]], HelperResult, BatchIngestReport]:
+        """Load spectral files via local ingest using SpecViz-style semantics."""
+
+        if directory is not None:
+            base = Path(directory).expanduser()
+        else:
+            base = None
+
+        try:
+            paths = _normalise_sequence(data)
+        except TypeError:
+            if directory is None:
+                raise
+            # Allow calls like helper.load_data(None, directory=...)
+            paths = []
+
+        resolved: List[Path] = []
+        for path in paths:
+            if base is not None and not path.is_absolute():
+                resolved.append((base / path).expanduser())
+            else:
+                resolved.append(path.expanduser())
+
+        if base is not None and not resolved:
+            resolved = [base]
+
+        if not resolved and not allow_empty:
+            raise SpecvizCompatError("No data paths were provided to SpecvizCompatHelper.load_data().")
+
+        report = ingest_local_paths(
+            resolved,
+            recursive=recursive,
+            glob_patterns=glob,
+            follow_symlinks=self._follow_symlinks,
+            context="specviz_helper",
+        )
+
+        payloads = report.successful_payloads()
+        if not payloads and not allow_empty:
+            errors = report.summary.get("errors") or []
+            raise SpecvizCompatError(
+                "SpecvizCompatHelper.load_data() did not ingest any spectra. "
+                f"Diagnostics: {errors}"
+            )
+
+        helper_options = {
+            "label": data_label,
+            "spectral_axis_unit": spectral_axis_unit,
+            "flux_unit": flux_unit,
+            "recursive": recursive,
+            "glob": glob,
+        }
+
+        mutable_payloads: List[MutableMapping[str, object]] = [dict(payload) for payload in payloads]
+        _apply_helper_provenance(mutable_payloads, helper_options)
+
+        if data_label and len(mutable_payloads) == 1:
+            mutable_payloads[0]["label"] = data_label
+
+        if spectral_axis_unit and mutable_payloads:
+            for payload in mutable_payloads:
+                wavelength = dict(payload.get("wavelength") or {})
+                wavelength["unit"] = spectral_axis_unit
+                payload["wavelength"] = wavelength
+
+        if flux_unit and mutable_payloads:
+            for payload in mutable_payloads:
+                payload["flux_unit"] = flux_unit
+
+        if return_report:
+            report.summary.setdefault("helper", helper_options)
+            return report
+
+        if diagnostics:
+            return HelperResult(payloads=mutable_payloads, report=report)
+
+        if len(mutable_payloads) == 1:
+            return mutable_payloads[0]
+        return mutable_payloads
+
+
+def load_data(*args, **kwargs):
+    """Module-level convenience wrapper mirroring SpecViz helpers."""
+
+    helper = SpecvizCompatHelper()
+    return helper.load_data(*args, **kwargs)
+
+
+__all__ = ["SpecvizCompatHelper", "SpecvizCompatError", "load_data", "HelperResult"]

--- a/app/providers/base.py
+++ b/app/providers/base.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 """Base dataclasses and helpers for archive provider adapters."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple
 
 import pandas as pd
 
@@ -19,6 +19,21 @@ class ProviderQuery:
     doi: str = ""
     limit: int = 5
     wavelength_range: Tuple[Optional[float], Optional[float]] = (None, None)
+    programs: Tuple[str, ...] = field(default_factory=tuple)
+    catalog: str = ""
+    concatenate: bool = False
+    use_cached_only: bool = False
+    diagnostics: bool = False
+    options: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        programs = tuple(
+            str(program).strip()
+            for program in self.programs
+            if isinstance(program, str) and str(program).strip()
+        )
+        object.__setattr__(self, "programs", programs)
+        object.__setattr__(self, "options", dict(self.options or {}))
 
     def as_dict(self) -> Dict[str, object]:
         return {
@@ -28,7 +43,44 @@ class ProviderQuery:
             "doi": self.doi,
             "limit": self.limit,
             "wavelength_range": self.wavelength_range,
+            "programs": list(self.programs),
+            "catalog": self.catalog,
+            "concatenate": self.concatenate,
+            "use_cached_only": self.use_cached_only,
+            "diagnostics": self.diagnostics,
+            "options": dict(self.options),
         }
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any]) -> "ProviderQuery":
+        programs_raw = payload.get("programs", ())
+        if isinstance(programs_raw, (str, bytes)):
+            programs: Tuple[str, ...] = (str(programs_raw),)
+        elif isinstance(programs_raw, Iterable):
+            programs = tuple(str(value) for value in programs_raw)
+        else:
+            programs = ()
+
+        options_raw = payload.get("options") or {}
+        if isinstance(options_raw, Mapping):
+            options = dict(options_raw)
+        else:
+            options = {}
+
+        return cls(
+            target=str(payload.get("target") or ""),
+            text=str(payload.get("text") or ""),
+            instrument=str(payload.get("instrument") or ""),
+            doi=str(payload.get("doi") or ""),
+            limit=int(payload.get("limit") or 5),
+            wavelength_range=tuple(payload.get("wavelength_range") or (None, None)),
+            programs=programs,
+            catalog=str(payload.get("catalog") or ""),
+            concatenate=bool(payload.get("concatenate")),
+            use_cached_only=bool(payload.get("use_cached_only")),
+            diagnostics=bool(payload.get("diagnostics")),
+            options=options,
+        )
 
 
 @dataclass

--- a/app/providers/sdss.py
+++ b/app/providers/sdss.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import unicodedata
 import re
-from typing import Iterable, List, Tuple
+from typing import Dict, Iterable, List, Tuple
 
 from app.server.fetchers import sdss as sdss_fetcher
 
@@ -72,29 +72,38 @@ def _match_targets(query: ProviderQuery) -> List[_TargetInfo]:
     if not _TARGETS:
         return []
 
+    catalog_filter = query.catalog.lower() if query.catalog else ""
+
     search_terms: List[str] = []
     for value in (query.target, query.text):
         if value:
             search_terms.append(value)
 
     if not search_terms:
-        return list(_TARGETS)
+        matches = list(_TARGETS)
+    else:
+        matches = []
+        seen: set[str] = set()
+        for term in search_terms:
+            token = _normalise_token(term)
+            if not token:
+                continue
+            for target in _TARGETS:
+                for alias in target.search_tokens:
+                    if not alias:
+                        continue
+                    if alias.startswith(token) or token.startswith(alias):
+                        if target.canonical_name not in seen:
+                            matches.append(target)
+                            seen.add(target.canonical_name)
+                        break
 
-    matches: List[_TargetInfo] = []
-    seen: set[str] = set()
-    for term in search_terms:
-        token = _normalise_token(term)
-        if not token:
-            continue
-        for target in _TARGETS:
-            for alias in target.search_tokens:
-                if not alias:
-                    continue
-                if alias.startswith(token) or token.startswith(alias):
-                    if target.canonical_name not in seen:
-                        matches.append(target)
-                        seen.add(target.canonical_name)
-                    break
+    if catalog_filter:
+        matches = [
+            target
+            for target in matches
+            if catalog_filter in target.data_release.lower()
+        ]
     return matches
 
 
@@ -199,7 +208,7 @@ def search(query: ProviderQuery) -> Iterable[ProviderHit]:
 
     limit = max(1, int(query.limit or 1))
     yielded = 0
-    errors: List[str] = []
+    aggregate_errors: List[Dict[str, object]] = []
 
     for target in targets:
         try:
@@ -210,15 +219,34 @@ def search(query: ProviderQuery) -> Iterable[ProviderHit]:
                 fiber=target.fiber,
             )
         except sdss_fetcher.SdssFetchError as exc:
-            errors.append(str(exc))
+            aggregate_errors.append(
+                {
+                    "target": target.canonical_name,
+                    "plate": target.plate,
+                    "mjd": target.mjd,
+                    "fiber": target.fiber,
+                    "error": str(exc),
+                }
+            )
             continue
-        yield _build_hit(payload, query, target)
+        hit = _build_hit(payload, query, target)
+        if query.catalog:
+            hit.metadata.setdefault("requested_catalog", query.catalog)
+        if query.diagnostics and aggregate_errors:
+            hit.provenance.setdefault("diagnostics", list(aggregate_errors))
+        yield hit
         yielded += 1
         if yielded >= limit:
             break
 
-    if yielded == 0 and errors:
-        raise sdss_fetcher.SdssFetchError(errors[0])
+    if yielded == 0 and aggregate_errors:
+        details = "\n".join(
+            f"- {error.get('target')} plate {error.get('plate')}/{error.get('mjd')}/{error.get('fiber')}: {error.get('error')}"
+            for error in aggregate_errors
+        )
+        raise sdss_fetcher.SdssFetchError(
+            "SDSS fetch attempts failed for all requested targets.\n" + details
+        )
 
 
 refresh_targets()

--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.1i",
-  "date_utc": "2025-10-23T00:00:00Z",
-  "summary": "Normalise local ingestion payloads to Spectrum1D objects and surface unit coercion errors."
+  "version": "v1.2.1k",
+  "date_utc": "2025-10-24T00:00:00Z",
+  "summary": "Add SpecViz-compatible batch ingestion helpers and provider diagnostics."
 }

--- a/docs/ai_log/2025-10-24.md
+++ b/docs/ai_log/2025-10-24.md
@@ -1,0 +1,16 @@
+# AI Log — 2025-10-24
+
+## Tasking — SpecViz batch ingestion helpers
+- Deliver SpecViz-compatible batch ingestion pathways with scripted helper parity and provider diagnostics.
+
+## Actions & Decisions
+- Added directory-aware batch ingest wrappers that report per-file provenance and expanded regression coverage for batch success/failure accounting. 【F:app/utils/local_ingest.py†L55-L167】【F:app/utils/local_ingest.py†L866-L1077】【F:tests/server/test_local_ingest.py†L787-L818】
+- Published `SpecvizCompatHelper` plus helper tests to mirror jdaviz helper signatures for scripted ingest workflows. 【F:app/helpers/specviz_compat.py†L1-L156】【F:tests/utils/test_specviz_compat.py†L1-L64】
+- Extended archive providers with program concatenation, catalog filters, and diagnostics to surface richer failure context; updated provider tests for concatenated pulls. 【F:app/providers/mast.py†L61-L405】【F:app/providers/eso.py†L72-L233】【F:app/providers/sdss.py†L71-L252】【F:app/providers/doi.py†L64-L218】【F:tests/providers/test_mast_provider.py†L122-L157】
+
+## Verification
+- `pytest tests/server/test_local_ingest.py tests/providers/test_mast_provider.py tests/utils/test_specviz_compat.py` 【6f7cf6†L1-L29】
+
+## Docs Consulted
+- SpecViz-inspired improvement backlog for helper parity requirements. 【F:docs/research/specviz_improvement_backlog.md†L1-L74】
+- MAST Data Format guidelines (mirrored) for provenance context expectations. 【F:docs/mirrored/stsci_archive/data_format.html.meta.json†L1-L7】

--- a/docs/atlas/brains.md
+++ b/docs/atlas/brains.md
@@ -1,3 +1,8 @@
+# SpecViz batch ingestion helpers — 2025-10-24
+- Added directory-aware batch ingest wrappers and a SpecViz-compatible helper module so scripted imports mirror jdaviz helper flows while capturing per-file provenance. 【F:app/utils/local_ingest.py†L55-L167】【F:app/utils/local_ingest.py†L866-L1077】【F:app/helpers/specviz_compat.py†L1-L156】
+- Extended provider adapters with program concatenation, catalog filters, and diagnostics to align archive searches with SpecViz helper expectations. 【F:app/providers/mast.py†L61-L405】【F:app/providers/eso.py†L72-L233】【F:app/providers/sdss.py†L71-L252】【F:app/providers/doi.py†L64-L218】
+- Documented the SpecViz backlog reference to keep parity planning attached to the jdaviz helper blueprint. 【F:docs/research/specviz_improvement_backlog.md†L1-L74】
+
 # Spectrum1D ingestion normalisation — 2025-10-5
 - Convert local ingest payloads into `Spectrum1D` objects with Astropy quantity checks so unit coercion errors surface before overlays are added, while skipping conversion for image products. 【F:app/utils/local_ingest.py†L300-L386】【F:app/utils/local_ingest.py†L597-L772】
 - Added specutils as a dependency and broadened ingestion tests to assert Spectrum1D availability and unit validation for base and additional traces. 【F:requirements.txt†L1-L11】【F:tests/server/test_local_ingest.py†L1-L186】【F:tests/server/test_local_ingest.py†L230-L321】

--- a/docs/patch_notes/v1.2.1k.md
+++ b/docs/patch_notes/v1.2.1k.md
@@ -1,0 +1,6 @@
+# v1.2.1k — SpecViz-compatible ingestion helpers
+
+- Added batch ingestion entry points that expand directories, capture per-file provenance, and expose success/failure summaries so scripted workflows mirror SpecViz directory imports. 【F:app/utils/local_ingest.py†L55-L167】【F:app/utils/local_ingest.py†L866-L1077】
+- Published `SpecvizCompatHelper` to mirror jdaviz helper signatures, returning overlay payloads, batch reports, or diagnostics for scripted ingest. 【F:app/helpers/specviz_compat.py†L1-L156】【F:tests/utils/test_specviz_compat.py†L1-L64】
+- Extended MAST, ESO, SDSS, and DOI providers to accept richer query payloads (program concatenation, cached catalog hints) while surfacing aggregated failure diagnostics. 【F:app/providers/mast.py†L61-L405】【F:app/providers/eso.py†L72-L233】【F:app/providers/sdss.py†L71-L252】【F:app/providers/doi.py†L64-L218】
+- Logged the SpecViz improvement backlog reference to keep parity efforts aligned with jdaviz helper behaviors. 【F:docs/research/specviz_improvement_backlog.md†L1-L74】

--- a/tests/providers/test_mast_provider.py
+++ b/tests/providers/test_mast_provider.py
@@ -119,6 +119,44 @@ def test_unknown_target_raises(monkeypatch):
         list(provider.search(query))
 
 
+def test_concatenate_programs_with_diagnostics(monkeypatch):
+    def fake_fetch(target: str, instrument: str = "", **kwargs):
+        instrument_key = (instrument or "STIS").upper()
+        if instrument_key == "FAIL":
+            raise provider.mast_fetcher.MastFetchError("Network down")
+        payload = _fake_payload()
+        meta = dict(payload["meta"])
+        meta["instrument"] = instrument_key
+        meta["cache_hit"] = True
+        if instrument_key == "MOD":
+            payload["wavelength_nm"] = [500.0, 510.0]
+            payload["intensity"] = [0.9, 1.1]
+        payload["meta"] = meta
+        return payload
+
+    monkeypatch.setattr(provider.mast_fetcher, "available_targets", _fake_available_targets)
+    monkeypatch.setattr(provider.mast_fetcher, "fetch", fake_fetch)
+    provider.refresh_targets()
+
+    query = ProviderQuery(
+        target="Sirius",
+        programs=("STIS", "MOD", "FAIL"),
+        concatenate=True,
+        diagnostics=True,
+    )
+    hits = list(provider.search(query))
+
+    assert len(hits) == 1
+    hit = hits[0]
+    assert hit.metadata["concatenated_programs"] == ["STIS", "MOD"]
+    assert len(hit.provenance["segments"]) == 2
+    assert any(entry.get("program") == "STIS" for entry in hit.provenance["segments"])
+    assert any(entry.get("program") == "MOD" for entry in hit.provenance["segments"])
+    diagnostics = hit.provenance.get("diagnostics")
+    assert diagnostics is not None
+    assert any(record.get("program") == "FAIL" for record in diagnostics)
+
+
 def teardown_module(module):  # pragma: no cover - test cleanup
     provider.refresh_targets()
 

--- a/tests/utils/test_specviz_compat.py
+++ b/tests/utils/test_specviz_compat.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.helpers.specviz_compat import HelperResult, SpecvizCompatError, SpecvizCompatHelper
+
+
+def _write_ascii(path: Path, name: str) -> Path:
+    file_path = path / name
+    file_path.write_text("wavelength,flux\n400,1\n410,0.9\n420,1.05\n")
+    return file_path
+
+
+def test_helper_loads_paths_and_applies_label(tmp_path):
+    helper = SpecvizCompatHelper()
+    path = _write_ascii(tmp_path, "spec.csv")
+
+    payload = helper.load_data([path], data_label="Custom")
+
+    assert payload["label"] == "Custom"
+    assert payload["provenance"]["helpers"][0]["helper"] == "SpecvizCompatHelper"
+
+
+def test_helper_return_report(tmp_path):
+    helper = SpecvizCompatHelper()
+    good = _write_ascii(tmp_path, "good.csv")
+
+    report = helper.load_data([good, tmp_path / "missing.csv"], return_report=True, allow_empty=True)
+
+    assert report.summary["succeeded"] == 1
+    assert report.summary["failed"] == 1
+    success_entry = next(entry for entry in report.entries if entry.status == "success")
+    assert success_entry.provenance["ingest"]["method"] == "specviz_helper"
+
+
+def test_helper_diagnostics_allows_empty(tmp_path):
+    helper = SpecvizCompatHelper()
+
+    result = helper.load_data([tmp_path / "absent.csv"], diagnostics=True, allow_empty=True)
+
+    assert isinstance(result, HelperResult)
+    assert result.report.summary["failed"] == 1
+    assert not result.payloads
+
+
+def test_helper_directory_glob(tmp_path):
+    helper = SpecvizCompatHelper()
+    subdir = tmp_path / "data"
+    subdir.mkdir()
+    _write_ascii(subdir, "one.csv")
+    (subdir / "skip.txt").write_text("not data")
+
+    payloads = helper.load_data([], directory=subdir, glob="*.csv")
+
+    assert isinstance(payloads, dict)
+    assert payloads["label"] == "one"
+
+
+def test_helper_raises_when_empty(tmp_path):
+    helper = SpecvizCompatHelper()
+    with pytest.raises(SpecvizCompatError):
+        helper.load_data([], allow_empty=False)


### PR DESCRIPTION
## Summary
- add batch ingestion reports for local filesystem ingestion and directory expansion, capturing per-file provenance for scripted workflows
- introduce SpecViz-compatible helper module for batch ingest scripting and document the new pathways in brains, patch notes, and ai log
- extend archive providers to accept richer query payloads, handle concatenated programs, and surface diagnostics with updated regression coverage

## Testing
- pytest tests/server/test_local_ingest.py tests/providers/test_mast_provider.py tests/utils/test_specviz_compat.py

------
https://chatgpt.com/codex/tasks/task_e_68e33cc4c0848329a3efea8de23f38b5