### PR TITLE
Add FTIR functional-group classifier integration

### DIFF
--- a/PATCHLOG.txt
+++ b/PATCHLOG.txt
@@ -52,5 +52,6 @@ Spectra App — Patch Log (append-only)
 - v1.2.1aa: Preserve Quant IR raw wavelength/flux metadata without forcing cm⁻¹ conversions so overlays display the archived units verbatim.
 - v1.2.1ab: Attach WebBook IR-SPEC source URLs to the manual H2O/CH4/CO2 Quant IR presets and surface the provenance links in metadata.
 - v1.2.1ac: Restore manual Quant IR presets by accepting direct JCAMP payloads when the WebBook page omits display_jcamp hooks and update regression coverage.
+- v1.2.1ad: Add FTIR functional-group classification with IR model integration, shaded band overlays, unit coverage, and release collateral updates.
 
 - v1.2.1aa (IR health hotfix): convert IR JCAMP Y-units to A10 with provenance, verify FIRSTY vs scaled samples, flip cm⁻¹ axes only when descending, and expose a ?health=1 Streamlit endpoint.

--- a/README.md
+++ b/README.md
@@ -92,3 +92,39 @@ oh fuck this is gonna display on the front page isnt it lol. whatever.
 If I forget to edit this before showing my teachers.. _Whoops_.
 
 I'll clean it up. 🤣
+
+---
+
+## Functional-group classifier integration
+
+Spectra App now bundles an IR functional-group classifier that projects the
+[`gj475/irchracterizationcnn`](https://github.com/gj475/irchracterizationcnn)
+model into the overlay workspace. Upload an FTIR spectrum, switch the axis to
+cm⁻¹, and use the **Identify functional groups** button on the overlay tab to
+run the classifier. The UI shades the corresponding NIST correlation bands and
+records the model confidences in a dedicated results table. Predictions are
+cached for the current reference overlay so you can continue inspecting the
+same spectrum without rerunning the network each time.
+
+### Assets & setup
+
+- Install the new dependencies from `requirements.txt` (`tensorflow`,
+  `scipy`, `rdkit-pypi`, `fastapi`, `uvicorn`, etc.).
+- Download the pretrained weights and optimal thresholds via
+  `python scripts/fetch_ir_model.py --model-url <model_url> --threshold-url <threshold_url>`
+  which saves the assets under `ml_models/ir_groups/`.
+- (Optional) Launch the FastAPI microservice by pointing `uvicorn` at
+  `app.server.ir_groups_api:app` and set `SPECTRA_IR_GROUP_API_URL` if you want
+  the UI to call the REST endpoint instead of running the classifier in-process.
+
+### Attribution
+
+- Functional-group taxonomy, preprocessing guidance, and pretrained weights are
+  courtesy of the open-source
+  [`irchracterizationcnn`](https://github.com/gj475/irchracterizationcnn)
+  project.
+- Correlation ranges and ground-truth FTIR spectra are sourced from the NIST
+  Chemistry WebBook and related documentation.
+- Supplementary spectral references come from the Spectral Database for Organic
+  Compounds (SDBS). Please cite these resources when publishing work based on
+  the classifier.

--- a/app/server/ir_groups_api.py
+++ b/app/server/ir_groups_api.py
@@ -1,0 +1,96 @@
+"""FastAPI service exposing the IR functional-group classifier."""
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import List, Mapping, Optional
+
+from fastapi import APIRouter, FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+from ml import IRGroupClassifier
+
+
+class SpectrumPayload(BaseModel):
+    """Request body describing an IR spectrum."""
+
+    wavenumber_cm_1: Optional[List[float]] = Field(
+        None, description="Wavenumber samples in cm^-1"
+    )
+    wavelength_nm: Optional[List[float]] = Field(
+        None, description="Wavelength samples in nm (will be converted to cm^-1)"
+    )
+    intensity: List[float] = Field(..., description="Intensity or absorbance samples")
+    normalise: bool = Field(
+        True,
+        description="Apply baseline correction and unit scaling prior to inference",
+    )
+
+    def to_classifier_payload(self) -> Mapping[str, object]:
+        payload: Mapping[str, object] = {
+            "intensity": self.intensity,
+        }
+        if self.wavenumber_cm_1 is not None:
+            payload = {**payload, "wavenumber": self.wavenumber_cm_1}
+        elif self.wavelength_nm is not None:
+            payload = {**payload, "wavelengths": self.wavelength_nm}
+        else:
+            raise ValueError("Request must include wavenumber_cm_1 or wavelength_nm")
+        return payload
+
+
+class FunctionalGroupResponse(BaseModel):
+    name: str
+    probability: float
+    threshold: float
+    present: bool
+
+
+class IRGroupResponse(BaseModel):
+    predictions: List[FunctionalGroupResponse]
+
+
+router = APIRouter()
+
+
+@lru_cache(maxsize=4)
+def _cached_classifier(normalise: bool = True) -> IRGroupClassifier:
+    return IRGroupClassifier(normalise=normalise)
+
+
+@router.post("/api/ir-groups", response_model=IRGroupResponse)
+def identify_ir_groups(payload: SpectrumPayload) -> IRGroupResponse:
+    """Run the IR functional-group classifier and return structured predictions."""
+
+    classifier = _cached_classifier(payload.normalise)
+    try:
+        spectrum = payload.to_classifier_payload()
+        predictions = classifier.predict_groups(spectrum)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except ImportError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return IRGroupResponse(
+        predictions=[
+            FunctionalGroupResponse(
+                name=item.name,
+                probability=item.probability,
+                threshold=item.threshold,
+                present=item.present,
+            )
+            for item in predictions
+        ]
+    )
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="Spectra App IR groups API")
+    app.include_router(router)
+    return app
+
+
+app = create_app()
+
+
+__all__ = ["app", "create_app", "identify_ir_groups"]

--- a/app/ui/ir_group_overlays.py
+++ b/app/ui/ir_group_overlays.py
@@ -1,0 +1,260 @@
+"""Helpers for rendering IR functional-group predictions in the UI."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Mapping, Sequence
+
+import plotly.graph_objects as go
+
+from ml import FunctionalGroupPrediction
+
+
+@dataclass(frozen=True)
+class FunctionalGroupRange:
+    group: str
+    band: str
+    high_cm_1: float
+    low_cm_1: float
+    notes: str = ""
+
+    @property
+    def range_tuple(self) -> tuple[float, float]:
+        return (self.high_cm_1, self.low_cm_1)
+
+
+# Representative correlation ranges compiled from common NIST and SDBS IR charts.
+# Values are approximate and provide visual guidance for the ML predictions.
+FUNCTIONAL_GROUP_RANGES: Dict[str, List[FunctionalGroupRange]] = {
+    "Alkane": [
+        FunctionalGroupRange("Alkane", "C–H stretch", 3000, 2850, "sp3 C–H"),
+        FunctionalGroupRange("Alkane", "C–H bend", 1470, 1370, "methyl deformation"),
+    ],
+    "Alkene": [
+        FunctionalGroupRange("Alkene", "C=C stretch", 1680, 1620),
+        FunctionalGroupRange("Alkene", "=C–H bend", 1000, 650),
+    ],
+    "Alkyne": [
+        FunctionalGroupRange("Alkyne", "C≡C stretch", 2260, 2100),
+        FunctionalGroupRange("Alkyne", "≡C–H stretch", 3330, 3260),
+    ],
+    "Arene": [
+        FunctionalGroupRange("Arene", "Aromatic C=C", 1600, 1400),
+        FunctionalGroupRange("Arene", "Out-of-plane C–H", 900, 670),
+    ],
+    "Haloalkane": [
+        FunctionalGroupRange("Haloalkane", "C–Cl", 800, 600),
+        FunctionalGroupRange("Haloalkane", "C–Br", 650, 500),
+    ],
+    "Alcohol": [
+        FunctionalGroupRange("Alcohol", "O–H stretch", 3650, 3200, "broad hydrogen bonding"),
+        FunctionalGroupRange("Alcohol", "C–O stretch", 1260, 1000),
+    ],
+    "Aldehyde": [
+        FunctionalGroupRange("Aldehyde", "C=O stretch", 1740, 1690),
+        FunctionalGroupRange("Aldehyde", "Fermi doublet", 2830, 2695),
+    ],
+    "Ketone": [
+        FunctionalGroupRange("Ketone", "C=O stretch", 1750, 1680),
+    ],
+    "Carboxylic acid": [
+        FunctionalGroupRange("Carboxylic acid", "O–H stretch", 3550, 2500, "very broad"),
+        FunctionalGroupRange("Carboxylic acid", "C=O stretch", 1725, 1700),
+    ],
+    "Acid anhydride": [
+        FunctionalGroupRange("Acid anhydride", "Asymmetric C=O", 1850, 1770),
+        FunctionalGroupRange("Acid anhydride", "Symmetric C=O", 1780, 1710),
+    ],
+    "Acyl halide": [
+        FunctionalGroupRange("Acyl halide", "C=O stretch", 1820, 1770),
+        FunctionalGroupRange("Acyl halide", "C–Cl stretch", 800, 600),
+    ],
+    "Ester": [
+        FunctionalGroupRange("Ester", "C=O stretch", 1750, 1730),
+        FunctionalGroupRange("Ester", "C–O stretch", 1300, 1000),
+    ],
+    "Ether": [
+        FunctionalGroupRange("Ether", "C–O stretch", 1200, 1020),
+    ],
+    "Amine": [
+        FunctionalGroupRange("Amine", "N–H stretch", 3500, 3250),
+        FunctionalGroupRange("Amine", "C–N stretch", 1250, 1000),
+    ],
+    "Amide": [
+        FunctionalGroupRange("Amide", "Amide I", 1700, 1630),
+        FunctionalGroupRange("Amide", "Amide II", 1570, 1510),
+    ],
+    "Nitrile": [
+        FunctionalGroupRange("Nitrile", "C≡N stretch", 2260, 2220),
+    ],
+    "Imide": [
+        FunctionalGroupRange("Imide", "Symmetric C=O", 1775, 1700),
+    ],
+    "Imine": [
+        FunctionalGroupRange("Imine", "C=N stretch", 1690, 1640),
+    ],
+    "Azo compound": [
+        FunctionalGroupRange("Azo compound", "N=N stretch", 1600, 1500),
+    ],
+    "Thiol": [
+        FunctionalGroupRange("Thiol", "S–H stretch", 2600, 2550),
+    ],
+    "Thial": [
+        FunctionalGroupRange("Thial", "C=S stretch", 1200, 1040),
+    ],
+    "Sulfone": [
+        FunctionalGroupRange("Sulfone", "S=O stretch", 1350, 1290),
+    ],
+    "Sulfonic acid": [
+        FunctionalGroupRange("Sulfonic acid", "S=O stretch", 1350, 1180),
+    ],
+    "Enol": [
+        FunctionalGroupRange("Enol", "O–H stretch", 3600, 3200),
+    ],
+    "Phenol": [
+        FunctionalGroupRange("Phenol", "O–H stretch", 3650, 3200),
+    ],
+    "Hydrazine": [
+        FunctionalGroupRange("Hydrazine", "N–H stretch", 3500, 3150),
+    ],
+    "Enamine": [
+        FunctionalGroupRange("Enamine", "C=C stretch", 1640, 1600),
+    ],
+    "Isocyanate": [
+        FunctionalGroupRange("Isocyanate", "N=C=O stretch", 2280, 2230),
+    ],
+    "Isothiocyanate": [
+        FunctionalGroupRange("Isothiocyanate", "N=C=S stretch", 2160, 2090),
+    ],
+    "Phosphine": [
+        FunctionalGroupRange("Phosphine", "P–H stretch", 2400, 2300),
+    ],
+    "Sulfonamide": [
+        FunctionalGroupRange("Sulfonamide", "S=O stretch", 1360, 1290),
+        FunctionalGroupRange("Sulfonamide", "N–H stretch", 3400, 3200),
+    ],
+    "Sulfonate": [
+        FunctionalGroupRange("Sulfonate", "S=O stretch", 1350, 1180),
+    ],
+    "Sulfoxide": [
+        FunctionalGroupRange("Sulfoxide", "S=O stretch", 1070, 1030),
+    ],
+    "Thioamide": [
+        FunctionalGroupRange("Thioamide", "C=S stretch", 1200, 1120),
+    ],
+    "Hydrazone": [
+        FunctionalGroupRange("Hydrazone", "C=N stretch", 1660, 1600),
+    ],
+    "Carbamate": [
+        FunctionalGroupRange("Carbamate", "C=O stretch", 1740, 1700),
+    ],
+    "Sulfide": [
+        FunctionalGroupRange("Sulfide", "C–S stretch", 740, 570),
+    ],
+}
+
+
+def shaded_ranges_for_predictions(
+    predictions: Sequence[FunctionalGroupPrediction],
+    *,
+    probability_floor: float = 0.25,
+) -> List[FunctionalGroupRange]:
+    """Return the correlation ranges to visualise for the predicted groups."""
+
+    shaded: List[FunctionalGroupRange] = []
+    for item in predictions:
+        if item.probability < probability_floor:
+            continue
+        ranges = FUNCTIONAL_GROUP_RANGES.get(item.name)
+        if not ranges:
+            continue
+        shaded.extend(ranges)
+    return shaded
+
+
+def apply_shaded_ranges(
+    fig: go.Figure,
+    ranges: Iterable[FunctionalGroupRange],
+    *,
+    axis_reversed: bool = True,
+) -> None:
+    """Add shaded rectangles for each functional-group correlation range."""
+
+    for index, entry in enumerate(ranges):
+        x0, x1 = entry.high_cm_1, entry.low_cm_1
+        if axis_reversed:
+            x0, x1 = x1, x0
+        fig.add_shape(
+            type="rect",
+            x0=x0,
+            x1=x1,
+            y0=0,
+            y1=1,
+            yref="paper",
+            fillcolor="rgba(255, 196, 45, 0.15)",
+            line=dict(width=0),
+            layer="below",
+        )
+        fig.add_annotation(
+            x=(x0 + x1) / 2,
+            y=1.02,
+            text=f"{entry.group}: {entry.band}",
+            showarrow=False,
+            xref="x",
+            yref="paper",
+            font=dict(size=11),
+            opacity=0.85,
+        )
+
+
+def build_prediction_table(
+    predictions: Sequence[FunctionalGroupPrediction],
+    *,
+    probability_floor: float = 0.05,
+) -> List[Mapping[str, object]]:
+    """Convert predictions into table rows for Streamlit."""
+
+    rows: List[Mapping[str, object]] = []
+    for item in predictions:
+        if item.probability < probability_floor:
+            continue
+        ranges = FUNCTIONAL_GROUP_RANGES.get(item.name) or []
+        if not ranges:
+            notes = f"Threshold {item.threshold:.2f}"
+            rows.append(
+                {
+                    "Band (cm⁻¹)": "—",
+                    "Range (cm⁻¹)": "—",
+                    "Group": item.name,
+                    "Confidence": f"{item.probability:.2f}",
+                    "Source": "ML",
+                    "Notes": notes,
+                }
+            )
+            continue
+
+        for band in ranges:
+            notes_parts: List[str] = []
+            if band.notes:
+                notes_parts.append(band.notes)
+            notes_parts.append(f"Threshold {item.threshold:.2f}")
+            notes = "; ".join(notes_parts)
+            rows.append(
+                {
+                    "Band (cm⁻¹)": band.band,
+                    "Range (cm⁻¹)": f"{band.high_cm_1:.0f}–{band.low_cm_1:.0f}",
+                    "Group": item.name,
+                    "Confidence": f"{item.probability:.2f}",
+                    "Source": "ML + Range",
+                    "Notes": notes,
+                }
+            )
+    return rows
+
+
+__all__ = [
+    "FUNCTIONAL_GROUP_RANGES",
+    "FunctionalGroupRange",
+    "apply_shaded_ranges",
+    "build_prediction_table",
+    "shaded_ranges_for_predictions",
+]

--- a/app/ui/main.py
+++ b/app/ui/main.py
@@ -37,6 +37,12 @@ from .panel_registry import (
     register_workspace_panel,
 )
 from .targets import RegistryUnavailableError, render_targets_panel
+from .ir_group_overlays import (
+    apply_shaded_ranges,
+    build_prediction_table,
+    shaded_ranges_for_predictions,
+    FunctionalGroupRange,
+)
 
 from .._version import get_version_info
 from ..ingest import OverlayIngestResult
@@ -45,6 +51,7 @@ from ..server.differential import ratio, resample_to_common_grid, subtract
 from ..server.fetch_archives import FetchError, fetch_spectrum
 from ..server.fetchers import nist_quant_ir
 from ..server.ir_units import IRMeta, to_A10
+from ..utils.ir_group_client import identify_functional_groups
 from ..similarity import (
     SimilarityCache,
     SimilarityOptions,
@@ -1158,6 +1165,34 @@ def _get_overlays() -> List[OverlayTrace]:
 def _set_overlays(overlays: Sequence[OverlayTrace]) -> None:
     st.session_state["overlay_traces"] = list(overlays)
     _ensure_reference_consistency()
+    state = st.session_state.get("ir_group_predictions_state")
+    if isinstance(state, dict):
+        trace_id = state.get("trace_id")
+        if trace_id and not any(trace.trace_id == trace_id for trace in overlays):
+            st.session_state["ir_group_predictions_state"] = {}
+
+
+def _trace_ir_vectors(trace: OverlayTrace) -> Tuple[np.ndarray, np.ndarray]:
+    axis_kind = _axis_kind_for_trace(trace)
+    if axis_kind not in {"wavelength", "spectrum", "sed"}:
+        raise ValueError("IR classification requires a wavelength-based spectrum")
+    wavelengths = np.asarray(trace.wavelength_nm, dtype=float)
+    intensities = np.asarray(trace.flux, dtype=float)
+    mask = np.isfinite(wavelengths) & np.isfinite(intensities) & (wavelengths > 0)
+    wavelengths = wavelengths[mask]
+    intensities = intensities[mask]
+    if wavelengths.size == 0:
+        raise ValueError("No finite wavelengths available for IR classification.")
+    wavenumbers = 1e7 / wavelengths
+    return wavenumbers, intensities
+
+
+def _active_ir_prediction_state() -> Dict[str, object]:
+    state = st.session_state.setdefault("ir_group_predictions_state", {})
+    if not isinstance(state, dict):
+        state = {}
+        st.session_state["ir_group_predictions_state"] = state
+    return state
 
 
 def _get_example_spec(slug: str) -> Optional[ExampleSpec]:
@@ -2464,7 +2499,8 @@ def _build_overlay_figure(
     axis_viewport_by_kind: Optional[
         Mapping[str, Tuple[float | None, float | None]]
     ] = None,
-) -> Tuple[go.Figure, str]:
+    ir_ranges: Optional[Sequence[FunctionalGroupRange]] = None,
+) -> Tuple[go.Figure, str, bool]:
     category_lookup: Dict[str, str] = {}
     target_overlays = [trace for trace in overlays if trace.visible] or list(overlays)
     for trace in target_overlays:
@@ -2703,7 +2739,9 @@ def _build_overlay_figure(
             )
         ]
     )
-    return fig, axis_title
+    if ir_ranges and display_units == "cm^-1":
+        apply_shaded_ranges(fig, ir_ranges, axis_reversed=should_reverse_axis)
+    return fig, axis_title, should_reverse_axis
 
 
 def _render_overlay_table(overlays: Sequence[OverlayTrace]) -> None:
@@ -3504,7 +3542,18 @@ def _render_overlay_tab(version_info: Dict[str, str]) -> None:
     if reference is not None and _axis_kind_for_trace(reference) in {"image", "time"}:
         reference = None
 
-    fig, axis_title = _build_overlay_figure(
+    ir_state = _active_ir_prediction_state()
+    active_ranges: Optional[Sequence[FunctionalGroupRange]] = None
+    if (
+        display_units == "cm^-1"
+        and reference is not None
+        and ir_state.get("trace_id") == reference.trace_id
+    ):
+        ranges = ir_state.get("ranges")
+        if isinstance(ranges, Sequence):
+            active_ranges = list(ranges)
+
+    fig, axis_title, _axis_reversed = _build_overlay_figure(
         overlays,
         display_units,
         display_mode,
@@ -3513,8 +3562,22 @@ def _render_overlay_tab(version_info: Dict[str, str]) -> None:
         differential_mode,
         version_info.get("version", "v?"),
         axis_viewport_by_kind=effective_viewports if single_axis else None,
+        ir_ranges=active_ranges,
     )
     st.plotly_chart(fig, use_container_width=True)
+
+    if (
+        reference is not None
+        and ir_state.get("trace_id") == reference.trace_id
+        and isinstance(ir_state.get("predictions"), Sequence)
+    ):
+        table_rows = build_prediction_table(
+            list(ir_state.get("predictions")), probability_floor=0.05
+        )
+        if table_rows:
+            st.markdown("#### Functional group predictions")
+            st.dataframe(pd.DataFrame(table_rows), width="stretch", hide_index=True)
+
     _render_image_overlay_panels(overlays)
 
     if len(visible_axis_kinds) > 1:
@@ -3535,6 +3598,42 @@ def _render_overlay_tab(version_info: Dict[str, str]) -> None:
                 display_mode,
                 effective_viewports,
             )
+        run_classifier = st.button(
+            "Identify functional groups",
+            key="ir_group_identify_button",
+            help="Run the IR functional-group classifier on the reference trace.",
+        )
+        if run_classifier:
+            if reference is None:
+                st.warning("Select a wavelength-based reference spectrum to analyse.")
+            else:
+                try:
+                    wavenumbers, intensities = _trace_ir_vectors(reference)
+                except Exception as exc:
+                    st.error(f"IR classification unavailable: {exc}")
+                else:
+                    with st.spinner("Running IR classifier..."):
+                        try:
+                            predictions = list(
+                                identify_functional_groups(
+                                    wavenumbers=wavenumbers,
+                                    intensities=intensities,
+                                )
+                            )
+                        except Exception as exc:
+                            st.error(f"IR classification failed: {exc}")
+                        else:
+                            ranges = shaded_ranges_for_predictions(predictions)
+                            st.session_state["ir_group_predictions_state"] = {
+                                "trace_id": reference.trace_id,
+                                "predictions": predictions,
+                                "ranges": ranges,
+                                "timestamp": time.time(),
+                            }
+                            detected = sum(1 for item in predictions if item.present)
+                            st.success(
+                                f"Classifier updated {detected} functional-group flags."
+                            )
         st.caption(f"Axis: {axis_title}")
 
     _render_metadata_summary(overlays)

--- a/app/utils/ir_group_client.py
+++ b/app/utils/ir_group_client.py
@@ -1,0 +1,83 @@
+"""Client helper for IR functional-group classification."""
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from typing import Iterable, Sequence
+
+import requests
+
+from ml import FunctionalGroupPrediction, IRGroupClassifier
+
+_API_URL_ENV = "SPECTRA_IR_GROUP_API_URL"
+_ENDPOINT = "/api/ir-groups"
+
+
+@lru_cache(maxsize=4)
+def _classifier(normalise: bool = True) -> IRGroupClassifier:
+    return IRGroupClassifier(normalise=normalise)
+
+
+def _call_remote(
+    base_url: str,
+    wavenumbers: Sequence[float],
+    intensities: Sequence[float],
+    *,
+    normalise: bool,
+) -> Sequence[FunctionalGroupPrediction] | None:
+    url = base_url.rstrip("/") + _ENDPOINT
+    try:
+        response = requests.post(
+            url,
+            json={
+                "wavenumber_cm_1": list(float(v) for v in wavenumbers),
+                "intensity": list(float(v) for v in intensities),
+                "normalise": normalise,
+            },
+            timeout=20,
+        )
+        response.raise_for_status()
+    except Exception:
+        return None
+    data = response.json()
+    predictions = []
+    for item in data.get("predictions", []):
+        try:
+            predictions.append(
+                FunctionalGroupPrediction(
+                    name=str(item.get("name", "")),
+                    probability=float(item.get("probability", 0.0)),
+                    threshold=float(item.get("threshold", 0.0)),
+                    present=bool(item.get("present", False)),
+                )
+            )
+        except Exception:
+            continue
+    return predictions
+
+
+def identify_functional_groups(
+    *,
+    wavenumbers: Iterable[float],
+    intensities: Iterable[float],
+    normalise: bool = True,
+) -> Sequence[FunctionalGroupPrediction]:
+    """Return functional-group predictions using the configured backend."""
+
+    wn = list(float(v) for v in wavenumbers)
+    it = list(float(v) for v in intensities)
+    if len(wn) != len(it):
+        raise ValueError("Wavenumber and intensity arrays must match in length")
+
+    base_url = os.environ.get(_API_URL_ENV)
+    if base_url:
+        remote = _call_remote(base_url, wn, it, normalise=normalise)
+        if remote is not None:
+            return remote
+
+    classifier = _classifier(normalise)
+    predictions = classifier.predict_groups({"wavenumber": wn, "intensity": it})
+    return predictions
+
+
+__all__ = ["identify_functional_groups"]

--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.1ac",
-  "date_utc": "2025-10-29T00:00:00Z",
-  "summary": "Restore Quant IR manual fetches when WebBook pages return raw JCAMP data."
+  "version": "v1.2.1ad",
+  "date_utc": "2025-10-30T00:00:00Z",
+  "summary": "Add FTIR functional-group classification with IR model integration."
 }

--- a/docs/ai_log/2025-10-30.md
+++ b/docs/ai_log/2025-10-30.md
@@ -1,0 +1,13 @@
+# AI Log — 2025-10-30
+
+## Tasking — Add FTIR functional-group classification
+- Implemented an IR functional-group classifier module, FastAPI endpoint, Streamlit integration, and client helper so overlays can invoke the pretrained network or a REST microservice.【F:ml/ir_group_classifier.py†L1-L236】【F:app/server/ir_groups_api.py†L1-L75】【F:app/ui/main.py†L1-L365】【F:app/utils/ir_group_client.py†L1-L63】
+- Added Plotly shading helpers, probability table rendering, a download script for the model assets, and extended project dependencies/documentation with TensorFlow/SciPy/RDKit plus proper attribution to irchracterizationcnn, NIST, and SDBS.【F:app/ui/ir_group_overlays.py†L1-L204】【F:scripts/fetch_ir_model.py†L1-L46】【F:requirements.txt†L1-L15】【F:README.md†L1-L127】
+- Recorded release collateral for v1.2.1ad (patch notes, patch log, version metadata) and introduced classifier unit coverage for preprocessing/threshold behaviour.【F:app/version.json†L1-L5】【F:PATCHLOG.txt†L46-L47】【F:docs/patch_notes/v1.2.1ad.md†L1-L4】【F:tests/ml/test_ir_group_classifier.py†L1-L57】
+
+## Verification
+- `pytest tests/ml/test_ir_group_classifier.py -q`【2fc578†L1-L2】
+
+## Docs Consulted
+- `docs/runtime.json`【F:docs/runtime.json†L1-L21】
+- `docs/ftir prediction.md`【F:docs/ftir prediction.md†L1-L52】

--- a/docs/brains/brains_v1.2.1aa.md
+++ b/docs/brains/brains_v1.2.1aa.md
@@ -8,3 +8,8 @@
 
 ## Continuity & release notes
 - Bumped `app/version.json`, appended changelog/patch log entries, and published v1.2.1aa patch notes (Markdown/txt) documenting the hotfix scope.【F:app/version.json†L1-L5】【F:CHANGELOG.md†L1-L8】【F:PATCHLOG.txt†L45-L55】【F:docs/patch_notes/v1.2.1aa_hotfix.md†L1-L9】【F:docs/PATCH_NOTES/v1.2.1aa.txt†L1-L1】
+
+## Decision log — FTIR functional-group classifier (v1.2.1ad)
+- Integrated the irchracterizationcnn FTIR classifier with a shared loader module, REST API, Streamlit UI button, shaded band overlays, and attribution docs covering NIST/SDBS sources.【F:ml/ir_group_classifier.py†L1-L236】【F:app/server/ir_groups_api.py†L1-L75】【F:app/utils/ir_group_client.py†L1-L63】【F:app/ui/main.py†L1-L362】【F:app/ui/ir_group_overlays.py†L1-L204】【F:README.md†L1-L127】
+- Added dependency and asset management collateral: download script, requirements updates, patch notes, and release metadata for v1.2.1ad.【F:scripts/fetch_ir_model.py†L1-L46】【F:requirements.txt†L1-L15】【F:app/version.json†L1-L5】【F:docs/patch_notes/v1.2.1ad.md†L1-L4】【F:PATCHLOG.txt†L46-L47】
+- Landed unit coverage for the classifier preprocessing/threshold logic so regressions surface without TensorFlow at test time.【F:tests/ml/test_ir_group_classifier.py†L1-L57】

--- a/docs/patch_notes/v1.2.1ad.md
+++ b/docs/patch_notes/v1.2.1ad.md
@@ -1,0 +1,5 @@
+# v1.2.1ad — 2025-10-30
+
+- integrate the irchracterizationcnn FTIR classifier, expose `/api/ir-groups`, and add a Streamlit workflow to identify functional groups with shaded correlation bands
+- bundle a script to fetch the pretrained weights/thresholds, extend requirements with TensorFlow/SciPy/RDKit/FastAPI, and document attribution for NIST and SDBS data sources
+- add unit coverage for the IRGroupClassifier preprocessing/threshold logic and refresh release metadata

--- a/ml/__init__.py
+++ b/ml/__init__.py
@@ -1,0 +1,5 @@
+"""Machine learning utilities for Spectra App."""
+
+from .ir_group_classifier import IRGroupClassifier, FunctionalGroupPrediction
+
+__all__ = ["IRGroupClassifier", "FunctionalGroupPrediction"]

--- a/ml/ir_group_classifier.py
+++ b/ml/ir_group_classifier.py
@@ -1,0 +1,322 @@
+"""IR functional-group classifier integration."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+import pickle
+from pathlib import Path
+from typing import Mapping, MutableMapping, Optional, Sequence, Tuple, Union, List
+
+import numpy as np
+
+try:  # Optional dependency used for baseline correction
+    from scipy.signal import savgol_filter  # type: ignore
+except Exception:  # pragma: no cover - SciPy unavailable in constrained envs
+    savgol_filter = None  # type: ignore
+
+
+Number = Union[int, float, np.floating]
+VectorLike = Union[Sequence[Number], np.ndarray]
+SpectrumInput = Union[
+    Mapping[str, Union[VectorLike, Number]],
+    Tuple[VectorLike, VectorLike],
+    List[Tuple[Number, Number]],
+    np.ndarray,
+]
+
+
+_LABEL_NAMES_EXTENDED: Tuple[str, ...] = (
+    "Alkane",
+    "Alkene",
+    "Alkyne",
+    "Arene",
+    "Haloalkane",
+    "Alcohol",
+    "Aldehyde",
+    "Ketone",
+    "Carboxylic acid",
+    "Acid anhydride",
+    "Acyl halide",
+    "Ester",
+    "Ether",
+    "Amine",
+    "Amide",
+    "Nitrile",
+    "Imide",
+    "Imine",
+    "Azo compound",
+    "Thiol",
+    "Thial",
+    "Sulfone",
+    "Sulfonic acid",
+    "Enol",
+    "Phenol",
+    "Hydrazine",
+    "Enamine",
+    "Isocyanate",
+    "Isothiocyanate",
+    "Phosphine",
+    "Sulfonamide",
+    "Sulfonate",
+    "Sulfoxide",
+    "Thioamide",
+    "Hydrazone",
+    "Carbamate",
+    "Sulfide",
+)
+
+
+@dataclass(frozen=True)
+class FunctionalGroupPrediction:
+    """Container describing a model prediction for a functional group."""
+
+    name: str
+    probability: float
+    threshold: float
+    present: bool
+
+    def to_dict(self) -> Mapping[str, object]:
+        """Return a serialisable representation."""
+
+        return {
+            "name": self.name,
+            "probability": float(self.probability),
+            "threshold": float(self.threshold),
+            "present": bool(self.present),
+        }
+
+
+class IRGroupClassifier:
+    """Interface to the IR functional-group classifier."""
+
+    DEFAULT_MODEL_PATH = Path("ml_models/ir_groups/0_model_extended.h5")
+    DEFAULT_THRESHOLDS_PATH = Path("ml_models/ir_groups/optimal_thresholds.pkl")
+
+    def __init__(
+        self,
+        *,
+        model: Optional[object] = None,
+        model_path: Optional[Union[str, Path]] = None,
+        thresholds: Optional[Mapping[int, float]] = None,
+        thresholds_path: Optional[Union[str, Path]] = None,
+        label_names: Optional[Sequence[str]] = None,
+        baseline_window: int = 51,
+        baseline_poly_order: int = 3,
+        normalise: bool = True,
+    ) -> None:
+        self._model = model
+        self._model_path = Path(model_path) if model_path else self.DEFAULT_MODEL_PATH
+        self._thresholds: MutableMapping[int, float] = dict(thresholds or {})
+        self._thresholds_path = (
+            Path(thresholds_path) if thresholds_path else self.DEFAULT_THRESHOLDS_PATH
+        )
+        self._label_names: Tuple[str, ...] = (
+            tuple(label_names) if label_names else _LABEL_NAMES_EXTENDED
+        )
+        self._baseline_window = max(3, int(baseline_window))
+        self._baseline_poly = max(1, int(baseline_poly_order))
+        self._normalise = bool(normalise)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def predict_groups(
+        self,
+        spectrum: SpectrumInput,
+    ) -> List[FunctionalGroupPrediction]:
+        """Return functional-group predictions for the provided spectrum."""
+
+        wavenumbers, intensities = self._coerce_spectrum(spectrum)
+        processed = self._preprocess(wavenumbers, intensities)
+        model = self._ensure_model()
+        raw = model.predict(processed, verbose=0)  # type: ignore[attr-defined]
+        probabilities = np.asarray(raw, dtype=np.float64).ravel()
+        thresholds = self._ensure_thresholds()
+
+        results: List[FunctionalGroupPrediction] = []
+        for index, name in enumerate(self._label_names):
+            prob = float(probabilities[index]) if index < probabilities.size else 0.0
+            threshold = float(thresholds.get(index, 0.5))
+            present = prob >= threshold
+            results.append(
+                FunctionalGroupPrediction(
+                    name=name,
+                    probability=prob,
+                    threshold=threshold,
+                    present=present,
+                )
+            )
+        results.sort(key=lambda item: item.probability, reverse=True)
+        return results
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _ensure_model(self) -> object:
+        if self._model is not None:
+            return self._model
+        try:
+            from tensorflow import keras  # type: ignore
+        except Exception as exc:  # pragma: no cover - TensorFlow missing in tests
+            raise ImportError(
+                "TensorFlow is required to load the IR functional-group model"
+            ) from exc
+        model_path = self._model_path.expanduser()
+        if not model_path.exists():
+            raise FileNotFoundError(
+                f"IR functional-group model not found: {model_path}"
+            )
+        self._model = keras.models.load_model(model_path)
+        return self._model
+
+    def _ensure_thresholds(self) -> Mapping[int, float]:
+        if self._thresholds:
+            return self._thresholds
+        path = self._thresholds_path.expanduser()
+        if not path.exists():
+            raise FileNotFoundError(
+                f"IR functional-group thresholds not found: {path}"
+            )
+        with path.open("rb") as handle:
+            loaded = pickle.load(handle)
+        if isinstance(loaded, Mapping):
+            self._thresholds = {int(k): float(v) for k, v in loaded.items()}
+        else:
+            raise ValueError("Threshold file does not contain a mapping")
+        return self._thresholds
+
+    @staticmethod
+    def _as_array(values: VectorLike) -> np.ndarray:
+        return np.asarray(values, dtype=float)
+
+    def _coerce_spectrum(
+        self, spectrum: SpectrumInput
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        if isinstance(spectrum, Mapping):
+            lower = {str(k).lower(): v for k, v in spectrum.items()}
+            wav = None
+            for key in ("wavenumbers", "wavenumber", "wavenumber_cm_1", "cm^-1", "cm_1"):
+                if key in lower:
+                    wav = self._as_array(lower[key])
+                    break
+            intensities = None
+            for key in (
+                "intensity",
+                "intensities",
+                "absorbance",
+                "transmittance",
+                "flux",
+                "y",
+            ):
+                if key in lower:
+                    intensities = self._as_array(lower[key])
+                    break
+            if wav is None and "wavelengths" in lower:
+                wav = self._wavelength_nm_to_wavenumber(lower.get("wavelengths"))
+            if wav is None:
+                raise ValueError("Spectrum mapping must include wavenumber or wavelength data")
+            if intensities is None:
+                raise ValueError("Spectrum mapping must include intensity data")
+            return wav, intensities
+
+        if isinstance(spectrum, (tuple, list)):
+            if len(spectrum) == 2 and all(
+                isinstance(component, (Sequence, np.ndarray)) for component in spectrum
+            ):
+                return (
+                    self._as_array(spectrum[0]),
+                    self._as_array(spectrum[1]),
+                )
+
+        arr = np.asarray(spectrum, dtype=float)
+        if arr.ndim == 2 and arr.shape[1] >= 2:
+            return (
+                self._as_array(arr[:, 0]),
+                self._as_array(arr[:, 1]),
+            )
+        raise ValueError("Unable to coerce spectrum into (wavenumbers, intensities)")
+
+    @staticmethod
+    def _wavelength_nm_to_wavenumber(values: Optional[VectorLike]) -> np.ndarray:
+        if values is None:
+            raise ValueError("Wavelength data not provided")
+        arr = np.asarray(values, dtype=float)
+        safe = np.where(arr > 0, arr, np.nan)
+        return 1e7 / safe
+
+    def _preprocess(
+        self,
+        wavenumbers: np.ndarray,
+        intensities: np.ndarray,
+    ) -> np.ndarray:
+        if wavenumbers.size == 0:
+            raise ValueError("Empty wavenumber array")
+        if intensities.size == 0:
+            raise ValueError("Empty intensity array")
+        if wavenumbers.size != intensities.size:
+            raise ValueError("Wavenumber and intensity arrays must be the same length")
+
+        order = np.argsort(wavenumbers)[::-1]  # descending order
+        sorted_wn = np.asarray(wavenumbers, dtype=float)[order]
+        sorted_intensity = np.asarray(intensities, dtype=float)[order]
+        mask = np.isfinite(sorted_wn) & np.isfinite(sorted_intensity)
+        sorted_wn = sorted_wn[mask]
+        sorted_intensity = sorted_intensity[mask]
+        if sorted_wn.size == 0 or sorted_intensity.size == 0:
+            raise ValueError("Spectrum contains no finite values after cleaning")
+
+        target_desc = np.linspace(4000.0, 400.0, 600)
+        target_asc = target_desc[::-1]
+        interp_x = np.asarray(sorted_wn[::-1], dtype=float)
+        interp_y = np.asarray(sorted_intensity[::-1], dtype=float)
+        resampled_asc = np.interp(
+            target_asc,
+            interp_x,
+            interp_y,
+            left=float(interp_y[0]),
+            right=float(interp_y[-1]),
+        )
+        resampled = resampled_asc[::-1]
+
+        processed = resampled.astype(np.float64)
+        if self._normalise:
+            processed = self._apply_baseline(processed)
+            processed = self._scale_unit_interval(processed)
+        processed = processed.reshape(1, processed.size, 1).astype(np.float32)
+        return processed
+
+    def _apply_baseline(self, values: np.ndarray) -> np.ndarray:
+        arr = np.asarray(values, dtype=float)
+        if savgol_filter is not None and arr.size > self._baseline_poly:
+            window = min(self._baseline_window, arr.size if arr.size % 2 == 1 else arr.size - 1)
+            window = max(window, self._baseline_poly + 2)
+            if window % 2 == 0:
+                window += 1
+            if window > arr.size:
+                window = arr.size if arr.size % 2 == 1 else arr.size - 1
+            try:
+                baseline = savgol_filter(arr, window_length=window, polyorder=self._baseline_poly)
+            except Exception:
+                baseline = np.nanmin(arr)
+        else:
+            baseline = np.nanmin(arr)
+        corrected = arr - baseline
+        return corrected
+
+    @staticmethod
+    def _scale_unit_interval(values: np.ndarray) -> np.ndarray:
+        arr = np.asarray(values, dtype=float)
+        finite = arr[np.isfinite(arr)]
+        if finite.size == 0:
+            return np.zeros_like(arr)
+        minimum = float(np.min(finite))
+        maximum = float(np.max(finite))
+        if math.isclose(maximum, minimum):
+            return np.zeros_like(arr)
+        scaled = (arr - minimum) / (maximum - minimum)
+        return scaled
+
+
+__all__ = ["IRGroupClassifier", "FunctionalGroupPrediction"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,8 @@ beautifulsoup4>=4.12
 pyvo
 pyyaml
 rich
+scipy>=1.11
+tensorflow>=2.16
+rdkit-pypi>=2022.9.5
+fastapi>=0.111
+uvicorn>=0.30

--- a/scripts/fetch_ir_model.py
+++ b/scripts/fetch_ir_model.py
@@ -1,0 +1,58 @@
+"""Download the IR functional-group classifier assets."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+import requests
+
+DEFAULT_MODEL_URL = "https://example.com/0_model_extended.h5"
+DEFAULT_THRESHOLDS_URL = "https://example.com/optimal_thresholds.pkl"
+TARGET_DIR = Path("ml_models/ir_groups")
+
+
+def _download(url: str, destination: Path) -> None:
+    response = requests.get(url, timeout=60)
+    response.raise_for_status()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_bytes(response.content)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--model-url",
+        default=DEFAULT_MODEL_URL,
+        help="URL for the 0_model_extended.h5 asset",
+    )
+    parser.add_argument(
+        "--threshold-url",
+        default=DEFAULT_THRESHOLDS_URL,
+        help="URL for the optimal_thresholds.pkl asset",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=str(TARGET_DIR),
+        help="Directory to store the downloaded artifacts",
+    )
+    args = parser.parse_args(argv)
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    model_path = output_dir / "0_model_extended.h5"
+    thresholds_path = output_dir / "optimal_thresholds.pkl"
+
+    print(f"Downloading model from {args.model_url} → {model_path}")
+    _download(args.model_url, model_path)
+
+    print(f"Downloading thresholds from {args.threshold_url} → {thresholds_path}")
+    _download(args.threshold_url, thresholds_path)
+
+    print("Download complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ml/test_ir_group_classifier.py
+++ b/tests/ml/test_ir_group_classifier.py
@@ -1,0 +1,67 @@
+import numpy as np
+import pytest
+
+from ml.ir_group_classifier import IRGroupClassifier
+
+
+class DummyModel:
+    def __init__(self, values):
+        self.values = np.asarray([values], dtype=np.float32)
+        self.calls = 0
+
+    def predict(self, data, verbose=0):
+        self.calls += 1
+        self.last_input_shape = data.shape
+        return self.values
+
+
+def test_preprocess_shapes_resample():
+    classifier = IRGroupClassifier(
+        model=DummyModel(np.zeros(37)),
+        thresholds={index: 0.5 for index in range(37)},
+    )
+    wavenumbers = np.linspace(4000, 400, 1200)
+    intensities = np.sin(np.linspace(0, np.pi, 1200))
+    processed = classifier._preprocess(wavenumbers, intensities)
+    assert processed.shape == (1, 600, 1)
+    assert np.isfinite(processed).all()
+
+
+def test_predict_groups_applies_thresholds_sorted():
+    probabilities = np.array([
+        0.1,
+        0.9,
+        0.2,
+        0.8,
+        *(0.0 for _ in range(33)),
+    ])
+    thresholds = {index: 0.5 for index in range(len(probabilities))}
+    model = DummyModel(probabilities)
+    classifier = IRGroupClassifier(
+        model=model,
+        thresholds=thresholds,
+        label_names=[f"Label {i}" for i in range(len(probabilities))],
+    )
+    wn = np.linspace(4000, 400, 600)
+    intensities = np.linspace(0.0, 1.0, 600)
+    results = classifier.predict_groups((wn, intensities))
+    assert model.calls == 1
+    assert results[0].name == "Label 1"
+    assert results[0].present is True
+    assert results[1].name == "Label 3"
+    assert results[1].present is True
+    assert all(0.0 <= item.probability <= 1.0 for item in results)
+
+
+def test_coerce_from_wavelength_mapping():
+    classifier = IRGroupClassifier(
+        model=DummyModel(np.zeros(37)),
+        thresholds={index: 0.5 for index in range(37)},
+    )
+    spectrum = {
+        "wavelengths": np.linspace(2500, 250, 600),
+        "intensity": np.linspace(0, 1, 600),
+    }
+    wavenumbers, intensities = classifier._coerce_spectrum(spectrum)
+    assert wavenumbers.shape == intensities.shape
+    assert np.all(wavenumbers > 0)


### PR DESCRIPTION
## Summary
- integrate the irchracterizationcnn FTIR classifier, add an /api/ir-groups FastAPI endpoint, and surface an "Identify functional groups" control with shaded correlation bands in the Streamlit overlay workspace
- add helper utilities for downloading the pretrained model, update project requirements, and document attribution to irchracterizationcnn, NIST, and SDBS
- record release metadata (v1.2.1ad) and unit coverage for the classifier preprocessing/threshold behaviour

## Testing
- pytest tests/ml/test_ir_group_classifier.py -q


------
https://chatgpt.com/codex/tasks/task_e_68ed733849c083298f8cfe456ba80ed4