### PR TITLE
Expose manual Quant IR catalog helper and guard sidebar fallback

### DIFF
--- a/app/server/fetchers/nist_quant_ir.py
+++ b/app/server/fetchers/nist_quant_ir.py
@@ -17,6 +17,7 @@ __all__ = [
     "DEFAULT_RESOLUTION_CM_1",
     "QuantIRFetchError",
     "available_species",
+    "manual_species_catalog",
     "fetch",
 ]
 
@@ -155,6 +156,12 @@ def _cached_catalog() -> Dict[str, QuantIRSpecies]:
 
 
 def _manual_species_catalog() -> Dict[str, QuantIRSpecies]:
+    return manual_species_catalog()
+
+
+def manual_species_catalog() -> Dict[str, QuantIRSpecies]:
+    """Return manually curated Quant IR species records."""
+
     return dict(_MANUAL_SPECIES_CATALOG)
 
 

--- a/app/ui/main.py
+++ b/app/ui/main.py
@@ -1585,12 +1585,22 @@ def _render_nist_quant_ir_form(
     form.caption(
         f"Resolution fixed at {NIST_QUANT_IR_RESOLUTION:.3f} cm⁻¹ using catalogued apodization windows."
     )
-    manual_names = sorted(
-        {
-            species.name
-            for species in nist_quant_ir._manual_species_catalog().values()
-        }
-    )
+    manual_catalog_getter = getattr(
+        nist_quant_ir, "manual_species_catalog", None
+    ) or getattr(nist_quant_ir, "_manual_species_catalog", None)
+    manual_names: Tuple[str, ...] = ()
+    if callable(manual_catalog_getter):
+        try:
+            manual_names = tuple(
+                sorted(
+                    {
+                        species.name
+                        for species in manual_catalog_getter().values()
+                    }
+                )
+            )
+        except Exception:  # pragma: no cover - defensive fallback
+            manual_names = ()
     if manual_names:
         form.caption(
             "Manual entries ({names}) map to the highest-resolution NIST WebBook IR spectra and are flagged in provenance.".format(

--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.1q",
-  "date_utc": "2025-10-27T00:00:00Z",
-  "summary": "Map WebBook IR fallbacks for H2O/CO2/methane, resample them to 0.125 cm⁻¹, and flag provenance in the Quant IR selector."
+  "version": "v1.2.1r",
+  "date_utc": "2025-10-28T00:00:00Z",
+  "summary": "Expose a public Quant IR manual catalog helper, guard the sidebar selector against missing APIs, and retain provenance cues."
 }

--- a/docs/ai_log/2025-10-07.md
+++ b/docs/ai_log/2025-10-07.md
@@ -22,3 +22,19 @@
 ## Docs Consulted
 - Spectra App v1.2+ – Handoff Protocol & Task Blueprint. 【F:docs/ai_handoff/Spectra App v1.2+ – Handoff Protocol & Task Blueprint.txt†L1-L78】
 - MAST API Documentation (field catalog). 【F:docs/mirrored/mast_api.meta.json†L1-L6】
+
+## Tasking — v1.2.1r
+- Restore the Quant IR sidebar by providing a supported hook for manual WebBook species when the private helper is absent.
+- Keep manual provenance messaging intact while tolerating fetcher implementations that pre-date the helper rename.
+- Refresh release collateral and unit coverage in line with the v1.2 continuity contract.
+
+## Actions & Decisions
+- Added a public `manual_species_catalog()` export that mirrors the curated WebBook entries while keeping `_manual_species_catalog()` as a compatibility alias. 【F:app/server/fetchers/nist_quant_ir.py†L18-L135】
+- Updated the Quant IR sidebar form to call whichever helper exists and defensively swallow catalog lookup failures so the panel renders even on legacy deployments. 【F:app/ui/main.py†L1557-L1591】
+- Swapped the regression onto the public helper and rolled release metadata/notes to capture the change. 【F:tests/server/test_nist_quant_ir.py†L96-L109】【F:app/version.json†L1-L5】【F:docs/patch_notes/v1.2.1r.md†L1-L10】
+
+## Verification
+- `pytest tests/server/test_nist_quant_ir.py -q` 【b20783†L1-L2】
+
+## Docs Consulted — v1.2.1r
+- _None._

--- a/docs/atlas/brains.md
+++ b/docs/atlas/brains.md
@@ -3,6 +3,11 @@
 - Exposed the new archive through the line catalog panel with a cached molecule selector that flags unavailable entries while funnelling successful picks through the overlay ingestion flow. 【F:app/ui/main.py†L53-L122】【F:app/ui/main.py†L1372-L1455】
 - Added parser and selection unit tests to lock the catalog row-span handling, JCAMP link extraction, and apodization priority behaviour. 【F:tests/server/test_nist_quant_ir.py†L1-L64】
 
+# Quant IR manual catalog API — 2025-10-28
+- Promoted a public `manual_species_catalog()` accessor that mirrors the curated WebBook fallbacks while leaving the legacy `_manual_species_catalog()` alias intact for compatibility. 【F:app/server/fetchers/nist_quant_ir.py†L18-L120】【F:app/server/fetchers/nist_quant_ir.py†L126-L135】
+- Hardened the Quant IR sidebar helper to consume either accessor and swallow unexpected catalog errors so the UI keeps rendering. 【F:app/ui/main.py†L1565-L1590】
+- Updated the Quant IR regression to rely on the supported helper, keeping manual coverage assertions aligned with the new API. 【F:tests/server/test_nist_quant_ir.py†L96-L109】
+
 # JCAMP-DX overlay ingestion — 2025-10-27
 - Implemented a JCAMP parser that tokenises XYDATA blocks, converts X units to nanometres with spectral equivalencies, drops uncertainty-labelled segments, and records provenance for caching tiers. 【F:app/server/ingest_jcamp.py†L20-L383】
 - Updated `_detect_format` and ingest routing so `.jdx` extensions or JCAMP headers trigger the new parser before falling back to ASCII handling. 【F:app/utils/local_ingest.py†L11-L75】【F:app/utils/local_ingest.py†L305-L404】

--- a/docs/patch_notes/v1.2.1r.md
+++ b/docs/patch_notes/v1.2.1r.md
@@ -1,0 +1,9 @@
+# Spectra App v1.2.1r — 2025-10-28
+
+## Summary
+- expose a supported `manual_species_catalog()` helper so the Quant IR fetcher surfaces curated WebBook mappings without relying on a private API
+- harden the Quant IR sidebar copy to tolerate legacy deployments that are missing the helper while still advertising manual coverage
+- refresh regression coverage and release metadata for the manual catalog accessor change
+
+## Verification
+- `pytest tests/server/test_nist_quant_ir.py -q`

--- a/tests/server/test_nist_quant_ir.py
+++ b/tests/server/test_nist_quant_ir.py
@@ -94,7 +94,7 @@ def test_choose_measurement_prefers_priority_apodization():
 
 
 def test_manual_species_catalog_includes_requested_entries():
-    manual_catalog = nist_quant_ir._manual_species_catalog()
+    manual_catalog = nist_quant_ir.manual_species_catalog()
     assert "h2o" in manual_catalog
     water = manual_catalog["h2o"]
     measurement = water.measurements[0]


### PR DESCRIPTION
## Summary
- add a supported `manual_species_catalog()` export while retaining the legacy private alias for compatibility
- update the Quant IR sidebar form to consume either helper and avoid hard crashes when the accessor is missing
- refresh the Quant IR test, release metadata, brains, and patch notes to cover the new API

## Testing
- pytest tests/server/test_nist_quant_ir.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e55d0e34048329b1af528decf65f35