### PR TITLE
Add NIST Quantitative IR catalog integration

### DIFF
--- a/PATCHLOG.txt
+++ b/PATCHLOG.txt
@@ -37,3 +37,4 @@ Spectra App — Patch Log (append-only)
 - v1.2.1k: Add JCAMP-DX ingestion so NIST IR uploads convert to nanometres, ignore uncertainty traces, and ship with regression coverage.
 - v1.2.1l: Allow JCAMP-DX uploads through the UI filter, update quick-start docs, and ship regression coverage for the union constants.
 - v1.2.1m: Auto-select original wavelength units when the first overlay loads so wavenumber uploads land on matching axes and extend regression coverage for the display-unit hints.
+- v1.2.1n: Add a NIST Quantitative IR fetcher with preset molecules at 0.125 cm⁻¹ and document the workflow.

--- a/app/server/fetch_archives.py
+++ b/app/server/fetch_archives.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict
 
-from .fetchers import doi, eso, mast, nist, sdss, simbad
+from .fetchers import doi, eso, mast, nist, nist_quant_ir, sdss, simbad
 
 class FetchError(Exception):
     pass
@@ -24,6 +24,8 @@ def fetch_spectrum(archive: str, **kwargs) -> Dict[str, Any]:
         return sdss.fetch(**kwargs)
     if archive == 'nist':
         return nist.fetch(**kwargs)
+    if archive in {'nist-quant-ir', 'nist_quant_ir', 'quant-ir'}:
+        return nist_quant_ir.fetch(**kwargs)
     if archive == 'doi':
         return doi.fetch(**kwargs)
     raise FetchError(f'Unsupported archive: {archive}')

--- a/app/server/fetchers/nist_quant_ir.py
+++ b/app/server/fetchers/nist_quant_ir.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+from functools import lru_cache
+from html import unescape
+from typing import Dict, Mapping, Optional, Sequence, Tuple
+from urllib.parse import urljoin
+
+import requests
+
+from ..ingest_jcamp import parse_jcamp
+
+__all__ = [
+    "DEFAULT_RESOLUTION_CM_1",
+    "QuantIRFetchError",
+    "available_species",
+    "fetch",
+]
+
+
+BASE_URL = "https://webbook.nist.gov"
+CATALOG_URL = f"{BASE_URL}/chemistry/quant-ir/"
+REQUEST_TIMEOUT = 30
+DEFAULT_RESOLUTION_CM_1 = 0.125
+DEFAULT_APODIZATION_PRIORITY: Tuple[str, ...] = (
+    "Boxcar",
+    "Triangular",
+    "Happ Genzel",
+    "3-Term Blackmann-Harris",
+    "Norton Beer Strong",
+)
+_JCAMP_PATTERN = re.compile(r"display_jcamp\('([^']+)'", re.IGNORECASE)
+_RELATIVE_UNCERTAINTY_PATTERN = re.compile(r"([-+]?\d*\.?\d+)")
+
+
+class QuantIRFetchError(RuntimeError):
+    """Raised when a NIST Quantitative IR request cannot be satisfied."""
+
+
+@dataclass(frozen=True)
+class QuantIRMeasurement:
+    apodization: str
+    resolution_links: Mapping[float, str]
+
+
+@dataclass(frozen=True)
+class QuantIRSpecies:
+    name: str
+    relative_uncertainty: str
+    measurements: Tuple[QuantIRMeasurement, ...]
+
+
+def _normalise_token(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", (value or "").lower())
+
+
+def _download_text(url: str, *, session: Optional[requests.Session] = None) -> str:
+    try:
+        response = (session or requests).get(url, timeout=REQUEST_TIMEOUT)
+        response.raise_for_status()
+    except requests.RequestException as exc:  # pragma: no cover - defensive branch
+        raise QuantIRFetchError(f"Failed to download {url}: {exc}") from exc
+    if not response.encoding:
+        response.encoding = "utf-8"
+    return response.text
+
+
+def _download_bytes(url: str, *, session: Optional[requests.Session] = None) -> bytes:
+    try:
+        response = (session or requests).get(url, timeout=REQUEST_TIMEOUT)
+        response.raise_for_status()
+    except requests.RequestException as exc:  # pragma: no cover - defensive branch
+        raise QuantIRFetchError(f"Failed to download {url}: {exc}") from exc
+    return response.content
+
+
+def _parse_catalog(html: str) -> Dict[str, QuantIRSpecies]:
+    try:
+        from bs4 import BeautifulSoup
+    except ImportError as exc:  # pragma: no cover - defensive branch
+        raise QuantIRFetchError("beautifulsoup4 is required to parse the Quant IR catalog") from exc
+
+    soup = BeautifulSoup(html, "html.parser")
+    table = soup.find("table", {"class": "list"})
+    if table is None:
+        raise QuantIRFetchError("Could not locate Quant IR species table")
+
+    rows = table.find_all("tr")
+    if len(rows) <= 1:
+        raise QuantIRFetchError("Quant IR species table contained no data")
+
+    catalog: Dict[str, QuantIRSpecies] = {}
+    current_name: Optional[str] = None
+    current_uncertainty: str = ""
+    current_measurements: list[QuantIRMeasurement] = []
+
+    for row in rows[1:]:
+        cells = row.find_all("td")
+        if not cells:
+            continue
+        if cells[0].has_attr("rowspan"):
+            if current_name is not None:
+                catalog[_normalise_token(current_name)] = QuantIRSpecies(
+                    name=current_name,
+                    relative_uncertainty=current_uncertainty,
+                    measurements=tuple(current_measurements),
+                )
+                current_measurements = []
+            current_name = cells[0].get_text(strip=True)
+            current_uncertainty = cells[1].get_text(strip=True)
+            data_cells = cells[2:]
+        else:
+            data_cells = cells
+        if len(data_cells) < 2 or current_name is None:
+            continue
+        apod_cell = data_cells[0]
+        resolution_cell = data_cells[1]
+        apodization = apod_cell.get_text(strip=True)
+        links = resolution_cell.find_all("a")
+        resolutions: Dict[float, str] = {}
+        for link in links:
+            href = link.get("href")
+            label = link.get_text(strip=True)
+            if not href or not label:
+                continue
+            try:
+                value = float(label)
+            except ValueError:
+                continue
+            resolutions[value] = urljoin(CATALOG_URL, href)
+        if not resolutions:
+            continue
+        current_measurements.append(
+            QuantIRMeasurement(apodization=apodization, resolution_links=dict(resolutions))
+        )
+
+    if current_name is not None and current_measurements:
+        catalog[_normalise_token(current_name)] = QuantIRSpecies(
+            name=current_name,
+            relative_uncertainty=current_uncertainty,
+            measurements=tuple(current_measurements),
+        )
+
+    return catalog
+
+
+@lru_cache(maxsize=1)
+def _cached_catalog() -> Dict[str, QuantIRSpecies]:
+    html = _download_text(CATALOG_URL)
+    return _parse_catalog(html)
+
+
+def _load_catalog(*, session: Optional[requests.Session] = None) -> Dict[str, QuantIRSpecies]:
+    if session is not None:
+        html = _download_text(CATALOG_URL, session=session)
+        return _parse_catalog(html)
+    return _cached_catalog()
+
+
+def available_species(*, session: Optional[requests.Session] = None) -> Tuple[Dict[str, object], ...]:
+    catalog = _load_catalog(session=session)
+    entries: list[Dict[str, object]] = []
+    for species in sorted(catalog.values(), key=lambda item: item.name.lower()):
+        entries.append(
+            {
+                "name": species.name,
+                "relative_uncertainty": species.relative_uncertainty,
+                "measurements": [
+                    {
+                        "apodization": measurement.apodization,
+                        "resolutions_cm_1": sorted(measurement.resolution_links.keys()),
+                    }
+                    for measurement in species.measurements
+                ],
+            }
+        )
+    return tuple(entries)
+
+
+def _choose_measurement(
+    species: QuantIRSpecies,
+    resolution_cm_1: float,
+    priority: Sequence[str],
+) -> Tuple[QuantIRMeasurement, float, str]:
+    target = float(resolution_cm_1)
+    normalised_priority = [_normalise_token(item) for item in priority]
+
+    for candidate_name in normalised_priority:
+        if not candidate_name:
+            continue
+        for measurement in species.measurements:
+            if _normalise_token(measurement.apodization) != candidate_name:
+                continue
+            for value, href in measurement.resolution_links.items():
+                if math.isclose(value, target, rel_tol=1e-9, abs_tol=1e-9):
+                    return measurement, value, href
+
+    for measurement in species.measurements:
+        for value, href in measurement.resolution_links.items():
+            if math.isclose(value, target, rel_tol=1e-9, abs_tol=1e-9):
+                return measurement, value, href
+
+    raise QuantIRFetchError(
+        f"{species.name} does not provide a {resolution_cm_1} cm⁻¹ measurement in the Quant IR catalog."
+    )
+
+
+def _extract_jcamp_url(page_html: str, page_url: str) -> str:
+    match = _JCAMP_PATTERN.search(page_html)
+    if not match:
+        raise QuantIRFetchError("Could not locate JCAMP link on Quant IR spectrum page")
+    relative = unescape(match.group(1))
+    return urljoin(page_url, relative)
+
+
+def _parse_relative_uncertainty(value: str) -> Optional[float]:
+    match = _RELATIVE_UNCERTAINTY_PATTERN.search(value)
+    if not match:
+        return None
+    try:
+        return float(match.group(1)) / 100.0
+    except ValueError:  # pragma: no cover - defensive branch
+        return None
+
+
+def fetch(
+    *,
+    species: str,
+    resolution_cm_1: float = DEFAULT_RESOLUTION_CM_1,
+    session: Optional[requests.Session] = None,
+    apodization_priority: Sequence[str] = DEFAULT_APODIZATION_PRIORITY,
+) -> Dict[str, object]:
+    if not species:
+        raise QuantIRFetchError("Species must be provided")
+
+    catalog = _load_catalog(session=session)
+    key = _normalise_token(species)
+    record = catalog.get(key)
+    if record is None:
+        raise QuantIRFetchError(f"{species} is not available in the NIST Quant IR catalog")
+
+    measurement, actual_resolution, page_href = _choose_measurement(
+        record, resolution_cm_1, apodization_priority
+    )
+    page_url = page_href
+    page_html = _download_text(page_url, session=session)
+    jcamp_url = _extract_jcamp_url(page_html, page_url)
+    payload = parse_jcamp(_download_bytes(jcamp_url, session=session), filename=f"{record.name}.jdx")
+
+    metadata = dict(payload.get("metadata") or {})
+    metadata.setdefault("source", "NIST Quantitative IR Database")
+    metadata["relative_uncertainty"] = record.relative_uncertainty
+    metadata["relative_uncertainty_fraction"] = _parse_relative_uncertainty(
+        record.relative_uncertainty
+    )
+    metadata["apodization"] = measurement.apodization
+    metadata["resolution_cm_1"] = actual_resolution
+    metadata["catalog_page"] = page_url
+    metadata["jcamp_url"] = jcamp_url
+    payload["metadata"] = metadata
+
+    provenance = dict(payload.get("provenance") or {})
+    provenance["archive"] = "NIST Quantitative IR"
+    provenance["relative_uncertainty"] = record.relative_uncertainty
+    provenance["apodization"] = measurement.apodization
+    provenance["resolution_cm_1"] = actual_resolution
+    provenance["catalog_page"] = page_url
+    provenance["jcamp_url"] = jcamp_url
+    payload["provenance"] = provenance
+
+    label = f"{record.name} • NIST Quant IR ({measurement.apodization}, {actual_resolution:.3f} cm⁻¹)"
+    payload["label"] = label
+    payload["provider"] = "NIST Quant IR"
+    payload["summary"] = (
+        f"{record.name} {measurement.apodization} window at {actual_resolution:.3f} cm⁻¹"
+        f" ({record.relative_uncertainty})"
+    )
+    payload.setdefault("kind", "spectrum")
+
+    return payload

--- a/app/ui/main.py
+++ b/app/ui/main.py
@@ -42,6 +42,7 @@ from ..ingest import OverlayIngestResult
 from ..export_manifest import build_manifest
 from ..server.differential import ratio, resample_to_common_grid, subtract
 from ..server.fetch_archives import FetchError, fetch_spectrum
+from ..server.fetchers import nist_quant_ir
 from ..similarity import (
     SimilarityCache,
     SimilarityOptions,
@@ -64,6 +65,36 @@ st.set_page_config(page_title="Spectra App", layout="wide")
 
 EXPORT_DIR = Path("exports")
 EXPORT_DIR.mkdir(parents=True, exist_ok=True)
+
+
+NIST_QUANT_IR_MOLECULES: Tuple[Dict[str, str], ...] = (
+    {"label": "H2O", "query": "H2O"},
+    {"label": "Methane", "query": "Methane"},
+    {"label": "CO₂", "query": "CO2"},
+    {"label": "Ethanol", "query": "Ethanol"},
+    {"label": "Methanol", "query": "Methanol"},
+    {"label": "Butane", "query": "Butane"},
+    {"label": "1,4-Dimethylbenzene", "query": "1,4- Dimethylbenzene"},
+    {"label": "Dichlorodifluoromethane", "query": "Dichlorodifluoromethane"},
+    {"label": "Dichloromethane", "query": "Dichloromethane"},
+    {"label": "1,2-Dimethylbenzene", "query": "1,2- Dimethylbenzene"},
+    {"label": "1,3-Dimethylbenzene", "query": "1,3- Dimethylbenzene"},
+    {"label": "Carbon Tetrachloride", "query": "Carbon Tetrachloride"},
+    {"label": "Sulfur dioxide", "query": "Sulfur dioxide"},
+    {"label": "Toluene", "query": "Toluene"},
+    {"label": "2-Butanone", "query": "2-Butanone"},
+    {"label": "Sulfur Hexafluoride", "query": "Sulfur Hexafluoride"},
+    {"label": "1-Butanol", "query": "1-Butanol"},
+    {"label": "Benzene", "query": "Benzene"},
+    {"label": "Ethyl Acetate", "query": "Ethyl Acetate"},
+)
+
+NIST_QUANT_IR_RESOLUTION = nist_quant_ir.DEFAULT_RESOLUTION_CM_1
+
+
+@st.cache_data(show_spinner=False)
+def _cached_quant_ir_catalog() -> Tuple[Dict[str, object], ...]:
+    return nist_quant_ir.available_species()
 
 
 @dataclass
@@ -186,14 +217,14 @@ class OverlayTrace:
             raise ValueError("Image overlays cannot be vectorised.")
         if max_points is None and viewport is None:
             df = self.to_dataframe()
-            return TraceVectors(
-                trace_id=self.trace_id,
-                label=self.label,
-                wavelengths_nm=df["wavelength_nm"].to_numpy(dtype=float),
-                flux=df["flux"].to_numpy(dtype=float),
-                kind=self.kind,
-                fingerprint=self.fingerprint,
-            )
+        return TraceVectors(
+            trace_id=self.trace_id,
+            label=self.label,
+            wavelengths_nm=df["wavelength_nm"].to_numpy(dtype=float),
+            flux=df["flux"].to_numpy(dtype=float),
+            kind=self.kind,
+            fingerprint=self.fingerprint,
+        )
         selected_w, selected_f, _, _ = self.sample(
             viewport or (None, None),
             max_points=max_points,
@@ -207,6 +238,15 @@ class OverlayTrace:
             kind=self.kind,
             fingerprint=self.fingerprint,
         )
+
+
+@dataclass(frozen=True)
+class QuantIROption:
+    label: str
+    query: str
+    available: bool
+    relative_uncertainty: Optional[str] = None
+    apodizations: Tuple[str, ...] = ()
 
     @property
     def points(self) -> int:
@@ -1402,9 +1442,13 @@ def _render_line_catalog_group(container: DeltaGenerator) -> None:
     if not online:
         container.caption("Using local cache")
         container.info("NIST lookups are unavailable while offline.")
-        return
     container.markdown("NIST ASD lines")
-    _render_nist_form(container)
+    if online:
+        _render_nist_form(container)
+    else:
+        container.caption("Connect to the network to fetch NIST ASD lines.")
+    container.markdown("NIST Quantitative IR spectra")
+    _render_nist_quant_ir_form(container, online=online)
 
 
 def _render_nist_form(container: DeltaGenerator) -> None:
@@ -1438,6 +1482,111 @@ def _render_nist_form(container: DeltaGenerator) -> None:
     payload = _convert_nist_payload(result)
     if not payload:
         container.warning("NIST returned no lines for that query.")
+        return
+    added, message = _add_overlay_payload(payload)
+    (container.success if added else container.info)(message)
+
+
+def _normalise_quant_ir_token(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", (value or "").lower())
+
+
+def _build_quant_ir_options(
+    catalog: Sequence[Mapping[str, object]]
+) -> List[QuantIROption]:
+    lookup: Dict[str, Mapping[str, object]] = {}
+    for entry in catalog:
+        name = str(entry.get("name") or "")
+        if not name:
+            continue
+        lookup[_normalise_quant_ir_token(name)] = entry
+
+    options: List[QuantIROption] = []
+    for molecule in NIST_QUANT_IR_MOLECULES:
+        query = molecule["query"]
+        entry = lookup.get(_normalise_quant_ir_token(query))
+        if entry:
+            relative = entry.get("relative_uncertainty")
+            relative_str = str(relative) if isinstance(relative, str) and relative else None
+            apodizations_raw = entry.get("measurements") or ()
+            apodizations: List[str] = []
+            for candidate in apodizations_raw:
+                if isinstance(candidate, Mapping):
+                    label = candidate.get("apodization")
+                    if label:
+                        apodizations.append(str(label))
+            options.append(
+                QuantIROption(
+                    label=molecule["label"],
+                    query=query,
+                    available=True,
+                    relative_uncertainty=relative_str,
+                    apodizations=tuple(apodizations),
+                )
+            )
+        else:
+            options.append(
+                QuantIROption(
+                    label=molecule["label"],
+                    query=query,
+                    available=False,
+                    relative_uncertainty=None,
+                    apodizations=(),
+                )
+            )
+    return options
+
+
+def _format_quant_ir_option(option: QuantIROption) -> str:
+    label = option.label
+    if not option.available:
+        return f"{label} — unavailable"
+    if option.relative_uncertainty:
+        return f"{label} ({option.relative_uncertainty} uncertainty)"
+    return label
+
+
+def _render_nist_quant_ir_form(
+    container: DeltaGenerator, *, online: bool
+) -> None:
+    if not online:
+        container.caption("Connect to the network to fetch NIST Quantitative IR spectra.")
+        return
+    try:
+        catalog = _cached_quant_ir_catalog()
+    except nist_quant_ir.QuantIRFetchError as exc:
+        container.error(f"NIST Quant IR catalog unavailable: {exc}")
+        return
+    options = _build_quant_ir_options(catalog)
+    if not options:
+        container.warning("No NIST Quant IR molecules configured.")
+        return
+
+    form = container.form("nist_quant_ir_form", clear_on_submit=False)
+    selection = form.selectbox(
+        "Molecule",
+        options,
+        format_func=_format_quant_ir_option,
+    )
+    form.caption(
+        f"Resolution fixed at {NIST_QUANT_IR_RESOLUTION:.3f} cm⁻¹ using catalogued apodization windows."
+    )
+    submitted = form.form_submit_button("Fetch spectrum", use_container_width=True)
+    if not submitted:
+        return
+    if not selection.available:
+        container.info(
+            f"{selection.label} is not currently available in the NIST Quantitative IR catalog."
+        )
+        return
+    try:
+        payload = fetch_spectrum(
+            "nist-quant-ir",
+            species=selection.query,
+            resolution_cm_1=NIST_QUANT_IR_RESOLUTION,
+        )
+    except (FetchError, ValueError, RuntimeError) as exc:
+        container.error(f"NIST Quant IR fetch failed: {exc}")
         return
     added, message = _add_overlay_payload(payload)
     (container.success if added else container.info)(message)

--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.1m",
+  "version": "v1.2.1n",
   "date_utc": "2025-10-27T00:00:00Z",
-  "summary": "Auto-select original wavelength units for uploaded spectra and document the behaviour."
+  "summary": "Add a NIST Quantitative IR fetcher with preset molecules at 0.125 cm⁻¹ resolution."
 }

--- a/docs/ai_log/2025-10-27.md
+++ b/docs/ai_log/2025-10-27.md
@@ -1,5 +1,19 @@
 # AI Log — 2025-10-27
 
+## Tasking — Integrate NIST Quantitative IR catalog
+- Scrape the Quant IR species table, resolve the 0.125 cm⁻¹ JCAMP entries, and expose the spectra through the app with provenance and regression coverage.
+
+## Actions & Decisions
+- Implemented a dedicated `nist_quant_ir` fetcher that caches the catalog, extracts JCAMP links, and annotates overlays with relative uncertainty, apodization, and source URLs. 【F:app/server/fetchers/nist_quant_ir.py†L1-L220】
+- Added a preset molecule selector to the line catalog panel with cached availability hints and fallback messaging for molecules missing from the Quant IR list. 【F:app/ui/main.py†L53-L122】【F:app/ui/main.py†L1372-L1455】
+- Documented the workflow in the quick start guide and added parser regressions to lock table parsing, JCAMP extraction, and apodization preference logic. 【F:docs/app/user_guide.md†L11-L18】【F:tests/server/test_nist_quant_ir.py†L1-L64】
+
+## Verification
+- `pytest tests/server/test_nist_quant_ir.py -q`
+
+## Docs Consulted
+- None (live NIST Quant IR page inspection).
+
 ## Tasking — Restore clean v1.2.1 baseline
 - Remove merge conflict artifacts introduced during an aborted plugin refactor and realign release collateral.
 

--- a/docs/app/user_guide.md
+++ b/docs/app/user_guide.md
@@ -12,6 +12,11 @@ The **Reference spectra** drawer on the left keeps quick actions together:
 - **NIST ASD lines** – fetch curated line lists directly from the app by typing
   an element (e.g. `Fe II`) and wavelength bounds. The lines arrive pre-tagged
   with metadata and can be toggled on or off alongside your uploaded spectra.
+- **NIST Quantitative IR spectra** – choose a molecule such as benzene,
+  dichloromethane, or sulfur hexafluoride from the preset list to pull the
+  0.125&nbsp;cm⁻¹ resolution scan from the Quant IR database. Each overlay records
+  the advertised apodization window, relative uncertainty, and JCAMP source so
+  it is easy to compare the lab reference against your own measurements.
 
 All traces land in the overlay table with provenance and duplicate controls so
 it is always obvious where each series originated.

--- a/docs/atlas/brains.md
+++ b/docs/atlas/brains.md
@@ -1,3 +1,8 @@
+# NIST Quantitative IR fetcher — 2025-10-27
+- Built a dedicated `nist_quant_ir` fetcher that scrapes the Quant IR catalog, selects the preferred 0.125 cm⁻¹ apodization window, resolves JCAMP links, and normalises metadata/provenance for overlays. 【F:app/server/fetchers/nist_quant_ir.py†L1-L220】
+- Exposed the new archive through the line catalog panel with a cached molecule selector that flags unavailable entries while funnelling successful picks through the overlay ingestion flow. 【F:app/ui/main.py†L53-L122】【F:app/ui/main.py†L1372-L1455】
+- Added parser and selection unit tests to lock the catalog row-span handling, JCAMP link extraction, and apodization priority behaviour. 【F:tests/server/test_nist_quant_ir.py†L1-L64】
+
 # JCAMP-DX overlay ingestion — 2025-10-27
 - Implemented a JCAMP parser that tokenises XYDATA blocks, converts X units to nanometres with spectral equivalencies, drops uncertainty-labelled segments, and records provenance for caching tiers. 【F:app/server/ingest_jcamp.py†L20-L383】
 - Updated `_detect_format` and ingest routing so `.jdx` extensions or JCAMP headers trigger the new parser before falling back to ASCII handling. 【F:app/utils/local_ingest.py†L11-L75】【F:app/utils/local_ingest.py†L305-L404】

--- a/docs/patch_notes/v1.2.1n.md
+++ b/docs/patch_notes/v1.2.1n.md
@@ -1,0 +1,9 @@
+# Spectra App v1.2.1n — 2025-10-27
+
+## Summary
+- Add a NIST Quantitative IR fetcher that parses the catalog, resolves 0.125 cm⁻¹ JCAMP spectra, and normalises metadata and provenance for overlays.
+- Surface a preset molecule selector in the line catalog panel with availability hints and cached catalog lookups.
+- Document the workflow in the quick start guide and back the catalog parsing utilities with unit tests.
+
+## Verification
+- `pytest tests/server/test_nist_quant_ir.py -q`

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ pandas>=2.2
 astropy>=6.0
 astroquery>=0.4.7
 requests>=2.32
+beautifulsoup4>=4.12
 pyvo
 pyyaml
 rich

--- a/tests/server/test_nist_quant_ir.py
+++ b/tests/server/test_nist_quant_ir.py
@@ -1,0 +1,92 @@
+import pytest
+
+from app.server.fetchers import nist_quant_ir
+
+
+def test_parse_catalog_extracts_species_and_resolutions():
+    html = """
+    <table class="list">
+      <tr>
+        <th>Species</th><th>Relative</th><th>Apodization</th><th>Resolution</th>
+      </tr>
+      <tr>
+        <td rowspan="2">Benzene</td>
+        <td rowspan="2">2.1 %</td>
+        <td>Boxcar</td>
+        <td>
+          <a href="../../cgi/cbook.cgi?ID=71-43-2&amp;Type=IR-SPEC&amp;Index=QUANT-IR,4#IR-SPEC">0.125</a>
+          <a href="../../cgi/cbook.cgi?ID=71-43-2&amp;Type=IR-SPEC&amp;Index=QUANT-IR,3#IR-SPEC">0.25</a>
+        </td>
+      </tr>
+      <tr>
+        <td>Triangular</td>
+        <td>
+          <a href="../../cgi/cbook.cgi?ID=71-43-2&amp;Type=IR-SPEC&amp;Index=QUANT-IR,9#IR-SPEC">0.125</a>
+        </td>
+      </tr>
+      <tr>
+        <td rowspan="1">Toluene</td>
+        <td rowspan="1">2.0 %</td>
+        <td>Boxcar</td>
+        <td>
+          <a href="../../cgi/cbook.cgi?ID=108-88-3&amp;Type=IR-SPEC&amp;Index=QUANT-IR,4#IR-SPEC">0.125</a>
+        </td>
+      </tr>
+    </table>
+    """
+    catalog = nist_quant_ir._parse_catalog(html)
+    assert "benzene" in catalog
+    benzene = catalog["benzene"]
+    assert benzene.name == "Benzene"
+    assert benzene.relative_uncertainty == "2.1 %"
+    assert len(benzene.measurements) == 2
+    first_measurement = benzene.measurements[0]
+    assert first_measurement.apodization == "Boxcar"
+    assert 0.125 in first_measurement.resolution_links
+    assert first_measurement.resolution_links[0.125].startswith(
+        "https://webbook.nist.gov/cgi/cbook.cgi?ID=71-43-2"
+    )
+    assert "toluene" in catalog
+
+
+def test_extract_jcamp_url_returns_absolute_path():
+    page_html = """
+    <html>
+      <body>
+        <script>
+          display_jcamp('/cgi/cbook.cgi?JCAMP=C71432&amp;Index=7&amp;Type=IR', null, 'jcamp-plot', 400, function () {});
+        </script>
+      </body>
+    </html>
+    """
+    page_url = "https://webbook.nist.gov/cgi/cbook.cgi?ID=71-43-2&Type=IR-SPEC&Index=QUANT-IR,4#IR-SPEC"
+    result = nist_quant_ir._extract_jcamp_url(page_html, page_url)
+    assert (
+        result
+        == "https://webbook.nist.gov/cgi/cbook.cgi?JCAMP=C71432&Index=7&Type=IR"
+    )
+
+
+def test_choose_measurement_prefers_priority_apodization():
+    species = nist_quant_ir.QuantIRSpecies(
+        name="Benzene",
+        relative_uncertainty="2.1 %",
+        measurements=(
+            nist_quant_ir.QuantIRMeasurement(
+                apodization="Triangular",
+                resolution_links={0.125: "https://example.invalid/tri"},
+            ),
+            nist_quant_ir.QuantIRMeasurement(
+                apodization="Boxcar",
+                resolution_links={0.125: "https://example.invalid/box"},
+            ),
+        ),
+    )
+    measurement, resolution, href = nist_quant_ir._choose_measurement(
+        species,
+        resolution_cm_1=0.125,
+        priority=("Boxcar", "Triangular"),
+    )
+    assert resolution == pytest.approx(0.125)
+    assert measurement.apodization == "Boxcar"
+    assert href == "https://example.invalid/box"


### PR DESCRIPTION
## Summary
- add a NIST Quantitative IR fetcher that parses the catalog, resolves 0.125 cm⁻¹ JCAMP spectra, and annotates overlays with provenance
- expose a preset molecule selector in the line catalog sidebar and document the new workflow
- cover the parser utilities with tests and roll release collateral (version, patch notes, patch log, AI log)

## Testing
- pytest tests/server/test_nist_quant_ir.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e451b187948329bd4200282f85602d