### PR TITLE
Stabilise IR overlay conversion forms for Streamlit 1.50

### DIFF
--- a/PATCHLOG.txt
+++ b/PATCHLOG.txt
@@ -64,3 +64,4 @@ Spectra App — Patch Log (append-only)
 - v1.2.3: Tidy FTIR classifier overlays by shrinking correlation bands, tinting fills by confidence, capping annotations, and wrapping the results table in a collapsible expander.
 - v1.2.4: Focus FTIR shading on peak-backed predictions, colour bands with intensity-aware confidence, and add UI regression coverage for the overlay helper.
 - v1.2.5: Align FTIR differential plots with cm⁻¹ axes, invert absorption traces for readability, cluster functional-group overlays by dominant peaks, and tuck conversion controls into expanders.
+- v1.2.6: Restore the FTIR overlay conversion prompts by instantiating Streamlit forms outside the expander context so number inputs stay usable with the new width API.

--- a/app/archive_ui.py
+++ b/app/archive_ui.py
@@ -89,7 +89,7 @@ class ArchiveUI:
                     height=260,
                     margin=dict(t=20, b=20, l=40, r=10),
                 )
-                st.plotly_chart(fig, use_container_width=True)
+                st.plotly_chart(fig, width="stretch")
                 st.caption(hit.summary)
                 cols = st.columns(2)
                 with cols[0]:

--- a/app/ui/main.py
+++ b/app/ui/main.py
@@ -456,28 +456,28 @@ def _render_ir_parameter_prompts(overlays: Sequence[OverlayTrace]) -> None:
         )
         expander.caption(f"Input units: {units_label or 'unknown'}")
         form_key = f"ir_params_form_{trace.trace_id}"
-        with expander.form(form_key) as form:
-            path_value = form.number_input(
-                "Path length (m)",
-                min_value=0.0,
-                value=float(default_path),
-                step=max(float(default_path) / 10.0, 0.1),
-                format="%0.4f",
-                key=f"{form_key}_path",
-            )
-            mole_value = form.number_input(
-                "Mole fraction (χ)",
-                min_value=0.0,
-                max_value=1.0,
-                value=float(default_mole),
-                step=max(float(default_mole) / 10.0, 1e-6),
-                format="%0.6f",
-                key=f"{form_key}_mole",
-                help="Enter as a fraction (e.g. 50 ppm = 5e-5).",
-            )
-            submitted = form.form_submit_button(
-                "Convert to A10", use_container_width=True
-            )
+        form = expander.form(form_key)
+        path_value = form.number_input(
+            "Path length (m)",
+            min_value=0.0,
+            value=float(default_path),
+            step=max(float(default_path) / 10.0, 0.1),
+            format="%0.4f",
+            key=f"{form_key}_path",
+        )
+        mole_value = form.number_input(
+            "Mole fraction (χ)",
+            min_value=0.0,
+            max_value=1.0,
+            value=float(default_mole),
+            step=max(float(default_mole) / 10.0, 1e-6),
+            format="%0.6f",
+            key=f"{form_key}_mole",
+            help="Enter as a fraction (e.g. 50 ppm = 5e-5).",
+        )
+        submitted = form.form_submit_button(
+            "Convert to A10", width="stretch"
+        )
         if submitted:
             success, message = _apply_ir_parameters_to_trace(
                 trace, float(path_value), float(mole_value)
@@ -1748,7 +1748,7 @@ def _render_examples_group(container: DeltaGenerator) -> None:
     )
     if selection.description:
         quick_form.caption(selection.description)
-    submitted = quick_form.form_submit_button("Load example", use_container_width=True)
+    submitted = quick_form.form_submit_button("Load example", width="stretch")
     if submitted:
         added, message = _load_example(selection)
         (container.success if added else container.info)(message)
@@ -1918,7 +1918,7 @@ def _render_nist_quant_ir_form(
                 names=", ".join(manual_names)
             )
         )
-    submitted = form.form_submit_button("Fetch spectrum", use_container_width=True)
+    submitted = form.form_submit_button("Fetch spectrum", width="stretch")
     if not submitted:
         return
     if not selection.available:
@@ -2957,7 +2957,7 @@ def _render_image_overlay_panels(overlays: Sequence[OverlayTrace]) -> None:
             margin=dict(t=30, b=40, l=40, r=20),
             height=420,
         )
-        st.plotly_chart(fig, use_container_width=True, key=f"image_plot_{trace.trace_id}")
+        st.plotly_chart(fig, width="stretch", key=f"image_plot_{trace.trace_id}")
 
         shape = payload.get("shape") if isinstance(payload, Mapping) else None
         if isinstance(shape, (list, tuple)):
@@ -3622,7 +3622,7 @@ def _render_overlay_tab(version_info: Dict[str, str]) -> None:
         axis_viewport_by_kind=effective_viewports if single_axis else None,
         ir_ranges=active_ranges,
     )
-    st.plotly_chart(fig, use_container_width=True)
+    st.plotly_chart(fig, width="stretch")
 
     if (
         reference is not None
@@ -3639,7 +3639,7 @@ def _render_overlay_tab(version_info: Dict[str, str]) -> None:
             ):
                 st.dataframe(
                     pd.DataFrame(table_rows),
-                    use_container_width=True,
+                    width="stretch",
                     hide_index=True,
                 )
 
@@ -3973,7 +3973,7 @@ def _render_differential_result(result: Optional[DifferentialResult]) -> None:
     if result is None:
         return
     fig = _build_differential_figure(result)
-    st.plotly_chart(fig, use_container_width=True)
+    st.plotly_chart(fig, width="stretch")
     if result.display_unit == "cm^-1" and result.grid_cm_1:
         grid = np.asarray(result.grid_cm_1, dtype=float)
         unit_label = "cm⁻¹"
@@ -4181,7 +4181,7 @@ def _render_differential_tab() -> None:
         submitted = st.form_submit_button(
             "Compute differential",
             key="differential_compute_submit",
-            use_container_width=True,
+            width="stretch",
         )
 
 

--- a/app/version.json
+++ b/app/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.2.5",
-  "date_utc": "2025-11-05T00:00:00Z",
-  "summary": "Align FTIR differentials with cm⁻¹ displays, invert absorption traces for readability, and cluster functional-group overlays around dominant peaks."
+  "version": "v1.2.6",
+  "date_utc": "2025-11-06T00:00:00Z",
+  "summary": "Stabilise IR parameter prompts by instantiating overlay forms outside context managers so conversion controls render reliably with the new width API."
 }

--- a/docs/ai_log/2025-11-06.md
+++ b/docs/ai_log/2025-11-06.md
@@ -1,0 +1,9 @@
+## 2025-11-06 — IR overlay prompt compatibility hotfix
+- Reworked the FTIR overlay conversion expander to instantiate the Streamlit form outside the context manager so the number inputs remain available after the platform removed form return values.【F:app/ui/main.py†L447-L485】
+- Bumped release metadata and patch collateral to v1.2.6 to document the compatibility fix across manifests and notes.【F:app/version.json†L1-L5】【F:docs/patch_notes/v1.2.6.md†L1-L9】【F:PATCHLOG.txt†L66-L67】
+- Logged the reasoning in `atlas/brains.md` for traceability back to the compatibility change and release update.【F:docs/atlas/brains.md†L1-L5】
+
+**Docs consulted**: none
+
+### Verification
+- _Not run (not requested)_

--- a/docs/atlas/brains.md
+++ b/docs/atlas/brains.md
@@ -1,3 +1,7 @@
+# IR overlay prompt compatibility — 2025-11-06
+- Instantiated the FTIR overlay conversion forms outside the expander context to survive Streamlit 1.50's context-manager change so number inputs and submit buttons keep rendering with the new width API.【F:app/ui/main.py†L447-L485】
+- Recorded the release bump to v1.2.6 so downstream tooling captures the compatibility hotfix in manifests and UI headers.【F:app/version.json†L1-L5】【F:PATCHLOG.txt†L66-L67】
+
 # FTIR differential cm⁻¹ alignment — 2025-11-05
 - Reversed differential axis handling for wavenumber spectra so subtraction plots render on a cm⁻¹ scale with high-to-low order, updated captions, and export metadata reflecting both nm and cm⁻¹ ranges.【F:app/ui/main.py†L3688-L3784】【F:tests/ui/test_differential_form.py†L1-L155】
 - Normalised FTIR classifier vectors by turning transmittance dips into absorbance peaks, flipping negative absorbance baselines, and clustering overlay ranges so only the dominant peak-backed groups render.【F:app/ui/main.py†L1159-L1189】【F:app/ui/ir_group_overlays.py†L86-L142】【F:tests/ui/test_ir_trace_vectors.py†L1-L46】

--- a/docs/patch_notes/v1.2.6.md
+++ b/docs/patch_notes/v1.2.6.md
@@ -1,0 +1,8 @@
+# Patch Notes — v1.2.6
+
+## Highlights
+- Prevent FTIR overlay conversion prompts from failing under Streamlit 1.50 by instantiating trace forms outside the context manager so the number inputs remain available and the submit button can adopt the new `width="stretch"` layout.【F:app/ui/main.py†L447-L485】
+- Bump the shipped version metadata to v1.2.6 with a summary describing the IR prompt stabilisation for release tracking.【F:app/version.json†L1-L5】
+
+## Verification
+- _Not run (not requested)_


### PR DESCRIPTION
## Summary
- instantiate the IR overlay conversion forms outside the expander context so Streamlit 1.50 continues to expose number inputs and submit buttons while using the new `width="stretch"` API
- bump release metadata, patch notes, and brains log to v1.2.6 to document the compatibility fix

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68edcd9a2c8c83299252bc6671f4ee12