### PR TITLE
Restore manual Quant IR JCAMP fallback

### DIFF
--- a/PATCHLOG.txt
+++ b/PATCHLOG.txt
@@ -50,5 +50,7 @@ Spectra App — Patch Log (append-only)
 - v1.2.1x: Rebuild the Quant IR manual catalog around authoritative WebBook JCAMP links, convert catalog spectra using pressure-derived Beer–Lambert scaling, and promote cm⁻¹ axis metadata across server and UI layers.
 - v1.2.1y: Stop renormalising NIST IR spectra, keep manual WebBook samples intact with cm⁻¹ tagging, and fall back to the offline catalog when the Quant IR table is unavailable.
 - v1.2.1aa: Preserve Quant IR raw wavelength/flux metadata without forcing cm⁻¹ conversions so overlays display the archived units verbatim.
+- v1.2.1ab: Attach WebBook IR-SPEC source URLs to the manual H2O/CH4/CO2 Quant IR presets and surface the provenance links in metadata.
+- v1.2.1ac: Restore manual Quant IR presets by accepting direct JCAMP payloads when the WebBook page omits display_jcamp hooks and update regression coverage.
 
 - v1.2.1aa (IR health hotfix): convert IR JCAMP Y-units to A10 with provenance, verify FIRSTY vs scaled samples, flip cm⁻¹ axes only when descending, and expose a ?health=1 Streamlit endpoint.

--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.1aa",
-  "date_utc": "2025-10-28T00:00:00Z",
-  "summary": "Normalize IR JCAMP units to A10, add ?health=1 endpoint, and guard initial routing."
+  "version": "v1.2.1ac",
+  "date_utc": "2025-10-29T00:00:00Z",
+  "summary": "Restore Quant IR manual fetches when WebBook pages return raw JCAMP data."
 }

--- a/docs/ai_log/2025-10-29.md
+++ b/docs/ai_log/2025-10-29.md
@@ -1,0 +1,25 @@
+# AI Log — 2025-10-29
+
+## Tasking — Record IR-SPEC provenance for manual Quant IR presets
+- Added `source_urls` support to manual Quant IR records so the Water/CH₄/CO₂ fallbacks expose their authoritative NIST WebBook IR-SPEC catalog pages via metadata and provenance. 【F:app/server/fetchers/nist_quant_ir.py†L225-L580】
+- Extended the manual catalog regression to assert the new IR-SPEC links for water, methane, and carbon dioxide. 【F:tests/server/test_nist_quant_ir.py†L99-L137】
+- Rolled release metadata, patch notes, and patch log for v1.2.1ab to document the provenance update. 【F:app/version.json†L1-L5】【F:docs/patch_notes/v1.2.1ab.md†L1-L4】【F:PATCHLOG.txt†L52-L53】
+
+## Verification
+- `pytest tests/server/test_nist_quant_ir.py -q` 【b99d5e†L1-L2】
+
+## Docs Consulted
+- `docs/runtime.json` 【F:docs/runtime.json†L1-L21】
+- `https://pages.nist.gov/dimspec/docs/references.html` 【F:docs/mirrored/nist_dimspec/references.meta.json†L1-L7】
+
+## Tasking — Restore manual Quant IR JCAMP fallback
+- Updated the Quant IR fetcher to reuse manual WebBook JCAMP payloads when the spectrum page responds with raw JCAMP data instead of a `display_jcamp` hook so manual presets load successfully again. 【F:app/server/fetchers/nist_quant_ir.py†L301-L312】
+- Added regression coverage that asserts the JCAMP fallback returns the manual endpoint unchanged for direct JCAMP responses. 【F:tests/server/test_nist_quant_ir.py†L47-L59】
+- Rolled version metadata, patch notes, and patch log for v1.2.1ac documenting the manual JCAMP fallback hotfix. 【F:app/version.json†L1-L5】【F:docs/patch_notes/v1.2.1ac.md†L1-L4】【F:PATCHLOG.txt†L54-L55】
+
+## Verification
+- `pytest tests/server/test_nist_quant_ir.py -q` 【627081†L1-L2】
+
+## Docs Consulted
+- `docs/runtime.json` 【F:docs/runtime.json†L1-L21】
+- `https://pages.nist.gov/dimspec/docs/references.html` 【F:docs/mirrored/nist_dimspec/references.meta.json†L1-L7】

--- a/docs/atlas/brains.md
+++ b/docs/atlas/brains.md
@@ -206,6 +206,14 @@
 - Added catalog fallbacks to serve manual WebBook entries when the live Quant IR table cannot be fetched, keeping Water/CO₂/CH₄ available offline. 【F:app/server/fetchers/nist_quant_ir.py†L236-L305】【F:app/server/fetchers/nist_quant_ir.py†L308-L337】
 - Reworked the regression to confirm `_finalise_payload` leaves flux arrays untouched while labelling cm⁻¹ metadata. 【F:tests/server/test_nist_quant_ir.py†L1-L120】
 
+# Quant IR manual provenance links — 2025-10-29
+- Recorded the authoritative NIST WebBook IR-SPEC catalog pages for the manual Water/CH₄/CO₂ presets and surfaced them through the metadata/provenance `source_urls` fields so overlays keep clickable provenance. 【F:app/server/fetchers/nist_quant_ir.py†L225-L580】
+- Extended the manual catalog regression to assert those IR-SPEC sources are wired into the manual lookup for Water, methane, and carbon dioxide. 【F:tests/server/test_nist_quant_ir.py†L99-L137】
+
+# Quant IR manual JCAMP fallback — 2025-10-29
+- Allowed manual Quant IR presets to reuse direct WebBook JCAMP payloads when the catalog page omits the `display_jcamp` hook, keeping manual fetches operational. 【F:app/server/fetchers/nist_quant_ir.py†L302-L311】
+- Added regression coverage ensuring `_extract_jcamp_url` returns manual JCAMP endpoints unchanged when the response already contains JCAMP-DX records. 【F:tests/server/test_nist_quant_ir.py†L47-L59】
+
 # Quant IR unit fidelity guard — 2025-10-28
 - Removed the injected `wavenumber_cm_1` arrays so Quant IR payloads carry only the raw wavelength samples reported by NIST, while keeping metadata/provenance hints aligned with the advertised unit. 【F:app/server/fetchers/nist_quant_ir.py†L1-L220】【F:app/server/fetchers/nist_quant_ir.py†L220-L360】
 - Updated release metadata and patch notes to document the raw-axis preservation. 【F:app/version.json†L1-L5】【F:docs/patch_notes/v1.2.1aa.md†L1-L5】

--- a/docs/patch_notes/v1.2.1ab.md
+++ b/docs/patch_notes/v1.2.1ab.md
@@ -1,0 +1,4 @@
+# v1.2.1ab — 2025-10-29
+
+- log the NIST WebBook IR-SPEC catalog pages for the manual water, methane, and carbon dioxide Quant IR presets
+- surface the IR-SPEC source URLs in metadata/provenance so overlays carry linkable provenance for those manual spectra

--- a/docs/patch_notes/v1.2.1ac.md
+++ b/docs/patch_notes/v1.2.1ac.md
@@ -1,0 +1,4 @@
+# v1.2.1ac — 2025-10-29
+
+- fall back to direct JCAMP downloads for manual Quant IR presets when the WebBook page does not expose a display_jcamp link
+- add regression coverage to confirm the manual JCAMP fallback and roll release metadata for the hotfix

--- a/tests/server/test_nist_quant_ir.py
+++ b/tests/server/test_nist_quant_ir.py
@@ -68,6 +68,15 @@ def test_extract_jcamp_url_returns_absolute_path():
     )
 
 
+def test_extract_jcamp_url_handles_direct_jcamp_pages():
+    page_html = "##TITLE=Water\n##JCAMP-DX=4.24\n##DATA TYPE=INFRARED SPECTRUM\n"
+    page_url = "https://webbook.nist.gov/cgi/cbook.cgi?JCAMP=C7732185&Index=1&Type=IR"
+
+    result = nist_quant_ir._extract_jcamp_url(page_html, page_url)
+
+    assert result == page_url
+
+
 def test_choose_measurement_prefers_priority_apodization():
     species = nist_quant_ir.QuantIRSpecies(
         name="Benzene",
@@ -123,6 +132,24 @@ def test_manual_species_catalog_includes_requested_entries():
     measurement = water.measurements[0]
     link = measurement.resolution_links[nist_quant_ir.DEFAULT_RESOLUTION_CM_1]
     assert link.startswith("https://webbook.nist.gov/cgi/cbook.cgi?JCAMP=C7732185")
+
+    manual_lookup = getattr(nist_quant_ir, "_MANUAL_SPECIES_LOOKUP")
+    water_record = manual_lookup[nist_quant_ir._normalise_token("Water")]
+    methane_record = manual_lookup[nist_quant_ir._normalise_token("Methane")]
+    carbon_dioxide_record = manual_lookup[nist_quant_ir._normalise_token("Carbon Dioxide")]
+
+    assert (
+        "https://webbook.nist.gov/cgi/cbook.cgi?ID=C7732185&Type=IR-SPEC&Index=1"
+        in water_record.sources
+    )
+    assert (
+        "https://webbook.nist.gov/cgi/cbook.cgi?ID=C74828&Type=IR-SPEC&Index=1"
+        in methane_record.sources
+    )
+    assert (
+        "https://webbook.nist.gov/cgi/cbook.cgi?ID=C124389&Type=IR-SPEC&Index=1"
+        in carbon_dioxide_record.sources
+    )
 
 
 def test_extract_delta_x_parses_numeric_value():


### PR DESCRIPTION
## Summary
- add IR-SPEC source URL support to manual NIST Quant IR species records for water, methane, and carbon dioxide
- surface the new source URLs in metadata/provenance and document the change in brains, patch notes, and patch log
- extend the manual catalog regression and bump release metadata to v1.2.1ab
- restore manual Quant IR presets by accepting direct JCAMP payloads when WebBook pages omit `display_jcamp` hooks and roll v1.2.1ac collateral

## Testing
- `pytest tests/server/test_nist_quant_ir.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68e6693dd5288329a07a72332c3db311