### PR TITLE
Add IR-SPEC provenance links for manual NIST Quant IR presets

### DIFF
--- a/PATCHLOG.txt
+++ b/PATCHLOG.txt
@@ -50,5 +50,6 @@ Spectra App — Patch Log (append-only)
 - v1.2.1x: Rebuild the Quant IR manual catalog around authoritative WebBook JCAMP links, convert catalog spectra using pressure-derived Beer–Lambert scaling, and promote cm⁻¹ axis metadata across server and UI layers.
 - v1.2.1y: Stop renormalising NIST IR spectra, keep manual WebBook samples intact with cm⁻¹ tagging, and fall back to the offline catalog when the Quant IR table is unavailable.
 - v1.2.1aa: Preserve Quant IR raw wavelength/flux metadata without forcing cm⁻¹ conversions so overlays display the archived units verbatim.
+- v1.2.1ab: Attach WebBook IR-SPEC source URLs to the manual H2O/CH4/CO2 Quant IR presets and surface the provenance links in metadata.
 
 - v1.2.1aa (IR health hotfix): convert IR JCAMP Y-units to A10 with provenance, verify FIRSTY vs scaled samples, flip cm⁻¹ axes only when descending, and expose a ?health=1 Streamlit endpoint.

--- a/app/server/fetchers/nist_quant_ir.py
+++ b/app/server/fetchers/nist_quant_ir.py
@@ -562,6 +562,8 @@ def fetch(
         manual_record = _MANUAL_SPECIES_LOOKUP.get(key)
         if manual_record and manual_record.tokens:
             metadata["aliases"] = tuple(sorted({alias for alias in manual_record.tokens}))
+        if manual_record and manual_record.sources:
+            metadata["source_urls"] = tuple(manual_record.sources)
     if delta_x is not None:
         metadata["source_delta_x_cm_1"] = delta_x
     payload["metadata"] = metadata
@@ -578,6 +580,8 @@ def fetch(
         manual_record = _MANUAL_SPECIES_LOOKUP.get(key)
         if manual_record and manual_record.tokens:
             provenance["aliases"] = tuple(sorted({alias for alias in manual_record.tokens}))
+        if manual_record and manual_record.sources:
+            provenance["source_urls"] = tuple(manual_record.sources)
     if delta_x is not None:
         provenance["source_delta_x_cm_1"] = delta_x
     payload["provenance"] = provenance
@@ -604,6 +608,7 @@ class ManualSpeciesRecord:
     tokens: Tuple[str, ...]
     relative_uncertainty: str = "—"
     apodization: str = "Manual (best available)"
+    sources: Tuple[str, ...] = ()
 
     def species(self) -> QuantIRSpecies:
         return QuantIRSpecies(
@@ -626,16 +631,25 @@ _MANUAL_SPECIES_RECORDS: Tuple[ManualSpeciesRecord, ...] = (
         name="Water",
         page_url="https://webbook.nist.gov/cgi/cbook.cgi?JCAMP=C7732185&Index=1&Type=IR",
         tokens=("H2O", "7732-18-5"),
+        sources=(
+            "https://webbook.nist.gov/cgi/cbook.cgi?ID=C7732185&Type=IR-SPEC&Index=1",
+        ),
     ),
     ManualSpeciesRecord(
         name="Methane",
         page_url="https://webbook.nist.gov/cgi/cbook.cgi?JCAMP=C74828&Index=1&Type=IR",
         tokens=("CH4", "74-82-8"),
+        sources=(
+            "https://webbook.nist.gov/cgi/cbook.cgi?ID=C74828&Type=IR-SPEC&Index=1",
+        ),
     ),
     ManualSpeciesRecord(
         name="Carbon Dioxide",
         page_url="https://webbook.nist.gov/cgi/cbook.cgi?JCAMP=C124389&Index=1&Type=IR",
         tokens=("CO2", "124-38-9"),
+        sources=(
+            "https://webbook.nist.gov/cgi/cbook.cgi?ID=C124389&Type=IR-SPEC&Index=1",
+        ),
     ),
     ManualSpeciesRecord(
         name="Benzene",

--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.1aa",
-  "date_utc": "2025-10-28T00:00:00Z",
-  "summary": "Normalize IR JCAMP units to A10, add ?health=1 endpoint, and guard initial routing."
+  "version": "v1.2.1ab",
+  "date_utc": "2025-10-29T00:00:00Z",
+  "summary": "Attach WebBook IR-SPEC provenance to manual H2O/CH4/CO2 Quant IR presets."
 }

--- a/docs/ai_log/2025-10-29.md
+++ b/docs/ai_log/2025-10-29.md
@@ -1,0 +1,13 @@
+# AI Log — 2025-10-29
+
+## Tasking — Record IR-SPEC provenance for manual Quant IR presets
+- Added `source_urls` support to manual Quant IR records so the Water/CH₄/CO₂ fallbacks expose their authoritative NIST WebBook IR-SPEC catalog pages via metadata and provenance. 【F:app/server/fetchers/nist_quant_ir.py†L225-L580】
+- Extended the manual catalog regression to assert the new IR-SPEC links for water, methane, and carbon dioxide. 【F:tests/server/test_nist_quant_ir.py†L99-L137】
+- Rolled release metadata, patch notes, and patch log for v1.2.1ab to document the provenance update. 【F:app/version.json†L1-L5】【F:docs/patch_notes/v1.2.1ab.md†L1-L4】【F:PATCHLOG.txt†L52-L53】
+
+## Verification
+- `pytest tests/server/test_nist_quant_ir.py -q` 【b99d5e†L1-L2】
+
+## Docs Consulted
+- `docs/runtime.json` 【F:docs/runtime.json†L1-L21】
+- `https://pages.nist.gov/dimspec/docs/references.html` 【F:docs/mirrored/nist_dimspec/references.meta.json†L1-L7】

--- a/docs/atlas/brains.md
+++ b/docs/atlas/brains.md
@@ -206,6 +206,10 @@
 - Added catalog fallbacks to serve manual WebBook entries when the live Quant IR table cannot be fetched, keeping Water/CO₂/CH₄ available offline. 【F:app/server/fetchers/nist_quant_ir.py†L236-L305】【F:app/server/fetchers/nist_quant_ir.py†L308-L337】
 - Reworked the regression to confirm `_finalise_payload` leaves flux arrays untouched while labelling cm⁻¹ metadata. 【F:tests/server/test_nist_quant_ir.py†L1-L120】
 
+# Quant IR manual provenance links — 2025-10-29
+- Recorded the authoritative NIST WebBook IR-SPEC catalog pages for the manual Water/CH₄/CO₂ presets and surfaced them through the metadata/provenance `source_urls` fields so overlays keep clickable provenance. 【F:app/server/fetchers/nist_quant_ir.py†L225-L580】
+- Extended the manual catalog regression to assert those IR-SPEC sources are wired into the manual lookup for Water, methane, and carbon dioxide. 【F:tests/server/test_nist_quant_ir.py†L99-L137】
+
 # Quant IR unit fidelity guard — 2025-10-28
 - Removed the injected `wavenumber_cm_1` arrays so Quant IR payloads carry only the raw wavelength samples reported by NIST, while keeping metadata/provenance hints aligned with the advertised unit. 【F:app/server/fetchers/nist_quant_ir.py†L1-L220】【F:app/server/fetchers/nist_quant_ir.py†L220-L360】
 - Updated release metadata and patch notes to document the raw-axis preservation. 【F:app/version.json†L1-L5】【F:docs/patch_notes/v1.2.1aa.md†L1-L5】

--- a/docs/patch_notes/v1.2.1ab.md
+++ b/docs/patch_notes/v1.2.1ab.md
@@ -1,0 +1,4 @@
+# v1.2.1ab — 2025-10-29
+
+- log the NIST WebBook IR-SPEC catalog pages for the manual water, methane, and carbon dioxide Quant IR presets
+- surface the IR-SPEC source URLs in metadata/provenance so overlays carry linkable provenance for those manual spectra

--- a/tests/server/test_nist_quant_ir.py
+++ b/tests/server/test_nist_quant_ir.py
@@ -124,6 +124,24 @@ def test_manual_species_catalog_includes_requested_entries():
     link = measurement.resolution_links[nist_quant_ir.DEFAULT_RESOLUTION_CM_1]
     assert link.startswith("https://webbook.nist.gov/cgi/cbook.cgi?JCAMP=C7732185")
 
+    manual_lookup = getattr(nist_quant_ir, "_MANUAL_SPECIES_LOOKUP")
+    water_record = manual_lookup[nist_quant_ir._normalise_token("Water")]
+    methane_record = manual_lookup[nist_quant_ir._normalise_token("Methane")]
+    carbon_dioxide_record = manual_lookup[nist_quant_ir._normalise_token("Carbon Dioxide")]
+
+    assert (
+        "https://webbook.nist.gov/cgi/cbook.cgi?ID=C7732185&Type=IR-SPEC&Index=1"
+        in water_record.sources
+    )
+    assert (
+        "https://webbook.nist.gov/cgi/cbook.cgi?ID=C74828&Type=IR-SPEC&Index=1"
+        in methane_record.sources
+    )
+    assert (
+        "https://webbook.nist.gov/cgi/cbook.cgi?ID=C124389&Type=IR-SPEC&Index=1"
+        in carbon_dioxide_record.sources
+    )
+
 
 def test_extract_delta_x_parses_numeric_value():
     assert nist_quant_ir._extract_delta_x(b"##DELTAX=0.125\n") == pytest.approx(0.125)


### PR DESCRIPTION
## Summary
- add IR-SPEC source URL support to manual NIST Quant IR species records for water, methane, and carbon dioxide
- surface the new source URLs in metadata/provenance and document the change in brains, patch notes, and patch log
- extend the manual catalog regression and bump release metadata to v1.2.1ab

## Testing
- `pytest tests/server/test_nist_quant_ir.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68e6693dd5288329a07a72332c3db311