### PR TITLE
Add dual-axis plotting for absorbance and transmittance

### DIFF
--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.1y",
+  "version": "v1.2.1z",
   "date_utc": "2025-10-28T00:00:00Z",
-  "summary": "Preserve native NIST WebBook transmittance samples while tagging cm⁻¹ axes and providing offline manual fallbacks."
+  "summary": "Add dual-axis absorbance/transmittance plotting so raw intensity scales stay intact by default."
 }

--- a/docs/ai_log/2025-10-28.md
+++ b/docs/ai_log/2025-10-28.md
@@ -1,0 +1,12 @@
+# AI Log — 2025-10-28
+
+## Tasking — Keep absorbance and transmittance on native scales
+- Added `_flux_axis_category` detection and dual-axis routing in `_build_overlay_figure` so absorbance overlays use a dedicated y-axis while transmittance and other flux traces remain on the primary scale. 【F:app/ui/main.py†L2116-L2437】
+- Updated `_add_line_trace` to honor Plotly's secondary axes, ensuring hover markers follow the same absorbance/transmittance split. 【F:app/ui/main.py†L2189-L2235】
+- Bumped release metadata and patch notes to advertise the new dual-axis plotting. 【F:app/version.json†L1-L4】【F:docs/patch_notes/v1.2.1z.md†L1-L6】
+
+## Verification
+- `python -m compileall app/ui/main.py` 【7deb01†L1-L2】
+
+## Docs Consulted
+- `docs/runtime.json` 【F:docs/runtime.json†L1-L21】

--- a/docs/atlas/brains.md
+++ b/docs/atlas/brains.md
@@ -12,6 +12,10 @@
 - Updated the Quant IR manual caption lookup to catch missing `_manual_species_catalog` attributes so older deployments keep rendering the sidebar without raising AttributeError. 【F:app/ui/main.py†L1583-L1597】
 - Recorded the release metadata bump for the resilience fix. 【F:app/version.json†L1-L5】
 
+# Dual-axis flux rendering — 2025-10-28
+- Introduced `_flux_axis_category` plus secondary-axis routing in `_build_overlay_figure` so absorbance traces land on a dedicated y-axis while transmittance and mixed flux data stay on the primary scale. 【F:app/ui/main.py†L2116-L2437】
+- Updated `_add_line_trace` to support Plotly secondary axes, keeping per-point hover markers aligned with whichever flux axis the overlay targets. 【F:app/ui/main.py†L2189-L2235】
+
 # JCAMP-DX overlay ingestion — 2025-10-27
 - Implemented a JCAMP parser that tokenises XYDATA blocks, converts X units to nanometres with spectral equivalencies, drops uncertainty-labelled segments, and records provenance for caching tiers. 【F:app/server/ingest_jcamp.py†L20-L383】
 - Updated `_detect_format` and ingest routing so `.jdx` extensions or JCAMP headers trigger the new parser before falling back to ASCII handling. 【F:app/utils/local_ingest.py†L11-L75】【F:app/utils/local_ingest.py†L305-L404】

--- a/docs/patch_notes/v1.2.1z.md
+++ b/docs/patch_notes/v1.2.1z.md
@@ -1,0 +1,5 @@
+# v1.2.1z — 2025-10-28
+
+- add a secondary y-axis for absorbance overlays so transmittance and absorbance traces retain their native scales without manual conversions
+- route absorbance traces to the secondary axis automatically while keeping transmittance and other flux kinds on the primary axis for consistent legends
+- update release metadata to announce the dual-axis plotting support


### PR DESCRIPTION
## Summary
- add `_flux_axis_category` detection and secondary-axis routing so absorbance overlays render on their own scale
- extend the line-plot helper to work with Plotly secondary axes without losing hover markers
- record the change in the release metadata, patch notes, and daily AI log

## Testing
- python -m compileall app/ui/main.py

------
https://chatgpt.com/codex/tasks/task_e_68e5a31c3ad08329bdd6077f3615e512